### PR TITLE
Add fist proficiency leveling system

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,6 +397,7 @@
               <button class="adventure-tab-btn active" data-tab="progress">📊 Progress</button>
               <button class="adventure-tab-btn" data-tab="bestiary">📖 Bestiary</button>
               <button class="adventure-tab-btn" data-tab="equipment">🎒 Equipment</button>
+              <button class="adventure-tab-btn" data-tab="proficiencies">🥊 Proficiencies</button>
             </div>
             
             <!-- Progress Tab -->
@@ -473,6 +474,13 @@
                   </div>
                 </div>
               </div>
+            </div>
+
+            <!-- Proficiencies Tab -->
+            <div id="proficienciesTab" class="adventure-tab-content" style="display: none;">
+              <div class="stat"><span>Fist Level</span><span id="fistLevel">1</span></div>
+              <div class="stat"><span>Experience</span><span id="fistExp">0</span> / <span id="fistExpMax">100</span></div>
+              <div class="activity-progress-bar"><div class="progress-fill" id="fistExpFill"></div></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Introduce fist combat proficiency with leveling and experience gains
- Display fist proficiency progress in new Adventure tab
- Apply fist level bonuses for +2 damage and +10% attack speed per level during combat

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d104614988326a64aaa16b7c6322a