### PR TITLE
feat: add cultivation stats sub tab

### DIFF
--- a/game.js
+++ b/game.js
@@ -2066,6 +2066,9 @@ function updateActivityCultivation() {
   
   // Update cultivation progression tree
   updateCultivationProgressionTree();
+
+  // Setup cultivation tab switching
+  setupCultivationTabs();
 }
 
 function updateCultivationProgressionTree() {
@@ -2131,6 +2134,26 @@ function updateCultivationProgressionTree() {
     `;
     
     container.appendChild(realmNode);
+  });
+}
+
+function setupCultivationTabs() {
+  const tabButtons = document.querySelectorAll('.cultivation-tab-btn');
+  tabButtons.forEach(button => {
+    button.onclick = () => {
+      const tabName = button.dataset.tab;
+      tabButtons.forEach(btn => btn.classList.remove('active'));
+      document.querySelectorAll('.cultivation-tab-content').forEach(content => {
+        content.classList.remove('active');
+        content.style.display = 'none';
+      });
+      button.classList.add('active');
+      const content = document.getElementById(tabName + 'SubTab');
+      if (content) {
+        content.classList.add('active');
+        content.style.display = 'block';
+      }
+    };
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -157,48 +157,59 @@
       <!-- Activity Content Panels -->
       <section id="activity-cultivation" class="activity-content" style="display:none;">
         <h2>🧘 Cultivation</h2>
-        <div class="cards">
-          <div class="card">
-            <h4>Cultivation Status</h4>
-            <div class="stat"><span>Current Realm</span><span id="realmNameActivity">Mortal 1</span></div>
-            <div class="stat"><span>Foundation</span><span><span id="foundValActivity">0</span>/<span id="foundCapActivity">60</span></span></div>
-            <div class="bar"><div class="fill" id="foundFillActivity"></div></div>
-            <div class="stat"><span>Qi</span><span><span id="qiValActivity">0</span>/<span id="qiCapActivity">100</span> (+<span id="qiRegenActivity">1.0</span>/s)</span></div>
-            <div class="bar"><div class="fill" id="qiFillActivity"></div></div>
-            <div class="row" style="margin-top:12px">
-              <button class="btn primary" id="startCultivationActivity">🧘 Start Cultivating</button>
-              <button class="btn warn" id="breakthroughBtnActivity">⚡ Attempt Breakthrough</button>
+        <div class="cultivation-tabs">
+          <button class="cultivation-tab-btn active" data-tab="cultivation">Cultivation</button>
+          <button class="cultivation-tab-btn" data-tab="stats">Stats</button>
+        </div>
+
+        <div id="cultivationSubTab" class="cultivation-tab-content active">
+          <div class="cards">
+            <div class="card">
+              <h4>Cultivation Status</h4>
+              <div class="stat"><span>Current Realm</span><span id="realmNameActivity">Mortal 1</span></div>
+              <div class="stat"><span>Foundation</span><span><span id="foundValActivity">0</span>/<span id="foundCapActivity">60</span></span></div>
+              <div class="bar"><div class="fill" id="foundFillActivity"></div></div>
+              <div class="stat"><span>Qi</span><span><span id="qiValActivity">0</span>/<span id="qiCapActivity">100</span> (+<span id="qiRegenActivity">1.0</span>/s)</span></div>
+              <div class="bar"><div class="fill" id="qiFillActivity"></div></div>
+              <div class="row" style="margin-top:12px">
+                <button class="btn primary" id="startCultivationActivity">🧘 Start Cultivating</button>
+                <button class="btn warn" id="breakthroughBtnActivity">⚡ Attempt Breakthrough</button>
+              </div>
+              <div class="muted" style="margin-top:8px">Foundation gain rate: <span id="foundationRate">0.0</span>/s</div>
             </div>
-            <div class="muted" style="margin-top:8px">Foundation gain rate: <span id="foundationRate">0.0</span>/s</div>
-          </div>
-          
-          <div class="card">
-            <h4>Breakthrough Details</h4>
-            <div class="stat"><span>Success Chance</span><span id="btChanceActivity">0%</span></div>
-            <div class="stat"><span>Power Multiplier</span><span id="powerMultActivity">1x</span></div>
-            <div id="breakthroughDetailsActivity" class="muted"></div>
-            <div class="row" style="margin-top:12px">
-              <button class="btn" id="useQiPillActivity">💊 Use Qi Pill</button>
-              <button class="btn" id="useWardPillActivity">💊 Use Ward Pill</button>
+
+            <div class="card" id="cultivationProgressionCard">
+              <h4>🏔️ Cultivation Progression</h4>
+              <p class="muted">Your journey through the realms of cultivation:</p>
+              <div id="cultivationProgressionTree" class="progression-tree">
+                <!-- Progression tree will be populated by JavaScript -->
+              </div>
             </div>
           </div>
-          
-          <div class="card" id="cultivationStatsCard" style="display:none;">
-            <h4>🌟 Cultivation Stats</h4>
-            <p class="muted">Enhanced cultivation abilities and multipliers:</p>
-            <div class="stat"><span>Talent</span><span id="cultivationTalent">1.0x</span></div>
-            <div class="stat"><span>Comprehension</span><span id="cultivationComprehension">1.0x</span></div>
-            <div class="stat"><span>Foundation Mult</span><span id="cultivationFoundationMult">1.0x</span></div>
-            <div class="stat"><span>Pill Mult</span><span id="cultivationPillMult">1.0x</span></div>
-            <div class="stat"><span>Building Mult</span><span id="cultivationBuildingMult">1.0x</span></div>
-            <div class="muted" style="margin-top:8px">These multipliers enhance foundation gain, pill effectiveness, and breakthrough chances</div>
-          </div>
-          
-          <div class="card" id="cultivationProgressionCard">
-            <h4>🏔️ Cultivation Progression</h4>
-            <p class="muted">Your journey through the realms of cultivation:</p>
-            <div id="cultivationProgressionTree" class="progression-tree">
-              <!-- Progression tree will be populated by JavaScript -->
+        </div>
+
+        <div id="statsSubTab" class="cultivation-tab-content" style="display:none;">
+          <div class="cards">
+            <div class="card">
+              <h4>Breakthrough Details</h4>
+              <div class="stat"><span>Success Chance</span><span id="btChanceActivity">0%</span></div>
+              <div class="stat"><span>Power Multiplier</span><span id="powerMultActivity">1x</span></div>
+              <div id="breakthroughDetailsActivity" class="muted"></div>
+              <div class="row" style="margin-top:12px">
+                <button class="btn" id="useQiPillActivity">💊 Use Qi Pill</button>
+                <button class="btn" id="useWardPillActivity">💊 Use Ward Pill</button>
+              </div>
+            </div>
+
+            <div class="card" id="cultivationStatsCard" style="display:none;">
+              <h4>🌟 Cultivation Stats</h4>
+              <p class="muted">Enhanced cultivation abilities and multipliers:</p>
+              <div class="stat"><span>Talent</span><span id="cultivationTalent">1.0x</span></div>
+              <div class="stat"><span>Comprehension</span><span id="cultivationComprehension">1.0x</span></div>
+              <div class="stat"><span>Foundation Mult</span><span id="cultivationFoundationMult">1.0x</span></div>
+              <div class="stat"><span>Pill Mult</span><span id="cultivationPillMult">1.0x</span></div>
+              <div class="stat"><span>Building Mult</span><span id="cultivationBuildingMult">1.0x</span></div>
+              <div class="muted" style="margin-top:8px">These multipliers enhance foundation gain, pill effectiveness, and breakthrough chances</div>
             </div>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -392,6 +392,47 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   display: block;
 }
 
+/* Cultivation Sub Tabs */
+.cultivation-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 15px;
+  border-bottom: 2px solid #444;
+  padding-bottom: 10px;
+}
+
+.cultivation-tab-btn {
+  padding: 8px 16px;
+  border: 2px solid #666;
+  background: #333;
+  color: #ccc;
+  border-radius: 6px 6px 0 0;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-weight: bold;
+  border-bottom: none;
+}
+
+.cultivation-tab-btn:hover {
+  border-color: #22c55e;
+  background: #444;
+}
+
+.cultivation-tab-btn.active {
+  border-color: #22c55e;
+  background: #22c55e;
+  color: white;
+  box-shadow: 0 0 10px rgba(34, 197, 94, 0.5);
+}
+
+.cultivation-tab-content {
+  display: none;
+}
+
+.cultivation-tab-content.active {
+  display: block;
+}
+
 /* Bestiary Styles */
 .bestiary-list {
   max-height: 300px;


### PR DESCRIPTION
## Summary
- split the cultivation activity into "Cultivation" and "Stats" sub tabs
- show breakthrough and cultivation stat cards under the new stats tab
- add styling and switching logic for cultivation sub tabs

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689d73e290f083268d4049f69ba1bec9