### PR TITLE
Persist player HP between enemies

### DIFF
--- a/game.js
+++ b/game.js
@@ -1518,6 +1518,7 @@ function updateAdventureCombat() {
       if (now - S.adventure.lastEnemyAttack >= (1000 / enemyAttackRate)) {
         const enemyDamage = S.adventure.currentEnemy.attack || 5;
         S.adventure.playerHP = Math.max(0, S.adventure.playerHP - enemyDamage);
+        S.hp = S.adventure.playerHP; // Sync global HP so it persists across fights
         S.adventure.lastEnemyAttack = now;
         
         S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${enemyDamage} damage to you`);


### PR DESCRIPTION
## Summary
- Sync global HP with adventure combat damage so player health carries between fights

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ddccdd2088326b183ac2aa2736f96