### PR TITLE
Implement save migrations with versioning

### DIFF
--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -1,0 +1,52 @@
+export const migrations = [
+  save => {
+    if(!save.laws){
+      save.laws = {
+        selected: null,
+        unlocked: [],
+        points: 0,
+        trees: {
+          sword: {},
+          formation: {},
+          alchemy: {}
+        }
+      };
+    }
+    if(!save.buildings){
+      save.buildings = {};
+    }
+    if(!save.cultivation){
+      save.cultivation = {
+        talent: 1.0,
+        comprehension: 1.0,
+        foundationMult: 1.0,
+        pillMult: 1.0,
+        buildingMult: 1.0
+      };
+    }
+    if(!save.proficiencies){
+      save.proficiencies = { fist: { level: 1, exp: 0, expMax: 100 } };
+    }
+    if(save.alchemy && !Object.prototype.hasOwnProperty.call(save.alchemy, 'unlocked')){
+      save.alchemy.unlocked = true;
+      save.alchemy.knownRecipes = ['qi', 'body', 'ward'];
+    }
+    if(typeof save.qiCapMult === 'undefined'){
+      save.qiCapMult = 0;
+    }
+    if(typeof save.qiRegenMult === 'undefined'){
+      save.qiRegenMult = 0;
+    }
+  }
+];
+
+export const SAVE_VERSION = migrations.length;
+
+export function runMigrations(save){
+  let ver = save.ver || 0;
+  while(ver < migrations.length){
+    migrations[ver](save);
+    ver++;
+  }
+  save.ver = ver;
+}


### PR DESCRIPTION
## Summary
- introduce migration framework for save files with runMigrations and version tracking
- load state with runMigrations and store current version on save

## Testing
- `npm test` (fails: Error: no test specified)
- `npx eslint src/game/migrations.js src/game/state.js`


------
https://chatgpt.com/codex/tasks/task_e_689e673a975c8326af692e985c03269e