### PR TITLE
Render sidebar activities dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,63 +45,7 @@
       <!-- Leveling Activities Group -->
       <div class="activity-group">
         <h4 class="group-title">⚡ Training & Skills</h4>
-        <div class="activities leveling-activities">
-          <div class="activity-item leveling-tab" data-activity="cultivation">
-            <div class="activity-header">
-              <div class="activity-icon">🧘</div>
-              <div class="activity-info">
-                <div class="activity-name">Cultivation</div>
-                <div class="activity-level" id="cultivationLevel">Mortal 1</div>
-              </div>
-            </div>
-            <div class="activity-progress-bar">
-              <div class="progress-fill" id="cultivationProgressFill"></div>
-              <div class="progress-text" id="cultivationProgressText">0%</div>
-            </div>
-          </div>
-          
-          <div class="activity-item leveling-tab" data-activity="physique">
-            <div class="activity-header">
-              <div class="activity-icon">💪</div>
-              <div class="activity-info">
-                <div class="activity-name">Physique</div>
-                <div class="activity-level" id="physiqueLevel">Level 1</div>
-              </div>
-            </div>
-            <div class="activity-progress-bar">
-              <div class="progress-fill" id="physiqueProgressFill"></div>
-              <div class="progress-text" id="physiqueProgressText">0%</div>
-            </div>
-          </div>
-          
-          <div class="activity-item leveling-tab" data-activity="mining">
-            <div class="activity-header">
-              <div class="activity-icon">⛏️</div>
-              <div class="activity-info">
-                <div class="activity-name">Mining</div>
-                <div class="activity-level" id="miningLevel">Level 1</div>
-              </div>
-            </div>
-            <div class="activity-progress-bar">
-              <div class="progress-fill" id="miningProgressFill"></div>
-              <div class="progress-text" id="miningProgressText">0%</div>
-            </div>
-          </div>
-          
-          <div class="activity-item leveling-tab" data-activity="cooking">
-            <div class="activity-header">
-              <div class="activity-icon">🍳</div>
-              <div class="activity-info">
-                <div class="activity-name">Cooking</div>
-                <div class="activity-level" id="cookingLevelSidebar">Level 1</div>
-              </div>
-            </div>
-            <div class="activity-progress-bar">
-              <div class="progress-fill" id="cookingProgressFillSidebar"></div>
-              <div class="progress-text" id="cookingProgressTextSidebar">0%</div>
-            </div>
-          </div>
-        </div>
+        <div class="activities leveling-activities" id="levelingActivities"></div>
       </div>
 
       <!-- Separator -->
@@ -114,34 +58,7 @@
       <!-- Exploration & Management Activities Group -->
       <div class="activity-group">
         <h4 class="group-title">🌟 Exploration & Management</h4>
-        <div class="activities management-activities">
-          <div class="activity-item management-tab" data-activity="adventure">
-            <div class="activity-header">
-              <div class="activity-icon">⚔️</div>
-              <div class="activity-info">
-                <div class="activity-name">Adventure</div>
-                <div class="activity-level" id="adventureLevel">Zone 1</div>
-              </div>
-            </div>
-            <div class="activity-progress-bar">
-              <div class="progress-fill" id="adventureProgressFill"></div>
-              <div class="progress-text" id="adventureProgressText">0%</div>
-            </div>
-          </div>
-          
-          <div class="activity-item management-tab" data-activity="sect">
-            <div class="activity-header">
-              <div class="activity-icon">🏛️</div>
-              <div class="activity-info">
-                <div class="activity-name">Sect</div>
-                <div class="activity-level" id="sectLevel">Buildings</div>
-              </div>
-            </div>
-            <div class="activity-status">
-              <div class="status-indicator" id="sectStatus">Inactive</div>
-            </div>
-          </div>
-        </div>
+        <div class="activities management-activities" id="managementActivities"></div>
       </div>
 
       <!-- Sect Selector -->

--- a/ui/index.js
+++ b/ui/index.js
@@ -25,6 +25,115 @@ import { initHp } from '../src/game/helpers.js';
 // Global variables
 let selectedActivity = 'cultivation'; // Current selected activity for the sidebar
 
+// Sidebar activities configuration
+const sidebarActivities = [
+  {
+    id: 'cultivation',
+    label: 'Cultivation',
+    icon: '🧘',
+    group: 'leveling',
+    levelId: 'cultivationLevel',
+    initialLevel: 'Mortal 1',
+    progressFillId: 'cultivationProgressFill',
+    progressTextId: 'cultivationProgressText',
+    cost: {}
+  },
+  {
+    id: 'physique',
+    label: 'Physique',
+    icon: '💪',
+    group: 'leveling',
+    levelId: 'physiqueLevel',
+    initialLevel: 'Level 1',
+    progressFillId: 'physiqueProgressFill',
+    progressTextId: 'physiqueProgressText',
+    cost: {}
+  },
+  {
+    id: 'mining',
+    label: 'Mining',
+    icon: '⛏️',
+    group: 'leveling',
+    levelId: 'miningLevel',
+    initialLevel: 'Level 1',
+    progressFillId: 'miningProgressFill',
+    progressTextId: 'miningProgressText',
+    cost: {}
+  },
+  {
+    id: 'cooking',
+    label: 'Cooking',
+    icon: '🍳',
+    group: 'leveling',
+    levelId: 'cookingLevelSidebar',
+    initialLevel: 'Level 1',
+    progressFillId: 'cookingProgressFillSidebar',
+    progressTextId: 'cookingProgressTextSidebar',
+    cost: {}
+  },
+  {
+    id: 'adventure',
+    label: 'Adventure',
+    icon: '⚔️',
+    group: 'management',
+    levelId: 'adventureLevel',
+    initialLevel: 'Zone 1',
+    progressFillId: 'adventureProgressFill',
+    progressTextId: 'adventureProgressText',
+    cost: {}
+  },
+  {
+    id: 'sect',
+    label: 'Sect',
+    icon: '🏛️',
+    group: 'management',
+    levelId: 'sectLevel',
+    initialLevel: 'Buildings',
+    statusId: 'sectStatus',
+    cost: {}
+  }
+];
+
+function renderSidebarActivities() {
+  const levelingContainer = document.getElementById('levelingActivities');
+  const managementContainer = document.getElementById('managementActivities');
+
+  sidebarActivities.forEach(act => {
+    const container = act.group === 'leveling' ? levelingContainer : managementContainer;
+    if (!container) return;
+
+    const item = document.createElement('div');
+    item.className = `activity-item ${act.group === 'leveling' ? 'leveling-tab' : 'management-tab'}`;
+    item.dataset.activity = act.id;
+
+    let html = `
+      <div class="activity-header">
+        <div class="activity-icon">${act.icon}</div>
+        <div class="activity-info">
+          <div class="activity-name">${act.label}</div>
+          <div class="activity-level" id="${act.levelId}">${act.initialLevel}</div>
+        </div>
+      </div>`;
+
+    if (act.progressFillId && act.progressTextId) {
+      html += `
+      <div class="activity-progress-bar">
+        <div class="progress-fill" id="${act.progressFillId}"></div>
+        <div class="progress-text" id="${act.progressTextId}">0%</div>
+      </div>`;
+    }
+
+    if (act.statusId) {
+      html += `
+      <div class="activity-status">
+        <div class="status-indicator" id="${act.statusId}">Inactive</div>
+      </div>`;
+    }
+
+    item.innerHTML = html;
+    container.appendChild(item);
+  });
+}
 
 const BEASTS = [
   {name:'Wild Rabbit', hp:20, atk:2, def:0, reward:{stones:5, herbs:2}},
@@ -343,6 +452,9 @@ function updateQiOrbEffect(){
 }
 
 function initUI(){
+  // Render sidebar activities
+  renderSidebarActivities();
+
   // Fill beasts
   const bs = document.getElementById('beastSelect');
   BEASTS.forEach((b,i)=>{const o=document.createElement('option'); o.value=i; o.textContent=`${b.name} (HP ${b.hp})`; bs.appendChild(o)});


### PR DESCRIPTION
## Summary
- Define `sidebarActivities` configuration with ids, labels, icons and progress metadata
- Add `renderSidebarActivities()` to build sidebar DOM from the configuration
- Populate the sidebar on UI init and drop duplicated hard‑coded markup in `index.html`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint ui/index.js`


------
https://chatgpt.com/codex/tasks/task_e_689e708d08d88326b21402af6f2713a4