### PR TITLE
refactor: centralize food slot updates

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -1502,22 +1502,6 @@ function updateActivityCooking() {
     progressFill.style.width = (S.cooking.exp / S.cooking.expMax * 100) + '%';
   }
   
-  // Update meat counts
-  setText('rawMeatCount', S.meat || 0);
-  setText('inventoryRawMeat', S.meat || 0);
-  setText('inventoryCookedMeat', S.cookedMeat || 0);
-  setText('inventoryRawMeatAdventure', S.meat || 0);
-  setText('inventoryCookedMeatAdventure', S.cookedMeat || 0);
-  
-  // Update cook amount input max
-  const cookInput = document.getElementById('cookAmount');
-  if (cookInput) {
-    cookInput.max = S.meat || 0;
-    if (parseInt(cookInput.value) > (S.meat || 0)) {
-      cookInput.value = Math.max(1, S.meat || 0);
-    }
-  }
-  
   // Update cook button
   const cookButton = document.getElementById('cookMeatButton');
   if (cookButton) {


### PR DESCRIPTION
## Summary
- Remove inline meat count and cook amount updates from cooking activity
- Delegate food-related UI refresh to `updateFoodSlots` in adventure module

## Testing
- `npm test` (fails: Error: no test specified)
- `node node_modules/eslint/bin/eslint.js ui/index.js src/game/adventure.js` (fails: TypeError: traverse is not a function)

------
https://chatgpt.com/codex/tasks/task_e_689f227cd9d48326ab7bd39c81e173c5