### PR TITLE
Refactor combat stat updates

### DIFF
--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -148,6 +148,7 @@ export function updateBattleDisplay() {
   const playerAttackRate = calculatePlayerAttackRate();
   setText('playerAttack', Math.floor(playerAttack));
   setText('playerAttackRate', `${playerAttackRate.toFixed(1)}/s`);
+  setText('combatAttackRate', `${playerAttackRate.toFixed(1)}/s`);
   if (S.adventure.inCombat && S.adventure.currentEnemy) {
     const enemy = S.adventure.currentEnemy;
     const enemyHP = S.adventure.enemyHP || 0;
@@ -420,15 +421,10 @@ export function updateActivityAdventure() {
   setText('totalKills', S.adventure.totalKills);
   setText('areasCompleted', S.adventure.areasCompleted);
   setText('zonesUnlocked', S.adventure.zonesUnlocked);
-  const playerAttack = calculatePlayerCombatAttack();
-  const playerAttackRate = calculatePlayerAttackRate();
   setText('currentWeapon', 'Fists');
   const fistBase = 5 + getFistBonuses().damage;
   setText('baseDamage', fistBase);
   setText('physiqueDamageBonus', `+${Math.floor((S.stats.physique - 10) * 2)}`);
-  setText('combatAttackRate', playerAttackRate.toFixed(1) + '/s');
-  setText('playerAttack', playerAttack);
-  setText('playerAttackRate', playerAttackRate.toFixed(1) + '/s');
   updateFistProficiencyDisplay();
   updateZoneButtons();
   updateAreaGrid();


### PR DESCRIPTION
## Summary
- Avoid duplicate combat stat calculations by letting `updateBattleDisplay` compute attack stats
- Remove redundant attack stat updates from `updateActivityAdventure`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node_modules/.bin/eslint src/game/adventure.js` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689f229031288326be883a4a4b124caf