### PR TITLE
Initialize adventure tab bindings once

### DIFF
--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -351,7 +351,10 @@ export function updateProgressButton() {
   progressBtn.textContent = isAreaCleared ? 'Progress to Next Area' : `Clear Area (${S.adventure.killsInCurrentArea}/${currentArea.killReq})`;
 }
 
+let tabsInitialized = false;
+
 export function setupAdventureTabs() {
+  if (tabsInitialized) return;
   const tabButtons = document.querySelectorAll('.adventure-tab-btn');
   tabButtons.forEach(button => {
     button.onclick = () => {
@@ -372,6 +375,7 @@ export function setupAdventureTabs() {
       }
     };
   });
+  tabsInitialized = true;
 }
 
 export function updateFoodSlots() {
@@ -436,5 +440,4 @@ export function updateActivityAdventure() {
   updateAdventureCombat();
   updateFoodSlots();
   updateProgressButton();
-  setupAdventureTabs();
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -30,7 +30,8 @@ import {
   progressToNextArea,
   retreatFromCombat,
   updateFistProficiencyDisplay,
-  updateFoodSlots
+  updateFoodSlots,
+  setupAdventureTabs
 } from '../src/game/adventure.js';
 
 // Global variables
@@ -2915,6 +2916,7 @@ window.addEventListener('load', ()=>{
   initUI();
   initLawSystem();
   initActivityListeners();
+  setupAdventureTabs();
   selectActivity('cultivation'); // Start with cultivation selected
   updateAll();
   tick();


### PR DESCRIPTION
## Summary
- guard adventure tab setup with flag to avoid duplicate event bindings
- invoke tab setup once on load instead of on every adventure update

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_689f22a5ae1c8326a14780400647f247