### PR TITLE
Bind hunt technique buttons to actions

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -2818,7 +2818,12 @@ function initActivityListeners() {
   // Session-based training event listeners
   document.getElementById('startTrainingSession')?.addEventListener('click', startTrainingSession);
   document.getElementById('hitButton')?.addEventListener('click', executeHit);
-  
+
+  // Hunt technique event listeners
+  document.getElementById('techSlash')?.addEventListener('click', techSlash);
+  document.getElementById('techGuard')?.addEventListener('click', techGuard);
+  document.getElementById('techBurst')?.addEventListener('click', techBurst);
+
   // Mining resource selection event listeners
   const miningResourceInputs = document.querySelectorAll('input[name="miningResource"]');
   miningResourceInputs.forEach(input => {


### PR DESCRIPTION
## Summary
- Bind Sword Slash, Guard, and Qi Burst buttons to their respective combat techniques in the activity panel.

## Testing
- `npm test` (fails: Error: no test specified)
- Node script to simulate clicks on tech buttons and verify console output.

------
https://chatgpt.com/codex/tasks/task_e_689f22eb74148326b424d1367b76d96c