### PR TITLE
Add bestiary kill tracking and display

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,9 +343,7 @@
             
             <!-- Bestiary Tab -->
             <div id="bestiaryTab" class="adventure-tab-content" style="display: none;">
-              <div class="bestiary-list" id="bestiaryList">
-                <div class="muted">Defeat enemies to unlock their information...</div>
-              </div>
+              <div class="bestiary-list" id="bestiaryList"></div>
             </div>
             
             <!-- Equipment Tab -->

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -73,6 +73,7 @@ export const defaultState = () => {
     zonesUnlocked: 1,
     killsInCurrentArea: 0,
     inCombat: false,
+    bestiary: {},
     playerHP: 100,
     enemyHP,
     enemyMaxHP,


### PR DESCRIPTION
## Summary
- Track kills per enemy type in the adventure bestiary
- Render bestiary entries with stats, zone and loot
- Prepare bestiary tab for dynamic content
- Avoid duplicate `setText` declarations by using a local helper

## Testing
- `npx eslint src/game/adventure.js src/game/state.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f22b274808326a155c4e2e17de8e7