### PR TITLE
Bind hunt technique buttons to adventure combat

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,14 @@
                 <button class="btn warn" id="retreatButton" style="display: none;">🏃 Retreat</button>
               </div>
             </div>
-            
+
+            <div class="combat-techniques">
+              <button class="btn small" id="techSlash">🗡️ Sword Slash</button>
+              <button class="btn small" id="techGuard">🛡️ Guard</button>
+              <button class="btn small" id="techBurst">💥 Qi Burst</button>
+            </div>
+            <p class="muted" id="techStatus"></p>
+
             <!-- Combat Log -->
             <div class="combat-log" id="combatLog">
               <div class="log-entry">Select an area to begin your adventure...</div>
@@ -634,12 +641,6 @@
               <span id="ourHpTxt">—</span>
             </div>
             <p class="muted">Affixes: <span id="affixList">None</span></p>
-            <div class="row" style="margin-top:8px">
-              <button class="btn small" id="techSlash">🗡️ Sword Slash</button>
-              <button class="btn small" id="techGuard">🛡️ Guard</button>
-              <button class="btn small" id="techBurst">💥 Qi Burst</button>
-            </div>
-            <p class="muted" id="techStatus"></p>
           </div>
 
           <div class="card">

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -175,6 +175,8 @@ export function updateBattleDisplay() {
     combatLog.innerHTML = recentLogs.map(l => `<div class="log-entry">${l}</div>`).join('');
     combatLog.scrollTop = combatLog.scrollHeight;
   }
+  const cd = S.combat.cds;
+  setText('techStatus', S.adventure.inCombat ? `Slash ${cd.slash||0}s • Guard ${cd.guard||0}s • Burst ${cd.burst||0}s` : '');
 }
 
 export function updateAdventureCombat() {
@@ -198,7 +200,8 @@ export function updateAdventureCombat() {
     if (S.adventure.enemyHP > 0 && S.adventure.currentEnemy) {
       const enemyAttackRate = S.adventure.currentEnemy.attackRate || 1.0;
       if (now - S.adventure.lastEnemyAttack >= (1000 / enemyAttackRate)) {
-        const enemyDamage = S.adventure.currentEnemy.attack || 5;
+        let enemyDamage = S.adventure.currentEnemy.attack || 5;
+        if (S.time < S.combat.guardUntil) enemyDamage *= 0.5;
         S.adventure.playerHP = Math.max(0, S.adventure.playerHP - enemyDamage);
         S.adventure.lastEnemyAttack = now;
         S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${enemyDamage} damage to you`);
@@ -210,9 +213,10 @@ export function updateAdventureCombat() {
       }
     }
   }
+  updateBattleDisplay();
 }
 
-function defeatEnemy() {
+export function defeatEnemy() {
   if (!S.adventure || !S.adventure.currentEnemy) return;
   const enemy = S.adventure.currentEnemy;
   S.adventure.totalKills++;

--- a/ui/index.js
+++ b/ui/index.js
@@ -30,7 +30,9 @@ import {
   progressToNextArea,
   retreatFromCombat,
   updateFistProficiencyDisplay,
-  updateFoodSlots
+  updateFoodSlots,
+  updateBattleDisplay,
+  defeatEnemy
 } from '../src/game/adventure.js';
 
 // Global variables
@@ -2596,22 +2598,25 @@ function resolveHunt(win){
 }
 
 function techSlash(){
-  if(!S.combat.hunt){ log('No active hunt','bad'); return; }
+  if(!(S.adventure && S.adventure.inCombat)){ log('No active battle','bad'); return; }
   if(S.combat.cds.slash>0){ log('Sword Slash on cooldown','bad'); return; }
   const dmg = calcAtk()*3;
-  S.combat.hunt.enemyHP = Math.max(0, S.combat.hunt.enemyHP - dmg);
-  S.combat.cds.slash = 8; log('You unleash Sword Slash!','good'); updateHuntUI();
+  S.adventure.enemyHP = Math.max(0, S.adventure.enemyHP - dmg);
+  S.combat.cds.slash = 8; log('You unleash Sword Slash!','good');
+  if (S.adventure.enemyHP <= 0) { defeatEnemy(); } else { updateBattleDisplay(); }
 }
 function techGuard(){
-  if(!S.combat.hunt){ log('No active hunt','bad'); return; }
+  if(!(S.adventure && S.adventure.inCombat)){ log('No active battle','bad'); return; }
   if(S.combat.cds.guard>0){ log('Guard on cooldown','bad'); return; }
-  S.combat.guardUntil = S.time + 5; S.combat.cds.guard = 20; log('You assume a guarded stance (5s).','good'); updateHuntUI();
+  S.combat.guardUntil = S.time + 5; S.combat.cds.guard = 20; log('You assume a guarded stance (5s).','good'); updateBattleDisplay();
 }
 function techBurst(){
-  if(!S.combat.hunt){ log('No active hunt','bad'); return; }
+  if(!(S.adventure && S.adventure.inCombat)){ log('No active battle','bad'); return; }
   if(S.combat.cds.burst>0){ log('Qi Burst on cooldown','bad'); return; }
   const need = 0.25*qCap(); if(S.qi < need){ log('Not enough Qi for Burst (25% required)','bad'); return; }
-  S.qi -= need; const dmg = need/3 + calcAtk(); S.combat.hunt.enemyHP = Math.max(0, S.combat.hunt.enemyHP - dmg); S.combat.cds.burst = 15; log('Qi Burst detonates!','good'); updateHuntUI();
+  S.qi -= need; const dmg = need/3 + calcAtk();
+  S.adventure.enemyHP = Math.max(0, S.adventure.enemyHP - dmg); S.combat.cds.burst = 15; log('Qi Burst detonates!','good');
+  if (S.adventure.enemyHP <= 0) { defeatEnemy(); } else { updateBattleDisplay(); }
 }
 
 function updateWinEst(){
@@ -2818,7 +2823,12 @@ function initActivityListeners() {
   // Session-based training event listeners
   document.getElementById('startTrainingSession')?.addEventListener('click', startTrainingSession);
   document.getElementById('hitButton')?.addEventListener('click', executeHit);
-  
+
+  // Hunt technique event listeners
+  document.getElementById('techSlash')?.addEventListener('click', techSlash);
+  document.getElementById('techGuard')?.addEventListener('click', techGuard);
+  document.getElementById('techBurst')?.addEventListener('click', techBurst);
+
   // Mining resource selection event listeners
   const miningResourceInputs = document.querySelectorAll('input[name="miningResource"]');
   miningResourceInputs.forEach(input => {


### PR DESCRIPTION
## Summary
- Move Sword Slash, Guard, and Qi Burst controls into the adventure battle card so they appear during fights
- Support techniques in adventure combat with cooldown display and guard damage reduction
- Update technique handlers to operate on adventure enemies

## Testing
- `npm test` (fails: Error: no test specified)
- Node script to simulate technique button clicks and confirm log output

------
https://chatgpt.com/codex/tasks/task_e_689f22eb74148326b424d1367b76d96c