### PR TITLE
refactor: extract affix logic into module

### DIFF
--- a/src/game/affixes.js
+++ b/src/game/affixes.js
@@ -1,0 +1,23 @@
+export const AFFIX_DEFS = {
+  Armored: h => { h.eDef *= 1.4; },
+  Frenzied: h => { h.eAtk *= 1.35; },
+  Regenerating: h => { h.regen += 0.02; },
+  Giant: h => { h.enemyMax = Math.floor(h.enemyMax * 1.6); h.enemyHP = h.enemyMax; },
+  Swift: h => { h.eAtk *= 1.15; }
+};
+
+export const AFFIX_KEYS = Object.keys(AFFIX_DEFS);
+
+export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
+  h.affixes = [];
+  const choices = [...AFFIX_KEYS];
+  for (let i = 0; i < count; i++) {
+    if (!choices.length) break;
+    const idx = Math.floor(Math.random() * choices.length);
+    const key = choices.splice(idx, 1)[0];
+    h.affixes.push(key);
+    const apply = AFFIX_DEFS[key];
+    if (apply) apply(h);
+  }
+  return h;
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -20,6 +20,7 @@ import {
   calculatePlayerAttackRate
 } from '../src/game/engine.js';
 import { initHp } from '../src/game/helpers.js';
+import { applyRandomAffixes } from '../src/game/affixes.js';
 import {
   updateRealmUI,
   updateActivityCultivation,
@@ -2136,20 +2137,9 @@ function usePill(type){
 function startHunt(){
   if(S.combat.hunt){ log('Already hunting','bad'); return; }
   const i= +document.getElementById('beastSelect').value; const b=BEASTS[i];
-  const KEYS = ['Armored','Frenzied','Regenerating','Giant','Swift'];
-  const aff = [];
-  const affCount = Math.floor(Math.random()*3);
   const { hp: enemyHP, hpMax: enemyMax } = initHp(b.hp);
-  const h = {i, name:b.name, base:b, affixes:aff, enemyMax, enemyHP, eAtk:b.atk, eDef:b.def, regen:0};
-  let chosen=[...KEYS];
-  for(let k=0;k<affCount;k++){
-    const idx=Math.floor(Math.random()*chosen.length); const key=chosen.splice(idx,1)[0]; aff.push(key);
-    if(key==='Armored') h.eDef *= 1.4;
-    if(key==='Frenzied') h.eAtk *= 1.35;
-    if(key==='Regenerating') h.regen += 0.02;
-    if(key==='Giant'){ h.enemyMax = Math.floor(h.enemyMax*1.6); h.enemyHP = h.enemyMax; }
-    if(key==='Swift') h.eAtk *= 1.15;
-  }
+  const h = {i, name:b.name, base:b, enemyMax, enemyHP, eAtk:b.atk, eDef:b.def, regen:0, affixes:[]};
+  applyRandomAffixes(h);
   S.combat.hunt = h; updateHuntUI();
 }
 


### PR DESCRIPTION
## Summary
- add `src/game/affixes.js` with affix definitions and random assignment helper
- use new affix module during hunts so enemies spawn with random affixes and UI displays them

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689f30bca3d88326ad53de5bc40ef2d3