### PR TITLE
refactor: remove duplicate setText imports

### DIFF
--- a/ui/dom.js
+++ b/ui/dom.js
@@ -1,14 +1,4 @@
-import { clamp } from '../src/game/engine.js';
-
 export const qs = sel => document.querySelector(sel);
 
-export function setText(id, v) {
-  const el = document.getElementById(id);
-  if (el) el.textContent = v;
-}
+export { setText, setFill, log } from '../src/game/utils.js';
 
-export function setFill(id, ratio) {
-  ratio = clamp(ratio, 0, 1);
-  const el = document.getElementById(id);
-  if (el) el.style.width = (ratio * 100).toFixed(1) + '%';
-}

--- a/ui/index.js
+++ b/ui/index.js
@@ -28,8 +28,7 @@ import {
   initRealmUI,
   getRealmName
 } from './realm.js';
-import { qs, setText, setFill } from './dom.js';
-import { setText, setFill, log } from '../src/game/utils.js';
+import { qs, setText, setFill, log } from './dom.js';
 import {
   ADVENTURE_ZONES,
   updateActivityAdventure,


### PR DESCRIPTION
## Summary
- centralize DOM helpers and re-export `setText`, `setFill`, and `log`
- fix redeclared `setText` by importing helpers from a single module

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node node_modules/eslint/bin/eslint.js ui/dom.js ui/index.js`


------
https://chatgpt.com/codex/tasks/task_e_689fb982bdfc8326ab81d8bf19140fe1