### PR TITLE
fix: import log function in realm

### DIFF
--- a/ui/realm.js
+++ b/ui/realm.js
@@ -11,7 +11,7 @@ import {
   foundationGainPerSec,
   powerMult
 } from '../src/game/engine.js';
-import { qs, setText } from './dom.js';
+import { qs, setText, log } from './dom.js';
 
 export function getRealmName(tier) {
   return REALMS[tier].name;


### PR DESCRIPTION
## Summary
- import `log` in `ui/realm.js` to allow breakthrough messages to display correctly

## Testing
- `npm test` (fails: no test specified)
- `npx eslint ui/realm.js` (fails: 'stopActivity' is not defined)


------
https://chatgpt.com/codex/tasks/task_e_689fc48215f8832695fb786a07d19dff