### PR TITLE
feat: centralize combat initialization

### DIFF
--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -1,6 +1,6 @@
 import { S } from './state.js';
-import { initHp } from './helpers.js';
 import { calculatePlayerCombatAttack, calculatePlayerAttackRate, getFistBonuses } from './engine.js';
+import { initializeFight, processAttack } from './combat.js';
 import { ENEMY_DATA } from '../../data/enemies.js';
 import { setText, setFill, log } from './utils.js';
 
@@ -188,7 +188,7 @@ export function updateAdventureCombat() {
     if (!S.adventure.lastPlayerAttack) S.adventure.lastPlayerAttack = now;
     if (!S.adventure.lastEnemyAttack) S.adventure.lastEnemyAttack = now;
     if (now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
-      S.adventure.enemyHP = Math.max(0, S.adventure.enemyHP - playerAttack);
+      S.adventure.enemyHP = processAttack(S.adventure.enemyHP, playerAttack);
       S.adventure.lastPlayerAttack = now;
       gainFistXP(playerAttack);
       S.adventure.combatLog = S.adventure.combatLog || [];
@@ -201,7 +201,7 @@ export function updateAdventureCombat() {
       const enemyAttackRate = S.adventure.currentEnemy.attackRate || 1.0;
       if (now - S.adventure.lastEnemyAttack >= (1000 / enemyAttackRate)) {
         const enemyDamage = S.adventure.currentEnemy.attack || 5;
-        S.adventure.playerHP = Math.max(0, S.adventure.playerHP - enemyDamage);
+        S.adventure.playerHP = processAttack(S.adventure.playerHP, enemyDamage);
         S.adventure.lastEnemyAttack = now;
         S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${enemyDamage} damage to you`);
         if (S.adventure.playerHP <= 0) {
@@ -232,9 +232,9 @@ function defeatEnemy() {
   }
   S.adventure.inCombat = false;
   S.adventure.currentEnemy = null;
-  const { hp, hpMax } = initHp(0);
-  S.adventure.enemyHP = hp;
-  S.adventure.enemyMaxHP = hpMax;
+  const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
+  S.adventure.enemyHP = enemyHP;
+  S.adventure.enemyMaxHP = enemyMax;
   log(`Defeated ${enemy.name}! Kills: ${S.adventure.totalKills}`, 'good');
   if (S.activities.adventure && S.adventure.playerHP > 0) {
     startAdventureCombat();
@@ -260,9 +260,9 @@ export function startAdventureCombat() {
   }
   S.adventure.inCombat = true;
   S.adventure.currentEnemy = { ...enemyData, type: enemyType };
-  const { hp, hpMax } = initHp(enemyData.hp);
-  S.adventure.enemyHP = hp;
-  S.adventure.enemyMaxHP = hpMax;
+  const { enemyHP, enemyMax } = initializeFight(enemyData);
+  S.adventure.enemyHP = enemyHP;
+  S.adventure.enemyMaxHP = enemyMax;
   S.adventure.playerHP = S.hp;
   S.adventure.lastPlayerAttack = 0;
   S.adventure.lastEnemyAttack = 0;
@@ -335,9 +335,9 @@ export function retreatFromCombat() {
   if (S.adventure.inCombat) {
     S.adventure.inCombat = false;
     S.adventure.currentEnemy = null;
-    const { hp, hpMax } = initHp(0);
-    S.adventure.enemyHP = hp;
-    S.adventure.enemyMaxHP = hpMax;
+    const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
+    S.adventure.enemyHP = enemyHP;
+    S.adventure.enemyMaxHP = enemyMax;
     S.adventure.combatLog = S.adventure.combatLog || [];
     S.adventure.combatLog.push('You retreated from combat.');
     log('Retreated from combat safely.', 'neutral');

--- a/src/game/combat.js
+++ b/src/game/combat.js
@@ -1,0 +1,13 @@
+import { initHp } from './helpers.js';
+
+export function initializeFight(enemy) {
+  const { hp: enemyHP, hpMax: enemyMax } = initHp(enemy.hp || 0);
+  const atk = enemy.atk ?? enemy.attack ?? 0;
+  const def = enemy.def ?? enemy.defense ?? 0;
+  return { enemyHP, enemyMax, atk, def };
+}
+
+export function processAttack(currentHP, damage) {
+  return Math.max(0, currentHP - damage);
+}
+


### PR DESCRIPTION
## Summary
- add shared combat utilities for fight setup and damage handling
- refactor hunt and adventure combat to use shared helpers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fc4115b208326beb4b822eb34b124