### PR TITLE
Add affix support to adventure enemies and expand bestiary unlocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,6 +301,7 @@
                     <span>ATK: <span id="enemyAttack">--</span></span>
                     <span>Rate: <span id="enemyAttackRate">--/s</span></span>
                   </div>
+                  <p class="muted">Affixes: <span id="enemyAffixes">None</span></p>
                 </div>
               </div>
               


### PR DESCRIPTION
## Summary
- apply random affixes to adventure enemies and display them in battle
- unlock detailed bestiary entries once kill requirements are met

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fc46d530883269b72f61a90836360