### PR TITLE
Fix cultivation start toggle

### DIFF
--- a/src/game/state.js
+++ b/src/game/state.js
@@ -44,7 +44,9 @@ export const defaultState = () => {
   bought:{},
   karmaPts:0, ascensions:0,
   karma:{qiRegen:0, yield:0, atk:0, def:0},
-  auto:{meditate:true, brewQi:false, hunt:false}, // Auto-meditate enabled by default
+  // Auto systems - players now begin with meditation disabled and must
+  // explicitly start cultivating via the UI.
+  auto:{meditate:false, brewQi:false, hunt:false},
   // Activity System - only one can be active at a time
   activities: {
     cultivation: false,

--- a/ui/index.js
+++ b/ui/index.js
@@ -972,11 +972,21 @@ function stopActivity(activityName) {
     S.physique.trainingSession = false;
     S.physique.timingActive = false;
   }
+  if (activityName === 'cultivation' && S.auto) {
+    // Ensure passive meditation doesn't continue when cultivation is stopped
+    S.auto.meditate = false;
+  }
   
   log(`Stopped ${activityName}`, 'neutral');
   updateActivitySelectors();
   updateActivityContent();
 }
+
+// Expose activity controls globally so other modules like realm.js can access
+// them when binding UI event handlers. Without this, the cultivation start/stop
+// button fails to toggle the activity state.
+window.startActivity = startActivity;
+window.stopActivity = stopActivity;
 
 function updateActivitySelectors() {
   // Ensure physique and mining data structures exist


### PR DESCRIPTION
## Summary
- Disable auto meditation by default so cultivation only starts when requested
- Ensure stopping cultivation clears passive meditation
- Expose activity controls globally so the cultivation button toggles correctly

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_689fce394ac08326aa13692ae9ee005a