### PR TITLE
Round combat stat values

### DIFF
--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -139,7 +139,7 @@ export function updateBattleDisplay() {
   ensureAdventure();
   const playerHP = S.adventure.playerHP || S.hp || 100;
   const playerMaxHP = S.hpMax || 100;
-  setText('playerHealthText', `${playerHP}/${playerMaxHP}`);
+  setText('playerHealthText', `${Math.round(playerHP)}/${Math.round(playerMaxHP)}`);
   const playerHealthFill = document.getElementById('playerHealthFill');
   if (playerHealthFill) {
     const playerHealthPct = (playerHP / playerMaxHP) * 100;
@@ -147,7 +147,7 @@ export function updateBattleDisplay() {
   }
   const playerAttack = calculatePlayerCombatAttack();
   const playerAttackRate = calculatePlayerAttackRate();
-  setText('playerAttack', Math.floor(playerAttack));
+  setText('playerAttack', Math.round(playerAttack));
   setText('playerAttackRate', `${playerAttackRate.toFixed(1)}/s`);
   setText('combatAttackRate', `${playerAttackRate.toFixed(1)}/s`);
   if (S.adventure.inCombat && S.adventure.currentEnemy) {
@@ -155,8 +155,8 @@ export function updateBattleDisplay() {
     const enemyHP = S.adventure.enemyHP || 0;
     const enemyMaxHP = S.adventure.enemyMaxHP || 0;
     setText('enemyName', enemy.name || 'Unknown Enemy');
-    setText('enemyHealthText', `${enemyHP}/${enemyMaxHP}`);
-    setText('enemyAttack', enemy.attack || 0);
+    setText('enemyHealthText', `${Math.round(enemyHP)}/${Math.round(enemyMaxHP)}`);
+    setText('enemyAttack', Math.round(enemy.attack || 0));
     setText('enemyAttackRate', `${(enemy.attackRate || 1.0).toFixed(1)}/s`);
     const enemyHealthFill = document.getElementById('enemyHealthFill');
     if (enemyHealthFill && enemyMaxHP > 0) {
@@ -188,11 +188,11 @@ export function updateAdventureCombat() {
     if (!S.adventure.lastPlayerAttack) S.adventure.lastPlayerAttack = now;
     if (!S.adventure.lastEnemyAttack) S.adventure.lastEnemyAttack = now;
     if (now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
-      S.adventure.enemyHP = processAttack(S.adventure.enemyHP, playerAttack);
+      S.adventure.enemyHP = processAttack(S.adventure.enemyHP, Math.round(playerAttack));
       S.adventure.lastPlayerAttack = now;
-      gainFistXP(playerAttack);
+      gainFistXP(Math.round(playerAttack));
       S.adventure.combatLog = S.adventure.combatLog || [];
-      S.adventure.combatLog.push(`You deal ${playerAttack} damage to ${S.adventure.currentEnemy.name}`);
+      S.adventure.combatLog.push(`You deal ${Math.round(playerAttack)} damage to ${S.adventure.currentEnemy.name}`);
       if (S.adventure.enemyHP <= 0) {
         defeatEnemy();
       }
@@ -200,7 +200,7 @@ export function updateAdventureCombat() {
     if (S.adventure.enemyHP > 0 && S.adventure.currentEnemy) {
       const enemyAttackRate = S.adventure.currentEnemy.attackRate || 1.0;
       if (now - S.adventure.lastEnemyAttack >= (1000 / enemyAttackRate)) {
-        const enemyDamage = S.adventure.currentEnemy.attack || 5;
+        const enemyDamage = Math.round(S.adventure.currentEnemy.attack || 5);
         S.adventure.playerHP = processAttack(S.adventure.playerHP, enemyDamage);
         S.adventure.lastEnemyAttack = now;
         S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${enemyDamage} damage to you`);
@@ -263,7 +263,7 @@ export function startAdventureCombat() {
   const { enemyHP, enemyMax } = initializeFight(enemyData);
   S.adventure.enemyHP = enemyHP;
   S.adventure.enemyMaxHP = enemyMax;
-  S.adventure.playerHP = S.hp;
+  S.adventure.playerHP = Math.round(S.hp);
   S.adventure.lastPlayerAttack = 0;
   S.adventure.lastEnemyAttack = 0;
   S.adventure.combatLog = S.adventure.combatLog || [];

--- a/src/game/combat.js
+++ b/src/game/combat.js
@@ -2,12 +2,12 @@ import { initHp } from './helpers.js';
 
 export function initializeFight(enemy) {
   const { hp: enemyHP, hpMax: enemyMax } = initHp(enemy.hp || 0);
-  const atk = enemy.atk ?? enemy.attack ?? 0;
-  const def = enemy.def ?? enemy.defense ?? 0;
+  const atk = Math.round(enemy.atk ?? enemy.attack ?? 0);
+  const def = Math.round(enemy.def ?? enemy.defense ?? 0);
   return { enemyHP, enemyMax, atk, def };
 }
 
 export function processAttack(currentHP, damage) {
-  return Math.max(0, currentHP - damage);
+  return Math.max(0, Math.round(currentHP - damage));
 }
 

--- a/src/game/helpers.js
+++ b/src/game/helpers.js
@@ -1,3 +1,4 @@
 export function initHp(hpMax){
-  return { hp: hpMax, hpMax };
+  const max = Math.round(hpMax);
+  return { hp: max, hpMax: max };
 }


### PR DESCRIPTION
## Summary
- ensure HP init uses integer values
- round enemy stats and damage calculations
- display rounded attack and health values for both combatants

## Testing
- `npx eslint src/game/combat.js src/game/helpers.js src/game/adventure.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fcf3f05c083269026dc2769941c09