### PR TITLE
feat: show current task in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       </div>
     </div>
     <div class="topbar" id="top-chips">
+      <div class="chip">Task: <span id="currentTask">Idle</span></div>
       <div class="chip">Realm: <span id="realmName">Mortal 1</span></div>
       <div class="chip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
       <div class="chip">Stones: <span id="stonesVal">0</span></div>

--- a/ui/index.js
+++ b/ui/index.js
@@ -502,6 +502,7 @@ function updateAll(){
   if (!S.activities) {
     S.activities = { cultivation: false, physique: false, mining: false, adventure: false, cooking: false };
   }
+  updateCurrentTaskDisplay();
 
   // Update progression displays
   setText('physiqueLevel', S.physique.level);
@@ -988,6 +989,20 @@ function stopActivity(activityName) {
 window.startActivity = startActivity;
 window.stopActivity = stopActivity;
 
+function updateCurrentTaskDisplay() {
+  const el = document.getElementById('currentTask');
+  if (!el) return;
+  const names = {
+    cultivation: 'Cultivating',
+    physique: 'Physique Training',
+    mining: 'Mining',
+    adventure: 'Adventuring',
+    cooking: 'Cooking'
+  };
+  const active = S.activities ? Object.keys(S.activities).find(key => S.activities[key]) : null;
+  el.textContent = active ? (names[active] || 'Idle') : 'Idle';
+}
+
 function updateActivitySelectors() {
   // Ensure physique and mining data structures exist
   if (!S.physique) {
@@ -1071,6 +1086,7 @@ function updateActivitySelectors() {
     const buildingCount = Object.values(S.buildings).reduce((sum, level) => sum + (level > 0 ? 1 : 0), 0);
     sectInfo.textContent = `${buildingCount} Buildings`;
   }
+  updateCurrentTaskDisplay();
 }
 
 function updateActivityContent() {


### PR DESCRIPTION
## Summary
- display current activity in header top bar
- update UI logic to show active task text dynamically

## Testing
- `npm test` *(fails: no test specified)*
- `npx eslint ui/index.js`

------
https://chatgpt.com/codex/tasks/task_e_689fe159a94483269d9b13ea1396a160