### PR TITLE
Persist adventure HP and add out-of-combat regen

### DIFF
--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -202,6 +202,7 @@ export function updateAdventureCombat() {
       if (now - S.adventure.lastEnemyAttack >= (1000 / enemyAttackRate)) {
         const enemyDamage = S.adventure.currentEnemy.attack || 5;
         S.adventure.playerHP = processAttack(S.adventure.playerHP, enemyDamage);
+        S.hp = S.adventure.playerHP;
         S.adventure.lastEnemyAttack = now;
         S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${enemyDamage} damage to you`);
         if (S.adventure.playerHP <= 0) {
@@ -230,6 +231,7 @@ function defeatEnemy() {
     S.meat = (S.meat || 0) + meatGained;
     S.adventure.combatLog.push(`Found ${meatGained} raw meat!`);
   }
+  S.hp = S.adventure.playerHP;
   S.adventure.inCombat = false;
   S.adventure.currentEnemy = null;
   const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
@@ -333,6 +335,7 @@ export function selectZone(zoneIndex) {
 export function retreatFromCombat() {
   if (!S.adventure) return;
   if (S.adventure.inCombat) {
+    S.hp = S.adventure.playerHP;
     S.adventure.inCombat = false;
     S.adventure.currentEnemy = null;
     const { enemyHP, enemyMax } = initializeFight({ hp: 0 });

--- a/ui/index.js
+++ b/ui/index.js
@@ -2223,10 +2223,12 @@ if (ascendBtn) {
 function tick(){
   S.time++;
 
-  // Passive Qi & HP regen
+  // Passive Qi regen and out-of-combat HP regen
   S.qi = clamp(S.qi + qiRegenPerSec(), 0, qCap());
-  const multHeal = 0.01 + S.realm.tier*0.002;
-  S.hp = clamp(S.hp + S.hpMax*multHeal, 0, S.hpMax);
+  if (!(S.adventure?.inCombat) && !S.combat.hunt) {
+    S.hp = clamp(S.hp + 1, 0, S.hpMax);
+    if (S.adventure) S.adventure.playerHP = S.hp;
+  }
 
   // Gathering
   S.herbs += yieldBase('herbs') * S.gather.herbs;


### PR DESCRIPTION
## Summary
- Keep player HP from resetting after defeating enemies
- Synchronize global HP with adventure health and add passive 1 HP/s regen outside combat

## Testing
- `npx eslint src/game/adventure.js ui/index.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689fe54988088326b6c1d7f72290decc