### PR TITLE
Triple enemy HP values

### DIFF
--- a/data/enemies.js
+++ b/data/enemies.js
@@ -4,28 +4,28 @@ export const ENEMY_DATA = {
   // Low-level creatures for beginners
   'Forest Rabbit': { 
     name: 'Forest Rabbit', 
-    hp: 15, 
+    hp: 45,
     attack: 3, 
     attackRate: 1.2, 
     loot: { stones: 2, herbs: 1 } 
   },
   'Wild Boar': { 
     name: 'Wild Boar', 
-    hp: 25, 
+    hp: 75,
     attack: 5, 
     attackRate: 0.9, 
     loot: { stones: 4, ore: 1 } 
   },
   'River Frog': { 
     name: 'River Frog', 
-    hp: 20, 
+    hp: 60,
     attack: 4, 
     attackRate: 1.1, 
     loot: { stones: 3, herbs: 1 } 
   },
   'Honey Bee': { 
     name: 'Honey Bee', 
-    hp: 12, 
+    hp: 36,
     attack: 5, 
     attackRate: 1.5, 
     loot: { herbs: 2 },
@@ -36,28 +36,28 @@ export const ENEMY_DATA = {
   // Magical forest creatures with nature-based loot
   'Tree Sprite': { 
     name: 'Tree Sprite', 
-    hp: 30, 
+    hp: 90,
     attack: 6, 
     attackRate: 1.0, 
     loot: { herbs: 3, wood: 1 } 
   },
   'Stone Lizard': { 
     name: 'Stone Lizard', 
-    hp: 40, 
+    hp: 120,
     attack: 7, 
     attackRate: 0.8, 
     loot: { stones: 5, ore: 2 } 
   },
   'Water Snake': { 
     name: 'Water Snake', 
-    hp: 28, 
+    hp: 84,
     attack: 8, 
     attackRate: 1.2, 
     loot: { herbs: 2, venom: 1 } 
   },
   'Grass Wolf': { 
     name: 'Grass Wolf', 
-    hp: 50, 
+    hp: 150,
     attack: 10, 
     attackRate: 1.0, 
     loot: { meat: 2, pelt: 1 },
@@ -68,14 +68,14 @@ export const ENEMY_DATA = {
   // Guardians and spirits protecting old secrets
   'Ruin Guardian': { 
     name: 'Ruin Guardian', 
-    hp: 80, 
+    hp: 240,
     attack: 15, 
     attackRate: 0.7, 
     loot: { ore: 3, ancientRelic: 1 } 
   },
   'Forest Spirit': { 
     name: 'Forest Spirit', 
-    hp: 120, 
+    hp: 360,
     attack: 20, 
     attackRate: 0.9, 
     loot: { herbs: 5, ancientRelic: 2, spiritEssence: 1 } 
@@ -85,7 +85,7 @@ export const ENEMY_DATA = {
   // Corrupted creatures infused with shadow essence
   'Shadow Wolf': { 
     name: 'Shadow Wolf', 
-    hp: 150, 
+    hp: 450,
     attack: 25, 
     attackRate: 1.2, 
     loot: { shadowEssence: 1, pelt: 2 },
@@ -93,56 +93,56 @@ export const ENEMY_DATA = {
   },
   'Dark Treant': { 
     name: 'Dark Treant', 
-    hp: 250, 
+    hp: 750,
     attack: 35, 
     attackRate: 0.8, 
     loot: { corruptedWood: 2, shadowEssence: 2 } 
   },
   'Cursed Toad': { 
     name: 'Cursed Toad', 
-    hp: 180, 
+    hp: 540,
     attack: 40, 
     attackRate: 1.1, 
     loot: { venom: 3, shadowEssence: 1 } 
   },
   'Thorn Beast': { 
     name: 'Thorn Beast', 
-    hp: 300, 
+    hp: 900,
     attack: 45, 
     attackRate: 0.9, 
     loot: { thorns: 4, shadowEssence: 2 } 
   },
   'Corrupted Familiar': { 
     name: 'Corrupted Familiar', 
-    hp: 220, 
+    hp: 660,
     attack: 50, 
     attackRate: 1.3, 
     loot: { shadowEssence: 3, arcaneDust: 2 } 
   },
   'Wraith': { 
     name: 'Wraith', 
-    hp: 350, 
+    hp: 1050,
     attack: 55, 
     attackRate: 1.0, 
     loot: { ectoplasm: 3, shadowEssence: 3 } 
   },
   'Nightmare Hound': { 
     name: 'Nightmare Hound', 
-    hp: 400, 
+    hp: 1200,
     attack: 65, 
     attackRate: 1.2, 
     loot: { nightmareEssence: 2, shadowEssence: 3 } 
   },
   'Skeleton Warrior': { 
     name: 'Skeleton Warrior', 
-    hp: 500, 
+    hp: 1500,
     attack: 70, 
     attackRate: 0.9, 
     loot: { ancientBones: 4, shadowEssence: 3 } 
   },
   'Dark Cultist': { 
     name: 'Dark Cultist', 
-    hp: 450, 
+    hp: 1350,
     attack: 80, 
     attackRate: 1.1, 
     loot: { shadowEssence: 5, arcaneTome: 1 } 
@@ -152,7 +152,7 @@ export const ENEMY_DATA = {
   // Powerful dark entities and nightmare creatures
   'Shadow Lord': { 
     name: 'Shadow Lord', 
-    hp: 1000, 
+    hp: 3000,
     attack: 100, 
     attackRate: 1.5, 
     loot: { shadowEssence: 10, darkCrystal: 1, ancientRelic: 5 } 
@@ -162,7 +162,7 @@ export const ENEMY_DATA = {
   // High-altitude creatures adapted to harsh conditions
   'Mountain Goat': { 
     name: 'Mountain Goat', 
-    hp: 800, 
+    hp: 2400,
     attack: 90, 
     attackRate: 1.3, 
     loot: { mountainHerbs: 3, goatHorn: 2 },
@@ -170,14 +170,14 @@ export const ENEMY_DATA = {
   },
   'Wind Elemental': { 
     name: 'Wind Elemental', 
-    hp: 600, 
+    hp: 1800,
     attack: 110, 
     attackRate: 1.8, 
     loot: { windCrystal: 3, essenceOfAir: 2 } 
   },
   'Frost Bear': { 
     name: 'Frost Bear', 
-    hp: 1200, 
+    hp: 3600,
     attack: 130, 
     attackRate: 0.9, 
     loot: { frostFur: 4, bearClaw: 2 },
@@ -185,42 +185,42 @@ export const ENEMY_DATA = {
   },
   'Crystal Golem': { 
     name: 'Crystal Golem', 
-    hp: 2000, 
+    hp: 6000,
     attack: 150, 
     attackRate: 0.7, 
     loot: { crystalShards: 5, earthEssence: 3 } 
   },
   'Giant Eagle': { 
     name: 'Giant Eagle', 
-    hp: 900, 
+    hp: 2700,
     attack: 140, 
     attackRate: 1.5, 
     loot: { eagleFeather: 3, talon: 2 } 
   },
   'Lightning Hawk': { 
     name: 'Lightning Hawk', 
-    hp: 700, 
+    hp: 2100,
     attack: 160, 
     attackRate: 2.0, 
     loot: { lightningFeather: 4, stormEssence: 3 } 
   },
   'Ice Titan': { 
     name: 'Ice Titan', 
-    hp: 3000, 
+    hp: 9000,
     attack: 200, 
     attackRate: 0.8, 
     loot: { titanIce: 5, frozenCore: 1 } 
   },
   'Young Dragon': { 
     name: 'Young Dragon', 
-    hp: 5000, 
+    hp: 15000,
     attack: 250, 
     attackRate: 1.2, 
     loot: { dragonScales: 5, dragonClaw: 3, dragonBlood: 2 } 
   },
   'Sky Guardian': { 
     name: 'Sky Guardian', 
-    hp: 4000, 
+    hp: 12000,
     attack: 300, 
     attackRate: 1.5, 
     loot: { guardianFeather: 5, skyEssence: 3, ancientRelic: 5 } 
@@ -230,7 +230,7 @@ export const ENEMY_DATA = {
   // Legendary beings that rule the highest peaks
   'Mountain King': { 
     name: 'Mountain King', 
-    hp: 10000, 
+    hp: 30000,
     attack: 400, 
     attackRate: 1.0, 
     loot: { kingsCrown: 1, mountainHeart: 1, ancientRelic: 10 } 

--- a/ui/index.js
+++ b/ui/index.js
@@ -156,11 +156,11 @@ function renderSidebarActivities() {
 }
 
 const BEASTS = [
-  {name:'Wild Rabbit', hp:20, atk:2, def:0, reward:{stones:5, herbs:2}},
-  {name:'Boar', hp:60, atk:5, def:2, reward:{stones:15, ore:3}},
-  {name:'Spirit Wolf', hp:140, atk:10, def:4, reward:{stones:35, wood:6}},
-  {name:'Tiger', hp:300, atk:18, def:8, reward:{stones:80, ore:12}},
-  {name:'Dragon Whelp', hp:800, atk:40, def:18, reward:{stones:220, herbs:30, ore:25}}
+  {name:'Wild Rabbit', hp:60, atk:2, def:0, reward:{stones:5, herbs:2}},
+  {name:'Boar', hp:180, atk:5, def:2, reward:{stones:15, ore:3}},
+  {name:'Spirit Wolf', hp:420, atk:10, def:4, reward:{stones:35, wood:6}},
+  {name:'Tiger', hp:900, atk:18, def:8, reward:{stones:80, ore:12}},
+  {name:'Dragon Whelp', hp:2400, atk:40, def:18, reward:{stones:220, herbs:30, ore:25}}
 ];
 
 


### PR DESCRIPTION
## Summary
- Triple HP for all enemies in ENEMY_DATA
- Scale BEASTS list HP values to match new enemy strength

## Testing
- `npm test` (fails: no test specified)
- `npx eslint data/enemies.js ui/index.js`

------
https://chatgpt.com/codex/tasks/task_e_689fea61c8108326b0f15fc251bc479b