### PR TITLE
Show colored affix tiles for enemies

### DIFF
--- a/index.html
+++ b/index.html
@@ -633,7 +633,8 @@
               <div class="bar" style="flex:1"><div class="fill" id="ourFill"></div></div>
               <span id="ourHpTxt">—</span>
             </div>
-            <p class="muted">Affixes: <span id="affixList">None</span></p>
+            <div class="muted">Affixes:</div>
+            <div id="affixList" class="affix-container muted">None</div>
             <div class="row" style="margin-top:8px">
               <button class="btn small" id="techSlash">🗡️ Sword Slash</button>
               <button class="btn small" id="techGuard">🛡️ Guard</button>

--- a/src/game/affixes.js
+++ b/src/game/affixes.js
@@ -1,14 +1,34 @@
-export const AFFIX_DEFS = {
-  Armored: h => { h.eDef *= 1.4; },          // +40% defense - reduces incoming damage
-  Frenzied: h => { h.eAtk *= 1.35; },        // +35% attack power - deals more damage
-  Regenerating: h => { h.regen += 0.02; },   // +2% health regeneration per tick
-  Giant: h => { h.enemyMax = Math.floor(h.enemyMax * 1.6); h.enemyHP = h.enemyMax; }, // +60% maximum health
-  Swift: h => { h.eAtk *= 1.15; }            // +15% attack power - minor damage boost
+export const AFFIXES = {
+  Armored: {
+    apply: h => { h.eDef *= 1.4; },
+    color: '#4e79a7',
+    desc: '+40% defense - reduces incoming damage'
+  },
+  Frenzied: {
+    apply: h => { h.eAtk *= 1.35; },
+    color: '#e15759',
+    desc: '+35% attack power - deals more damage'
+  },
+  Regenerating: {
+    apply: h => { h.regen += 0.02; },
+    color: '#59a14f',
+    desc: '+2% health regeneration per tick'
+  },
+  Giant: {
+    apply: h => { h.enemyMax = Math.floor(h.enemyMax * 1.6); h.enemyHP = h.enemyMax; },
+    color: '#b07aa1',
+    desc: '+60% maximum health'
+  },
+  Swift: {
+    apply: h => { h.eAtk *= 1.15; },
+    color: '#f28e2b',
+    desc: '+15% attack power - minor damage boost'
+  }
 };
 
-export const AFFIX_KEYS = Object.keys(AFFIX_DEFS);
+export const AFFIX_KEYS = Object.keys(AFFIXES);
 
-export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
+export function applyRandomAffixes(h, count = 1 + Math.floor(Math.random() * 3)) {
   h.affixes = [];
   const choices = [...AFFIX_KEYS];
   for (let i = 0; i < count; i++) {
@@ -16,7 +36,7 @@ export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
     const idx = Math.floor(Math.random() * choices.length);
     const key = choices.splice(idx, 1)[0];
     h.affixes.push(key);
-    const apply = AFFIX_DEFS[key];
+    const apply = AFFIXES[key]?.apply;
     if (apply) apply(h);
   }
   return h;

--- a/style.css
+++ b/style.css
@@ -1727,3 +1727,7 @@ tr td:last-child{border-top-right-radius:10px; border-bottom-right-radius:10px}
 
 /* Tooltip */
 .hint{border-bottom:1px dotted #475569; cursor:help}
+
+/* Affix display */
+.affix-container{display:flex;flex-wrap:wrap;gap:4px;margin-top:4px}
+.affix-tile{padding:2px 6px;border-radius:4px;border:1px solid transparent;font-size:12px}

--- a/ui/index.js
+++ b/ui/index.js
@@ -20,7 +20,7 @@ import {
   calculatePlayerAttackRate
 } from '../src/game/engine.js';
 import { initializeFight, processAttack } from '../src/game/combat.js';
-import { applyRandomAffixes } from '../src/game/affixes.js';
+import { applyRandomAffixes, AFFIXES } from '../src/game/affixes.js';
 import {
   updateRealmUI,
   updateActivityCultivation,
@@ -2152,13 +2152,37 @@ function startHunt(){
   S.combat.hunt = h; updateHuntUI();
 }
 
+function renderAffixTiles(list){
+  const el = qs('#affixList');
+  el.innerHTML = '';
+  if (!list || !list.length) {
+    el.textContent = 'None';
+    el.classList.add('muted');
+    return;
+  }
+  el.classList.remove('muted');
+  list.forEach(name => {
+    const info = AFFIXES[name] || {};
+    const div = document.createElement('div');
+    div.className = 'affix-tile';
+    div.textContent = name;
+    if (info.color) {
+      div.style.backgroundColor = info.color + '33';
+      div.style.borderColor = info.color;
+      div.style.color = info.color;
+    }
+    if (info.desc) div.title = info.desc;
+    el.appendChild(div);
+  });
+}
+
 function updateHuntUI(){
   const h=S.combat.hunt; const el=qs('#huntStatus');
-  if(!h){ el.textContent='No active hunt.'; setText('enemyHpTxt','—'); setText('ourHpTxt','—'); setFill('enemyFill',0); setFill('ourFill',0); setText('affixList','None'); setText('techStatus',''); return; }
+  if(!h){ el.textContent='No active hunt.'; setText('enemyHpTxt','—'); setText('ourHpTxt','—'); setFill('enemyFill',0); setFill('ourFill',0); renderAffixTiles([]); setText('techStatus',''); return; }
   const b=h.base; el.textContent=`Fighting ${b.name}…`;
   setFill('enemyFill', h.enemyHP/h.enemyMax); setText('enemyHpTxt', `${Math.ceil(h.enemyHP)}/${h.enemyMax}`);
   setFill('ourFill', S.hp/S.hpMax); setText('ourHpTxt', `${Math.ceil(S.hp)}/${S.hpMax}`);
-  setText('affixList', h.affixes.length? h.affixes.join(', '): 'None');
+  renderAffixTiles(h.affixes);
   const cd = S.combat.cds; setText('techStatus', `Slash ${cd.slash||0}s • Guard ${cd.guard||0}s • Burst ${cd.burst||0}s`);
 }
 function resolveHunt(win){


### PR DESCRIPTION
## Summary
- Ensure enemies spawn with at least one random affix
- Display affixes under enemies as colored tiles with tooltips
- Add styles for affix tile layout and coloring
- Remove muted styling when affixes are present so tiles show

## Testing
- `npm test` (fails: Error: no test specified)
- `npx eslint src/game/affixes.js ui/index.js index.html style.css`


------
https://chatgpt.com/codex/tasks/task_e_689fe93a0b648326bf5c5b5061b90b5c