### PR TITLE
Implement enemy affix system with UI tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,7 @@
                 <div class="combat-vs">VS</div>
                 
                 <div class="combatant enemy">
+                  <div class="enemy-affixes" id="enemyAffixes"></div>
                   <div class="combatant-name" id="enemyName">Select an area to begin</div>
                   <div class="health-bar">
                     <div class="health-fill" id="enemyHealthFill"></div>

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -3,6 +3,7 @@ import { calculatePlayerCombatAttack, calculatePlayerAttackRate, getFistBonuses 
 import { initializeFight, processAttack } from './combat.js';
 import { ENEMY_DATA } from '../../data/enemies.js';
 import { setText, setFill, log } from './utils.js';
+import { applyRandomAffixes, AFFIXES } from './affixes.js';
 
 // Adventure zones and enemy data
 export const ADVENTURE_ZONES = [
@@ -158,6 +159,19 @@ export function updateBattleDisplay() {
     setText('enemyHealthText', `${Math.round(enemyHP)}/${Math.round(enemyMaxHP)}`);
     setText('enemyAttack', Math.round(enemy.attack || 0));
     setText('enemyAttackRate', `${(enemy.attackRate || 1.0).toFixed(1)}/s`);
+    const affixEl = document.getElementById('enemyAffixes');
+    if (affixEl) {
+      if (enemy.affixes && enemy.affixes.length) {
+        affixEl.innerHTML = enemy.affixes.map(a => {
+          const info = AFFIXES[a] || {};
+          const color = info.color || '#555';
+          const desc = (info.desc || '').replace(/"/g, '&quot;');
+          return `<div class="affix-tile" style="background:${color}" data-desc="${desc}">${a}</div>`;
+        }).join('');
+      } else {
+        affixEl.innerHTML = '';
+      }
+    }
     const enemyHealthFill = document.getElementById('enemyHealthFill');
     if (enemyHealthFill && enemyMaxHP > 0) {
       const enemyHealthPct = (enemyHP / enemyMaxHP) * 100;
@@ -170,6 +184,8 @@ export function updateBattleDisplay() {
     setText('enemyAttackRate', '--/s');
     const enemyHealthFill = document.getElementById('enemyHealthFill');
     if (enemyHealthFill) enemyHealthFill.style.width = '0%';
+    const affixEl = document.getElementById('enemyAffixes');
+    if (affixEl) affixEl.innerHTML = '';
   }
   const combatLog = document.getElementById('combatLog');
   if (combatLog && S.adventure.combatLog) {
@@ -187,12 +203,18 @@ export function updateAdventureCombat() {
     const now = Date.now();
     if (!S.adventure.lastPlayerAttack) S.adventure.lastPlayerAttack = now;
     if (!S.adventure.lastEnemyAttack) S.adventure.lastEnemyAttack = now;
+    const enemyDef = S.adventure.currentEnemy.defense || 0;
+    const regen = S.adventure.currentEnemy.regen || 0;
+    if (regen) {
+      S.adventure.enemyHP = Math.min(S.adventure.enemyMaxHP, S.adventure.enemyHP + regen * S.adventure.enemyMaxHP);
+    }
     if (now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
-      S.adventure.enemyHP = processAttack(S.adventure.enemyHP, Math.round(playerAttack));
+      const dmg = Math.max(1, Math.round(playerAttack - enemyDef * 0.6));
+      S.adventure.enemyHP = processAttack(S.adventure.enemyHP, dmg);
       S.adventure.lastPlayerAttack = now;
       gainFistXP(Math.round(playerAttack));
       S.adventure.combatLog = S.adventure.combatLog || [];
-      S.adventure.combatLog.push(`You deal ${Math.round(playerAttack)} damage to ${S.adventure.currentEnemy.name}`);
+      S.adventure.combatLog.push(`You deal ${dmg} damage to ${S.adventure.currentEnemy.name}`);
       if (S.adventure.enemyHP <= 0) {
         defeatEnemy();
       }
@@ -260,11 +282,20 @@ export function startAdventureCombat() {
     log(`Enemy data not found for ${enemyType}`, 'bad');
     return;
   }
+  const { enemyHP, enemyMax, atk, def } = initializeFight(enemyData);
+  const h = { enemyHP, enemyMax, eAtk: atk, eDef: def, regen: 0, affixes: [] };
+  applyRandomAffixes(h);
   S.adventure.inCombat = true;
-  S.adventure.currentEnemy = { ...enemyData, type: enemyType };
-  const { enemyHP, enemyMax } = initializeFight(enemyData);
-  S.adventure.enemyHP = enemyHP;
-  S.adventure.enemyMaxHP = enemyMax;
+  S.adventure.currentEnemy = {
+    ...enemyData,
+    type: enemyType,
+    attack: Math.round(h.eAtk),
+    defense: Math.round(h.eDef),
+    regen: h.regen,
+    affixes: h.affixes
+  };
+  S.adventure.enemyHP = h.enemyHP;
+  S.adventure.enemyMaxHP = h.enemyMax;
   S.adventure.playerHP = Math.round(S.hp);
   S.adventure.lastPlayerAttack = 0;
   S.adventure.lastEnemyAttack = 0;

--- a/src/game/affixes.js
+++ b/src/game/affixes.js
@@ -1,12 +1,32 @@
-export const AFFIX_DEFS = {
-  Armored: h => { h.eDef *= 1.4; },          // +40% defense - reduces incoming damage
-  Frenzied: h => { h.eAtk *= 1.35; },        // +35% attack power - deals more damage
-  Regenerating: h => { h.regen += 0.02; },   // +2% health regeneration per tick
-  Giant: h => { h.enemyMax = Math.floor(h.enemyMax * 1.6); h.enemyHP = h.enemyMax; }, // +60% maximum health
-  Swift: h => { h.eAtk *= 1.15; }            // +15% attack power - minor damage boost
+export const AFFIXES = {
+  Armored: {
+    color: '#3b82f6',
+    desc: '+40% defense - reduces incoming damage',
+    apply: h => { h.eDef *= 1.4; }
+  },
+  Frenzied: {
+    color: '#ef4444',
+    desc: '+35% attack power - deals more damage',
+    apply: h => { h.eAtk *= 1.35; }
+  },
+  Regenerating: {
+    color: '#22c55e',
+    desc: '+2% health regeneration per tick',
+    apply: h => { h.regen += 0.02; }
+  },
+  Giant: {
+    color: '#fbbf24',
+    desc: '+60% maximum health',
+    apply: h => { h.enemyMax = Math.floor(h.enemyMax * 1.6); h.enemyHP = h.enemyMax; }
+  },
+  Swift: {
+    color: '#a855f7',
+    desc: '+15% attack power - minor damage boost',
+    apply: h => { h.eAtk *= 1.15; }
+  }
 };
 
-export const AFFIX_KEYS = Object.keys(AFFIX_DEFS);
+export const AFFIX_KEYS = Object.keys(AFFIXES);
 
 export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
   h.affixes = [];
@@ -16,8 +36,8 @@ export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
     const idx = Math.floor(Math.random() * choices.length);
     const key = choices.splice(idx, 1)[0];
     h.affixes.push(key);
-    const apply = AFFIX_DEFS[key];
-    if (apply) apply(h);
+    const affix = AFFIXES[key];
+    if (affix && affix.apply) affix.apply(h);
   }
   return h;
 }

--- a/style.css
+++ b/style.css
@@ -1525,6 +1525,36 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   font-size: 1.1em;
 }
 
+.enemy-affixes {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.affix-tile {
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75em;
+  color: #fff;
+  position: relative;
+  cursor: default;
+}
+
+.affix-tile:hover::after {
+  content: attr(data-desc);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 4px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  z-index: 10;
+}
+
 .health-bar {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- Spawn adventure enemies with randomized affixes that adjust stats
- Render affixes above enemies as colored tiles with hover tooltips
- Factor enemy defense and regeneration into combat calculations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ff78ad3488326a3169f868276a141