### PR TITLE
feat: centralize weapon proficiency tracking

### DIFF
--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,6 +1,7 @@
 import { REALMS } from '../../data/realms.js';
 import { LAWS } from '../../data/laws.js';
 import { S } from './state.js';
+import { getProficiency } from './systems/proficiency.js';
 
 export const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
 
@@ -162,11 +163,11 @@ export function getStatEffects() {
 }
 
 export function getFistBonuses() {
-  const prof = S.proficiencies?.fist || { level: 1 };
-  const levels = Math.max(0, prof.level - 1);
+  const { bonus } = getProficiency('fist', S);
+  const base = 5;
   return {
-    damage: levels * 2,
-    speed: levels * 0.1
+    damage: Math.round(base * (bonus - 1)),
+    speed: bonus - 1
   };
 }
 

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -24,8 +24,16 @@ export const migrations = [
         buildingMult: 1.0
       };
     }
-    if(!save.proficiencies){
-      save.proficiencies = { fist: { level: 1, exp: 0, expMax: 100 } };
+    if(!save.proficiency){
+      if(save.proficiencies){
+        save.proficiency = {};
+        for(const [k,v] of Object.entries(save.proficiencies)){
+          save.proficiency[k] = typeof v === 'object' ? (v.level || 0) : v;
+        }
+        delete save.proficiencies;
+      }else{
+        save.proficiency = {};
+      }
     }
     if(save.alchemy && !Object.prototype.hasOwnProperty.call(save.alchemy, 'unlocked')){
       save.alchemy.unlocked = true;

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -87,10 +87,8 @@ export const defaultState = () => {
     progress: 0,
     maxProgress: 100
   },
-  // Combat Proficiencies
-  proficiencies: {
-    fist: { level: 1, exp: 0, expMax: 100 }
-  },
+  // Combat Proficiency
+  proficiency: {},
   cultivation: {
     talent: 1.0, // Base cultivation talent multiplier
     foundationMult: 1.0, // Foundation gain multiplier from various sources

--- a/src/game/systems/proficiency.js
+++ b/src/game/systems/proficiency.js
@@ -1,0 +1,20 @@
+// Proficiency is stored on the player state as an object: { [weaponKey]: number }
+export function gainProficiency(key, amount, state) {
+  state.proficiency = state.proficiency || {};
+  state.proficiency[key] = (state.proficiency[key] || 0) + amount;
+}
+
+export function getProficiency(key, state) {
+  const value = (state.proficiency && state.proficiency[key]) || 0;
+  // Soft cap: returns multiplier >1 but growth slows down
+  const bonus = 1 + Math.pow(value, 0.6) * 0.01;
+  return { value, bonus };
+}
+
+/* Dev harness
+const state = { proficiency: {} };
+for (let i = 0; i < 100; i++) {
+  gainProficiency('sword', 1, state);
+  console.log(i + 1, getProficiency('sword', state).bonus);
+}
+*/

--- a/src/game/systems/weapons.js
+++ b/src/game/systems/weapons.js
@@ -1,15 +1,5 @@
-import { WEAPON_CONFIG, WEAPON_FLAGS } from '../../data/weapons.js';
+import { WEAPON_FLAGS } from '../../data/weapons.js';
 import { WEAPON_LOOT_TABLE } from '../../data/lootTables.js'; // WEAPONS-INTEGRATION
-
-export function ensureWeaponProficiency(state, weapon) {
-  if (!WEAPON_FLAGS[weapon] || weapon === 'fist') return;
-  state.proficiencies = state.proficiencies || {};
-  if (!state.proficiencies[weapon]) {
-    const base = WEAPON_CONFIG[weapon].proficiencyBase;
-    state.proficiencies[weapon] = { level: 1, exp: 0, expMax: base };
-  }
-  console.log('[weapon]', 'proficiency', weapon, state.proficiencies[weapon]);
-}
 
 export function rollWeaponDrop(weapon, rng = Math.random) {
   if (!WEAPON_FLAGS[weapon]) return false;


### PR DESCRIPTION
## Summary
- add `proficiency` system with gain/get helpers
- track `proficiency` in default state and migrations
- convert adventure and combat logic to use new proficiency helpers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cbcf8d048326b7c375159f14cd9a