### PR TITLE
feat: add basic weapon damage system

### DIFF
--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -1,6 +1,6 @@
 import { S } from './state.js';
 import { calculatePlayerCombatAttack, calculatePlayerAttackRate, getFistBonuses } from './engine.js';
-import { initializeFight, processAttack } from './combat.js';
+import { initializeFight, processAttack, computeWeaponDamage } from './combat.js';
 import { ENEMY_DATA } from '../../data/enemies.js';
 import { setText, setFill, log } from './utils.js';
 import { applyRandomAffixes, AFFIXES } from './affixes.js';
@@ -205,7 +205,6 @@ export function updateBattleDisplay() {
 export function updateAdventureCombat() {
   if (!S.adventure || !S.adventure.inCombat) return;
   if (S.adventure.currentEnemy && S.adventure.enemyHP > 0) {
-    const playerAttack = calculatePlayerCombatAttack();
     const playerAttackRate = calculatePlayerAttackRate();
     const now = Date.now();
     if (!S.adventure.lastPlayerAttack) S.adventure.lastPlayerAttack = now;
@@ -216,15 +215,35 @@ export function updateAdventureCombat() {
       S.adventure.enemyHP = Math.min(S.adventure.enemyMaxHP, S.adventure.enemyHP + regen * S.adventure.enemyMaxHP);
     }
     if (now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
-      const dmg = Math.max(1, Math.round(playerAttack - enemyDef * 0.6));
-      S.adventure.enemyHP = processAttack(S.adventure.enemyHP, dmg);
-      S.adventure.lastPlayerAttack = now;
-      gainProficiency('fist', Math.round(playerAttack), S);
-      updateFistProficiencyDisplay();
-      S.adventure.combatLog = S.adventure.combatLog || [];
-      S.adventure.combatLog.push(`You deal ${dmg} damage to ${S.adventure.currentEnemy.name}`);
-      if (S.adventure.enemyHP <= 0) {
-        defeatEnemy();
+      if (S.flags?.weaponsEnabled) {
+        const result = computeWeaponDamage(S);
+        const attackValue = result.damage;
+        console.log('[weapon]', result.weapon.key, 'roll', result.baseDamage.toFixed(2), 'final', result.damage.toFixed(2));
+        let dmg = Math.max(1, Math.round(attackValue - enemyDef * 0.6));
+        const critChance = S.stats.criticalChance || 0;
+        const isCrit = Math.random() < critChance;
+        if (isCrit) dmg *= 2;
+        S.adventure.enemyHP = processAttack(S.adventure.enemyHP, dmg);
+        S.adventure.lastPlayerAttack = now;
+        gainProficiency(result.weapon.proficiencyKey, isCrit ? 2 : 1, S);
+        if (result.weapon.key === 'fist') updateFistProficiencyDisplay();
+        S.adventure.combatLog = S.adventure.combatLog || [];
+        S.adventure.combatLog.push(`You deal ${dmg} damage to ${S.adventure.currentEnemy.name}`);
+        if (S.adventure.enemyHP <= 0) {
+          defeatEnemy();
+        }
+      } else {
+        const playerAttack = calculatePlayerCombatAttack();
+        const dmg = Math.max(1, Math.round(playerAttack - enemyDef * 0.6));
+        S.adventure.enemyHP = processAttack(S.adventure.enemyHP, dmg);
+        S.adventure.lastPlayerAttack = now;
+        gainProficiency('fist', Math.round(playerAttack), S);
+        updateFistProficiencyDisplay();
+        S.adventure.combatLog = S.adventure.combatLog || [];
+        S.adventure.combatLog.push(`You deal ${dmg} damage to ${S.adventure.currentEnemy.name}`);
+        if (S.adventure.enemyHP <= 0) {
+          defeatEnemy();
+        }
       }
     }
     if (S.adventure.enemyHP > 0 && S.adventure.currentEnemy) {

--- a/src/game/combat.js
+++ b/src/game/combat.js
@@ -1,5 +1,6 @@
 import { initHp } from './helpers.js';
-import { WEAPON_CONFIG, WEAPON_FLAGS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
+import { WEAPONS, WEAPON_CONFIG, WEAPON_FLAGS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
+import { getProficiency } from './systems/proficiency.js';
 
 export function initializeFight(enemy) {
   const { hp: enemyHP, hpMax: enemyMax } = initHp(enemy.hp || 0);
@@ -18,6 +19,22 @@ export function applyWeaponDamage(base, weapon = 'fist') {
 
 export function processAttack(currentHP, damage) {
   return Math.max(0, Math.round(currentHP - damage));
+}
+
+export function getEquippedWeapon(state) {
+  return state.equipment?.mainhand || 'fist';
+}
+
+export function computeWeaponDamage(state) {
+  const weaponKey = getEquippedWeapon(state);
+  const weapon = WEAPONS[weaponKey] || WEAPONS.fist;
+  const baseDamage = (Math.random() * (weapon.base.max - weapon.base.min) + weapon.base.min) * weapon.base.attackRate;
+  const scale = weapon.scales.physique * (state.stats?.physique ?? 0) +
+                weapon.scales.agility * (state.stats?.agility ?? 0) +
+                weapon.scales.mind * (state.stats?.mind ?? 0);
+  const profBonus = getProficiency(weapon.proficiencyKey, state).bonus;
+  const damage = baseDamage * (1 + scale) * profBonus;
+  return { weapon, baseDamage, damage };
 }
 
 // CHANGELOG: Added weapon damage calculation.

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -80,7 +80,7 @@ export function foundationGainPerSec(){
   }
   if (!S.stats) {
     S.stats = {
-      physique: 10, mind: 10, dexterity: 10, comprehension: 10,
+      physique: 10, mind: 10, agility: 10, dexterity: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0
     };
   }
@@ -110,7 +110,7 @@ export function calcAtk(){
   const stageBonus = Math.floor(baseAtk * (S.realm.stage - 1) * 0.08);
   if (!S.stats) {
     S.stats = {
-      physique: 10, mind: 10, dexterity: 10, comprehension: 10,
+      physique: 10, mind: 10, agility: 10, dexterity: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0
     };
   }
@@ -126,7 +126,7 @@ export function calcDef(){
   const stageBonus = Math.floor(baseDef * (S.realm.stage - 1) * 0.08);
   if (!S.stats) {
     S.stats = {
-      physique: 10, mind: 10, dexterity: 10, comprehension: 10,
+      physique: 10, mind: 10, agility: 10, dexterity: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0
     };
   }
@@ -138,7 +138,7 @@ export function calcDef(){
 export function getStatEffects() {
   if (!S.stats) {
     S.stats = {
-      physique: 10, mind: 10, dexterity: 10, comprehension: 10,
+      physique: 10, mind: 10, agility: 10, dexterity: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0
     };
   }

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -29,6 +29,7 @@ export const defaultState = () => {
   stats: {
     physique: 10,        // Physical power, mining yield
     mind: 10,            // Spell power, alchemy, learning speed
+    agility: 10,         // Weapon handling, dodge
     dexterity: 10,       // Attack speed, cooldowns, crafting, adventure speed
     comprehension: 10,   // Foundation gain, learning speed
     criticalChance: 0.05, // Base critical hit chance
@@ -89,6 +90,8 @@ export const defaultState = () => {
   },
   // Combat Proficiency
   proficiency: {},
+  equipment: { mainhand: 'fist' },
+  flags: { weaponsEnabled: false },
   cultivation: {
     talent: 1.0, // Base cultivation talent multiplier
     foundationMult: 1.0, // Foundation gain multiplier from various sources


### PR DESCRIPTION
## Summary
- integrate weapon selection via equipment slot and add feature flag
- compute damage using weapon stats, scaling and proficiency with logging
- track weapon proficiency and default to fists when flag disabled

## Testing
- `npx eslint src/game/combat.js src/game/adventure.js src/game/state.js src/game/engine.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0da37e7808326a6c0ace6beb7d9b3