### PR TITLE
Add retreat timer and keep boss challenge visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,6 @@
                 <button class="btn primary" id="startBattleButton">⚔️ Start Battle</button>
                 <button class="btn success" id="progressButton" disabled>🚀 Progress to Next Stage</button>
                 <button class="btn danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
-                <button class="btn warn" id="retreatButton" style="display: none;">🏃 Retreat</button>
               </div>
             </div>
             

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -516,6 +516,20 @@ export function updateAdventureCombat() {
           S.adventure.inCombat = false;
           S.adventure.combatLog.push('You have been defeated!');
           log('Defeated in combat! Returning to safety...', 'bad');
+          S.qi = 0;
+          if (typeof globalThis.stopActivity === 'function') {
+            globalThis.stopActivity('adventure');
+          } else {
+            S.activities.adventure = false;
+          }
+          const btn = document.getElementById('startBattleButton');
+          if (btn) {
+            btn.textContent = '⚔️ Start Battle';
+            btn.classList.remove('warn');
+            btn.classList.add('primary');
+            btn.disabled = false;
+          }
+          updateActivityAdventure();
         }
       }
     }
@@ -880,9 +894,9 @@ export function updateProgressButton() {
   
   // Show boss button when area is cleared but boss not defeated
   if (bossBtn) {
-    if (isAreaCleared && !isBossDefeated && !S.adventure.inCombat) {
+    if (isAreaCleared && !isBossDefeated) {
       bossBtn.style.display = 'inline-block';
-      bossBtn.disabled = false;
+      bossBtn.disabled = S.adventure.inCombat;
     } else {
       bossBtn.style.display = 'none';
     }


### PR DESCRIPTION
## Summary
- Replace Start Battle button with 5s retreat countdown that costs 25% Qi
- Remove old retreat button and reset battle button after escape or defeat
- Keep Challenge Boss button visible once unlocked and drain all Qi on defeat

## Testing
- ❌ `npm test` (no test specified)
- ⚠️ `npx eslint index.html ui/index.js src/game/adventure.js` (index.html ignored; no errors)


------
https://chatgpt.com/codex/tasks/task_e_68a0ee70f7f88326814fdbd2039052f8