### PR TITLE
feat: add basic inventory and equipment panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -548,6 +548,14 @@
                   </div>
                 </div>
               </div>
+              <div class="equipment-section">
+                <h4>⚔️ Weapons</h4>
+                <div id="weaponInventory"></div>
+              </div>
+              <div class="equipment-section">
+                <h4>🛡️ Armor</h4>
+                <div id="armorInventory"></div>
+              </div>
             </div>
 
             <!-- Proficiencies Tab -->

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -8,6 +8,7 @@ import { applyRandomAffixes, AFFIXES } from './affixes.js';
 import { gainProficiency, getProficiency } from './systems/proficiency.js';
 import { ZONES, getZoneById, getAreaById, isZoneUnlocked, isAreaUnlocked } from '../../data/zones.js'; // MAP-UI-UPDATE
 import { save } from './state.js'; // MAP-UI-UPDATE
+import { renderEquipmentPanel } from '../../ui/panels/equipment.js';
 
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 
@@ -935,6 +936,7 @@ export function setupAdventureTabs() {
       }
       if (tabName === 'equipment') {
         updateFoodSlots();
+        renderEquipmentPanel();
       }
     };
   });

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -45,6 +45,19 @@ export const migrations = [
     if(typeof save.qiRegenMult === 'undefined'){
       save.qiRegenMult = 0;
     }
+  },
+  save => {
+    if(!save.inventory){
+      save.inventory = { weapons: [], armor: [] };
+    }else{
+      if(!Array.isArray(save.inventory.weapons)) save.inventory.weapons = [];
+      if(!Array.isArray(save.inventory.armor)) save.inventory.armor = [];
+    }
+    if(!save.equipment){
+      save.equipment = { mainhand: 'fist', armor: null };
+    }else if(typeof save.equipment.armor === 'undefined'){
+      save.equipment.armor = null;
+    }
   }
 ];
 

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -93,7 +93,8 @@ export const defaultState = () => {
   },
   // Combat Proficiency
   proficiency: {},
-  equipment: { mainhand: 'fist' },
+  equipment: { mainhand: 'fist', armor: null },
+  inventory: { weapons: [], armor: [] },
   flags: { weaponsEnabled: false },
   cultivation: {
     talent: 1.0, // Base cultivation talent multiplier

--- a/style.css
+++ b/style.css
@@ -1879,6 +1879,23 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   font-weight: bold;
 }
 
+.equipment-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 6px 0;
+  border-bottom: 1px solid #444;
+}
+
+.equipment-item:last-child {
+  border-bottom: none;
+}
+
+.equipment-details {
+  flex: 1;
+  margin-right: 8px;
+}
+
 /* Food Inventory */
 .food-inventory {
   display: flex;

--- a/ui/panels/equipment.js
+++ b/ui/panels/equipment.js
@@ -1,0 +1,63 @@
+import { S, save } from '../../src/game/state.js';
+import { WEAPONS } from '../../src/data/weapons.js';
+import { qs, setText } from '../dom.js';
+
+function createWeaponElement(item){
+  const div = document.createElement('div');
+  div.className = 'equipment-item';
+
+  const details = document.createElement('div');
+  details.className = 'equipment-details';
+  const base = item.base ? `${item.base.min}-${item.base.max} (${item.base.attackRate}/s)` : 'N/A';
+  const scales = item.scales ? Object.entries(item.scales).map(([k,v]) => `${k} ${(v*100).toFixed(0)}%`).join(', ') : 'None';
+  const tags = item.tags ? item.tags.join(', ') : 'None';
+  const status = item.statusHooks ? item.statusHooks.join(', ') : 'None';
+  details.innerHTML = `<div><strong>${item.displayName}</strong></div>
+    <div>Base: ${base}</div>
+    <div>Scales: ${scales}</div>
+    <div>Tags: ${tags}</div>
+    <div>Status: ${status}</div>`;
+
+  const btn = document.createElement('button');
+  btn.className = 'btn small';
+  btn.textContent = 'Equip';
+  btn.onclick = () => {
+    S.equipment.mainhand = item.key;
+    save();
+    setText('currentWeapon', item.displayName);
+    renderEquipmentPanel();
+  };
+
+  div.appendChild(details);
+  div.appendChild(btn);
+  return div;
+}
+
+function createArmorElement(item){
+  const div = document.createElement('div');
+  div.className = 'equipment-item';
+  const name = item.displayName || item.key || 'Unknown';
+  const base = item.base ? `Base: ${item.base}` : '';
+  const scales = item.scales ? `Scales: ${Object.entries(item.scales).map(([k,v])=>`${k} ${(v*100).toFixed(0)}%`).join(', ')}` : '';
+  const tags = item.tags ? `Tags: ${item.tags.join(', ')}` : '';
+  const status = item.statusHooks ? `Status: ${item.statusHooks.join(', ')}` : '';
+  div.innerHTML = `<div class="equipment-details"><div><strong>${name}</strong></div>${base?`<div>${base}</div>`:''}${scales?`<div>${scales}</div>`:''}${tags?`<div>${tags}</div>`:''}${status?`<div>${status}</div>`:''}</div>`;
+  return div;
+}
+
+export function renderEquipmentPanel(){
+  const weaponList = qs('#weaponInventory');
+  const armorList = qs('#armorInventory');
+  if(!weaponList || !armorList) return;
+
+  weaponList.innerHTML = '';
+  (S.inventory?.weapons || []).forEach(key => {
+    const item = WEAPONS[key];
+    if(item) weaponList.appendChild(createWeaponElement(item));
+  });
+
+  armorList.innerHTML = '';
+  (S.inventory?.armor || []).forEach(item => {
+    armorList.appendChild(createArmorElement(item));
+  });
+}


### PR DESCRIPTION
## Summary
- track player inventory with weapon and armor slots
- add equipment panel to view and equip weapons
- ensure saves include inventory via migration

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI changes blocked until documentation updated)*

------
https://chatgpt.com/codex/tasks/task_e_68a106b85d3483268518599061c23b38