### PR TITLE
Add combat FX system with reduce-motion support

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -77,24 +77,29 @@ way-of-ascension/
 │   │   ├── status.js
 │   │   ├── statusesByElement.js
 │   │   └── weapons.js
-│   └── game/
-│       ├── combat/
-│       │   ├── attack.js
-│       │   └── statusEngine.js
-│       ├── systems/
-│       │   ├── proficiency.js
-│       │   └── weapons.js
-│       ├── adventure.js
-│       ├── affixes.js
-│       ├── combat.js
-│       ├── engine.js
-│       ├── helpers.js
-│       ├── migrations.js
-│       ├── state.js
-│       └── utils.js
+│   ├── game/
+│   │   ├── combat/
+│   │   │   ├── attack.js
+│   │   │   └── statusEngine.js
+│   │   ├── systems/
+│   │   │   ├── proficiency.js
+│   │   │   └── weapons.js
+│   │   ├── adventure.js
+│   │   ├── affixes.js
+│   │   ├── combat.js
+│   │   ├── engine.js
+│   │   ├── helpers.js
+│   │   ├── migrations.js
+│   │   ├── state.js
+│   │   └── utils.js
+│   └── ui/
+│       └── fx/
+│           └── fx.js
 ├── ui/
 │   ├── dom.js
 │   ├── index.js
+│   ├── panels/
+│   │   └── equipment.js
 │   └── realm.js
 ├── README.md
 ├── eslint.config.mjs
@@ -286,6 +291,17 @@ function updateAll() {
 #### `realm.js` - Realm UI Components
 **Purpose**: Realm-specific UI components and cultivation displays
 **When to modify**: Add new realm UI features, modify cultivation interface
+
+#### `panels/equipment.js` - Equipment Panel
+**Purpose**: Handles rendering and interaction for the player's equipment inventory.
+**When to modify**: Add new equipment slots, change equipment UI behavior.
+
+### UI Effects (`src/ui/fx/`)
+
+#### `fx.js` - SVG Combat Effects
+**Purpose**: Utility functions for spawning and animating combat visual effects using SVG.
+**Key Functions**: `playSlashArc()`, `playThrustLine()`, `playRingShockwave()`, `playBeam()`, `playChakram()`, `playShieldDome()`, `playSparkBurst()`, `setFxTint()`, `setReduceMotion()`.
+**When to modify**: Extend or adjust visual effect primitives.
 
 ### HTML Structure (`index.html`)
 **Purpose**: Main game interface structure

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
       <div class="chip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
       <div class="chip">Stones: <span id="stonesVal">0</span></div>
       <div class="chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span></div>
+      <div class="chip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
     </div>
     <div class="right-actions">
       <button class="btn small ghost" id="saveBtn">💾 Save</button>
@@ -433,7 +434,37 @@
             
             <div class="battle-area" id="battleArea">
               <div class="area-background" id="areaBackground"></div>
-              
+
+              <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
+                <defs>
+                  <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
+                    <feGaussianBlur stdDeviation="2" result="blur" />
+                    <feMerge>
+                      <feMergeNode in="blur" />
+                      <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                  </filter>
+                  <linearGradient id="fx-gradient" x1="0" y1="0" x2="1" y2="1">
+                    <stop offset="0%" stop-color="var(--fx-a, #fff)" />
+                    <stop offset="100%" stop-color="var(--fx-b, #fff)" />
+                  </linearGradient>
+                  <linearGradient id="elem-fire" x1="0" y1="0" x2="1" y2="1">
+                    <stop offset="0%" stop-color="#ff9a00" />
+                    <stop offset="100%" stop-color="#ff0000" />
+                  </linearGradient>
+                  <linearGradient id="elem-ice" x1="0" y1="0" x2="1" y2="1">
+                    <stop offset="0%" stop-color="#00c6ff" />
+                    <stop offset="100%" stop-color="#0072ff" />
+                  </linearGradient>
+                  <symbol id="rune-circle" viewBox="0 0 100 100">
+                    <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="6" />
+                  </symbol>
+                  <symbol id="shockwave-ring" viewBox="0 0 100 100">
+                    <circle cx="50" cy="50" r="45" fill="none" stroke="currentColor" stroke-width="10" />
+                  </symbol>
+                </defs>
+              </svg>
+
               <div class="combat-display">
                 <div class="combatant player">
                   <div class="combatant-name">You</div>

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -1,6 +1,6 @@
 import { S } from './state.js';
 import { calculatePlayerCombatAttack, calculatePlayerAttackRate, getFistBonuses } from './engine.js';
-import { initializeFight, processAttack } from './combat.js';
+import { initializeFight, processAttack, getEquippedWeapon } from './combat.js';
 import { performAttack, decayStunBar } from './combat/attack.js'; // STATUS-REFORM
 import { ENEMY_DATA } from '../../data/enemies.js';
 import { setText, setFill, log } from './utils.js';
@@ -9,6 +9,17 @@ import { gainProficiency, getProficiency } from './systems/proficiency.js';
 import { ZONES, getZoneById, getAreaById, isZoneUnlocked, isAreaUnlocked } from '../../data/zones.js'; // MAP-UI-UPDATE
 import { save } from './state.js'; // MAP-UI-UPDATE
 import { renderEquipmentPanel } from '../../ui/panels/equipment.js';
+import { WEAPONS } from '../../data/weapons.js';
+import {
+  playSlashArc,
+  playThrustLine,
+  playRingShockwave,
+  playBeam,
+  playChakram,
+  playShieldDome,
+  playSparkBurst,
+  setFxTint
+} from '../ui/fx/fx.js';
 
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 
@@ -20,6 +31,25 @@ export function updateFistProficiencyDisplay() {
   setText('fistExpMax', '');
   setFill('fistExpFill', Math.min(value / 100, 1));
   setText('fistBonus', bonus.toFixed(2));
+}
+
+function getCombatPositions() {
+  const svg = document.getElementById('combatFx');
+  const playerEl = document.querySelector('.combatant.player');
+  const enemyEl = document.querySelector('.combatant.enemy');
+  if (!svg || !playerEl || !enemyEl) return null;
+  const rect = svg.getBoundingClientRect();
+  const pRect = playerEl.getBoundingClientRect();
+  const eRect = enemyEl.getBoundingClientRect();
+  const from = {
+    x: ((pRect.right - rect.left) / rect.width) * 100,
+    y: ((pRect.top + pRect.height / 2 - rect.top) / rect.height) * 50,
+  };
+  const to = {
+    x: ((eRect.left - rect.left) / rect.width) * 100,
+    y: ((eRect.top + eRect.height / 2 - rect.top) / rect.height) * 50,
+  };
+  return { svg, from, to };
 }
 
 // Adventure zone and area UI helpers
@@ -485,6 +515,8 @@ export function updateAdventureCombat() {
   if (!S.adventure || !S.adventure.inCombat) return;
   if (S.adventure.currentEnemy && S.adventure.enemyHP > 0) {
     const playerAttackRate = calculatePlayerAttackRate();
+    const weaponKey = getEquippedWeapon(S);
+    const weapon = WEAPONS[weaponKey] || WEAPONS.fist;
     const now = Date.now();
     const deltaTime = (now - (S.adventure.lastCombatTick || now)) / 1000; // STATUS-REFORM
     S.adventure.lastCombatTick = now; // STATUS-REFORM
@@ -509,6 +541,40 @@ export function updateAdventureCombat() {
       const enemyState = { stunBar: S.adventure.enemyStunBar, hpMax: S.adventure.enemyMaxHP }; // STATUS-REFORM
       performAttack(S, enemyState, { attackIsPhysical: true, physDamageDealt: dmg, usingPalm: S.equipment?.mainhand === 'palm' }, S); // STATUS-REFORM
       S.adventure.enemyStunBar = enemyState.stunBar; // STATUS-REFORM
+      const pos = getCombatPositions();
+      if (pos) {
+        setFxTint(pos.svg, weapon.animations?.tint || 'auto');
+        (weapon.animations?.fx || []).forEach(fx => {
+          switch (fx) {
+            case 'slashArc':
+              playSlashArc(pos.svg, pos.from, pos.to);
+              break;
+            case 'pierceThrust':
+            case 'palmStrike':
+              playThrustLine(pos.svg, pos.from, pos.to);
+              break;
+            case 'smash':
+              playRingShockwave(pos.svg, pos.to, 20);
+              break;
+            case 'flurry': {
+              const mid = { x: (pos.from.x + pos.to.x) / 2, y: pos.from.y };
+              playSlashArc(pos.svg, pos.from, mid);
+              setTimeout(() => playSlashArc(pos.svg, mid, pos.to), 80);
+              playSparkBurst(pos.svg, pos.to);
+              break;
+            }
+            case 'spinThrow':
+              playChakram(pos.svg, pos.from, pos.to);
+              break;
+            case 'magicBolt':
+            case 'smite':
+              playBeam(pos.svg, pos.from, pos.to);
+              break;
+            default:
+              break;
+          }
+        });
+      }
       if (S.adventure.enemyHP <= 0) {
         defeatEnemy();
       }
@@ -524,6 +590,13 @@ export function updateAdventureCombat() {
         const playerState = { stunBar: S.adventure.playerStunBar, hpMax: S.hpMax }; // STATUS-REFORM
         performAttack(S.adventure.currentEnemy, playerState, { attackIsPhysical: true, physDamageDealt: enemyDamage }, S); // STATUS-REFORM
         S.adventure.playerStunBar = playerState.stunBar; // STATUS-REFORM
+        if (weaponKey === 'focus') {
+          const pos = getCombatPositions();
+          if (pos) {
+            setFxTint(pos.svg, weapon.animations?.tint || 'auto');
+            playShieldDome(pos.svg, pos.from, 25);
+          }
+        }
         if (S.adventure.playerHP <= 0) {
           S.adventure.inCombat = false;
           S.adventure.combatLog.push('You have been defeated!');

--- a/src/ui/fx/fx.js
+++ b/src/ui/fx/fx.js
@@ -1,0 +1,134 @@
+const NS = 'http://www.w3.org/2000/svg';
+
+let active = 0;
+const MAX_FX = 25;
+let reduceMotion = false;
+try {
+  reduceMotion = localStorage.getItem('reduce-motion') === '1';
+} catch {}
+
+export function setReduceMotion(v) {
+  reduceMotion = v;
+}
+
+function spawn(svg, el, duration = 400) {
+  if (!svg || reduceMotion || active >= MAX_FX) return;
+  active++;
+  svg.appendChild(el);
+  setTimeout(() => {
+    if (el.parentNode === svg) svg.removeChild(el);
+    active--;
+  }, duration);
+}
+
+export function setFxTint(svg, tint = 'auto') {
+  if (!svg) return;
+  const map = {
+    auto: ['#fff', '#ddd'],
+    blue: ['#6cf', '#39f'],
+    red: ['#ff9a00', '#ff0000'],
+    green: ['#9f9', '#0f0'],
+    yellow: ['#fffa8b', '#ffd700'],
+  };
+  const [a, b] = map[tint] || map.auto;
+  svg.style.setProperty('--fx-a', a);
+  svg.style.setProperty('--fx-b', b);
+}
+
+export function playSlashArc(svg, from, to) {
+  const path = document.createElementNS(NS, 'path');
+  const midX = (from.x + to.x) / 2;
+  const midY = Math.min(from.y, to.y) - 10;
+  path.setAttribute('d', `M${from.x},${from.y} Q${midX},${midY} ${to.x},${to.y}`);
+  path.classList.add('fx-stroke');
+  spawn(svg, path, 400);
+}
+
+export function playThrustLine(svg, from, to) {
+  const line = document.createElementNS(NS, 'line');
+  line.setAttribute('x1', from.x);
+  line.setAttribute('y1', from.y);
+  line.setAttribute('x2', to.x);
+  line.setAttribute('y2', to.y);
+  line.classList.add('fx-thrust');
+  spawn(svg, line, 300);
+}
+
+export function playRingShockwave(svg, center, radius = 20) {
+  const circle = document.createElementNS(NS, 'circle');
+  circle.setAttribute('cx', center.x);
+  circle.setAttribute('cy', center.y);
+  circle.setAttribute('r', 0);
+  circle.style.setProperty('--fx-radius', radius);
+  circle.classList.add('fx-ring');
+  spawn(svg, circle, 600);
+}
+
+function playRuneCircle(svg, at) {
+  const g = document.createElementNS(NS, 'g');
+  g.setAttribute('transform', `translate(${at.x - 50},${at.y - 50})`);
+  g.classList.add('fx-rotate');
+  const use = document.createElementNS(NS, 'use');
+  use.setAttribute('href', '#rune-circle');
+  g.appendChild(use);
+  spawn(svg, g, 600);
+}
+
+export function playBeam(svg, from, to) {
+  playRuneCircle(svg, from);
+  const line = document.createElementNS(NS, 'line');
+  line.setAttribute('x1', from.x);
+  line.setAttribute('y1', from.y);
+  line.setAttribute('x2', to.x);
+  line.setAttribute('y2', to.y);
+  line.classList.add('fx-beam');
+  spawn(svg, line, 400);
+}
+
+export function playChakram(svg, from, to) {
+  const g = document.createElementNS(NS, 'g');
+  const use = document.createElementNS(NS, 'use');
+  use.setAttribute('href', '#rune-circle');
+  g.appendChild(use);
+  svg.appendChild(g);
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  let start;
+  const duration = 600;
+  function animate(ts) {
+    if (!start) start = ts;
+    const t = ts - start;
+    const p = t / duration;
+    const progress = p <= 0.5 ? p * 2 : (1 - p) * 2;
+    const x = from.x + dx * progress;
+    const y = from.y + dy * progress;
+    g.setAttribute('transform', `translate(${x - 50},${y - 50})`);
+    if (p < 1) {
+      requestAnimationFrame(animate);
+    } else {
+      svg.removeChild(g);
+    }
+  }
+  if (!reduceMotion && active < MAX_FX) {
+    active++;
+    requestAnimationFrame(animate);
+    setTimeout(() => { active--; }, duration);
+  } else if (svg.contains(g)) {
+    svg.removeChild(g);
+  }
+}
+
+export function playShieldDome(svg, center, radius = 25) {
+  const circle = document.createElementNS(NS, 'circle');
+  circle.setAttribute('cx', center.x);
+  circle.setAttribute('cy', center.y);
+  circle.style.setProperty('--fx-radius', radius);
+  circle.classList.add('fx-shield');
+  spawn(svg, circle, 600);
+}
+
+export function playSparkBurst(svg, center) {
+  playRingShockwave(svg, center, 6);
+}
+
+export { reduceMotion };

--- a/style.css
+++ b/style.css
@@ -3887,3 +3887,19 @@ tr td:last-child{border-top-right-radius:10px; border-bottom-right-radius:10px}
 
 /* Tooltip */
 .hint{border-bottom:1px dotted #475569; cursor:help}
+
+/* Combat FX Layer */
+.battle-area{position:relative;overflow:hidden}
+.fx-layer{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;--fx-a:#fff;--fx-b:#fff}
+.fx-stroke,.fx-thrust,.fx-beam{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-linecap:round}
+.fx-stroke{stroke-width:2;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .35s linear forwards}
+.fx-thrust{stroke-width:2;stroke-dasharray:60;stroke-dashoffset:60;animation:fx-draw .25s linear forwards}
+.fx-beam{stroke-width:3;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .4s linear forwards}
+.fx-ring{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-width:4;animation:fx-ring .5s ease-out forwards}
+.fx-shield{fill:rgba(255,255,255,.15);stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-width:2;animation:fx-shield .6s ease-out forwards}
+.fx-rotate{animation:fx-rotate .6s linear}
+
+@keyframes fx-draw{to{stroke-dashoffset:0;opacity:0}}
+@keyframes fx-ring{to{r:var(--fx-radius);opacity:0}}
+@keyframes fx-shield{from{r:0;opacity:.6}to{r:var(--fx-radius);opacity:0}}
+@keyframes fx-rotate{to{transform:rotate(360deg)}}

--- a/ui/index.js
+++ b/ui/index.js
@@ -43,6 +43,7 @@ import {
   setupAdventureTabs
 } from '../src/game/adventure.js';
 import { ZONES } from '../data/zones.js'; // MAP-UI-UPDATE
+import { setReduceMotion } from '../src/ui/fx/fx.js';
 
 // Global variables
 let selectedActivity = 'cultivation'; // Current selected activity for the sidebar
@@ -461,6 +462,18 @@ function initUI(){
   if (autoHunt) {
     autoHunt.checked = S.auto.hunt;
     autoHunt.addEventListener('change', e => S.auto.hunt = e.target.checked);
+  }
+
+  const reduceMotionToggle = qs('#reduceMotionToggle');
+  if (reduceMotionToggle) {
+    const stored = localStorage.getItem('reduce-motion') === '1';
+    reduceMotionToggle.checked = stored;
+    setReduceMotion(stored);
+    reduceMotionToggle.addEventListener('change', e => {
+      const v = e.target.checked;
+      localStorage.setItem('reduce-motion', v ? '1' : '0');
+      setReduceMotion(v);
+    });
   }
 
   // Save/Load (with safe null checks)


### PR DESCRIPTION
## Summary
- Overlay combat arena with SVG definitions for glow, gradients, and reusable symbols
- Add fx.js helpers (slash arc, thrust, ring, beam, chakram, shield) and bind to weapon types
- Introduce Reduce Motion toggle to cap heavy animations and document new structure

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a1362290cc8326ae4f6dba323d6018