### PR TITLE
feat: double iron sword drop rate

### DIFF
--- a/docs/To-dos/equipment.md
+++ b/docs/To-dos/equipment.md
@@ -20,13 +20,12 @@
   * Example: Sword (Base 10) + Rare (×1.5) + Proficiency (20%) = 18 DPS.
 
 * **Early Weapons & Drop Rates**:
-
-  * **Iron Sword** – base 4–7 damage, balanced scaling. Drops in Peaceful Lands (~5%).
+  * **Iron Sword** – base 4–7 damage, balanced scaling. Drops in Peaceful Lands (~10%) and Forest Edge (~8%).
   * **Bronze Hammer** – base 8–12 damage, slower but stronger. Drops in Forest Edge (~3%) and Meadow Path (~3%).
   * **Elder Wand** – base 2–3 damage, mind‑focused. Drops in Meadow Path (~2%).
 
 * **Zone Loot Tables**:
 
-  * **Peaceful Lands** – `ironSword` 5 %, `herbs` 95 %.
-  * **Forest Edge** – `bronzeHammer` 3 %, `ironSword` 4 %, `ore` 93 %.
+  * **Peaceful Lands** – `ironSword` 10 %, `herbs` 90 %.
+  * **Forest Edge** – `bronzeHammer` 3 %, `ironSword` 8 %, `ore` 89 %.
   * **Meadow Path** – `elderWand` 2 %, `bronzeHammer` 3 %, `herbs` 95 %.

--- a/src/data/lootTables.js
+++ b/src/data/lootTables.js
@@ -1,13 +1,13 @@
 // WEAPONS-INTEGRATION: add weapons to loot tables
 export const LOOT_TABLES = {
   peacefulLands: [
-    { item: 'ironSword', weight: 5 },   // ~5% chance
-    { item: 'herbs', weight: 95 },
+    { item: 'ironSword', weight: 10 },   // ~10% chance
+    { item: 'herbs', weight: 90 },
   ],
   forestEdge: [
     { item: 'bronzeHammer', weight: 3 },
-    { item: 'ironSword', weight: 4 },
-    { item: 'ore', weight: 93 },
+    { item: 'ironSword', weight: 8 },
+    { item: 'ore', weight: 89 },
   ],
   meadowPath: [
     { item: 'elderWand', weight: 2 },


### PR DESCRIPTION
## Summary
- double iron sword loot weights in peacefulLands and forestEdge zones
- document updated drop rates for iron sword

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a207ba2f0c8326af1fb0bb6376dc8f