### PR TITLE
feat: add debug console with instakill control

### DIFF
--- a/docs/To-dos/equipment.md
+++ b/docs/To-dos/equipment.md
@@ -20,13 +20,12 @@
   * Example: Sword (Base 10) + Rare (×1.5) + Proficiency (20%) = 18 DPS.
 
 * **Early Weapons & Drop Rates**:
-
-  * **Iron Sword** – base 4–7 damage, balanced scaling. Drops in Peaceful Lands (~5%).
+  * **Iron Sword** – base 4–7 damage, balanced scaling. Drops in Peaceful Lands (~10%) and Forest Edge (~8%).
   * **Bronze Hammer** – base 8–12 damage, slower but stronger. Drops in Forest Edge (~3%) and Meadow Path (~3%).
   * **Elder Wand** – base 2–3 damage, mind‑focused. Drops in Meadow Path (~2%).
 
 * **Zone Loot Tables**:
 
-  * **Peaceful Lands** – `ironSword` 5 %, `herbs` 95 %.
-  * **Forest Edge** – `bronzeHammer` 3 %, `ironSword` 4 %, `ore` 93 %.
+  * **Peaceful Lands** – `ironSword` 10 %, `herbs` 90 %.
+  * **Forest Edge** – `bronzeHammer` 3 %, `ironSword` 8 %, `ore` 89 %.
   * **Meadow Path** – `elderWand` 2 %, `bronzeHammer` 3 %, `herbs` 95 %.

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
       <div class="chip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
     </div>
     <div class="right-actions">
+      <button class="btn small ghost" id="debugBtn">🐛 Debug</button>
       <button class="btn small ghost" id="saveBtn">💾 Save</button>
       <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
       <button class="btn small ghost" id="importBtn">⬆️ Import</button>
@@ -893,6 +894,15 @@
       </div>
     </div>
   </main>
+
+  <div id="debugConsole" class="debug-console" style="display:none;">
+    <div id="debugOutput"></div>
+    <input id="debugInput" type="text" placeholder="Enter command"/>
+    <div>
+      <button id="debugRunBtn">Run</button>
+      <button id="debugKillBtn">Kill Enemy</button>
+    </div>
+  </div>
 
   <script type="module" src="ui/index.js"></script>
 </body>

--- a/src/data/lootTables.js
+++ b/src/data/lootTables.js
@@ -1,13 +1,13 @@
 // WEAPONS-INTEGRATION: add weapons to loot tables
 export const LOOT_TABLES = {
   peacefulLands: [
-    { item: 'ironSword', weight: 5 },   // ~5% chance
-    { item: 'herbs', weight: 95 },
+    { item: 'ironSword', weight: 10 },   // ~10% chance
+    { item: 'herbs', weight: 90 },
   ],
   forestEdge: [
     { item: 'bronzeHammer', weight: 3 },
-    { item: 'ironSword', weight: 4 },
-    { item: 'ore', weight: 93 },
+    { item: 'ironSword', weight: 8 },
+    { item: 'ore', weight: 89 },
   ],
   meadowPath: [
     { item: 'elderWand', weight: 2 },

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -749,6 +749,15 @@ function defeatEnemy() {
   }
 }
 
+export function instakillCurrentEnemy() {
+  if (S.adventure && S.adventure.currentEnemy) {
+    S.adventure.enemyHP = 0;
+    defeatEnemy();
+  }
+}
+
+
+
 export function generateBossEnemy() {
   if (!S.adventure) return null;
   const currentZone = ZONES[S.adventure.selectedZone || 0];

--- a/style.css
+++ b/style.css
@@ -3915,3 +3915,25 @@ tr:last-child td {
 @keyframes fx-ring{to{r:var(--fx-radius);opacity:0}}
 @keyframes fx-shield{from{r:0;opacity:.6}to{r:var(--fx-radius);opacity:0}}
 @keyframes fx-rotate{to{transform:rotate(360deg)}}
+/* Debug console */
+.debug-console {
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  background: rgba(0,0,0,0.8);
+  color: #fff;
+  padding: 8px;
+  border: 1px solid #555;
+  z-index: 1000;
+  font-family: monospace;
+}
+.debug-console input {
+  width: 100%;
+  margin-bottom: 4px;
+  background: #222;
+  color: #fff;
+  border: 1px solid #555;
+}
+.debug-console button {
+  margin-right: 4px;
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -41,6 +41,7 @@ import {
   retreatFromCombat,
   updateFistProficiencyDisplay,
   updateFoodSlots,
+  instakillCurrentEnemy,
   setupAdventureTabs
 } from '../src/game/adventure.js';
 import { ZONES } from '../data/zones.js'; // MAP-UI-UPDATE
@@ -502,6 +503,31 @@ function initUI(){
       inp.click();
     });
   }
+  const debugBtn = qs('#debugBtn');
+  const debugConsole = qs('#debugConsole');
+  if (debugBtn && debugConsole) {
+    debugBtn.addEventListener('click', () => {
+      debugConsole.style.display = debugConsole.style.display === 'none' ? 'block' : 'none';
+    });
+  }
+
+  const debugRunBtn = qs('#debugRunBtn');
+  if (debugRunBtn) {
+    debugRunBtn.addEventListener('click', () => {
+      const input = qs('#debugInput');
+      const output = qs('#debugOutput');
+      try {
+        const result = eval(input.value);
+        if (output) output.textContent = String(result);
+      } catch (err) {
+        if (output) output.textContent = err.message;
+      }
+    });
+  }
+
+  const debugKillBtn = qs('#debugKillBtn');
+  if (debugKillBtn) debugKillBtn.addEventListener('click', instakillCurrentEnemy);
+
 
   // Safe render calls - only call functions that exist
   if (typeof renderUpgrades === 'function') renderUpgrades();


### PR DESCRIPTION
## Summary
- double iron sword loot weights in peacefulLands and forestEdge zones
- document updated drop rates for iron sword
- add debug console with instant enemy kill control

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a207ba2f0c8326af1fb0bb6376dc8f