### PR TITLE
feat: add character equipment and session loot

### DIFF
--- a/index.html
+++ b/index.html
@@ -488,7 +488,7 @@
             <div class="adventure-tabs">
               <button class="adventure-tab-btn active" data-tab="progress">📊 Progress</button>
               <button class="adventure-tab-btn" data-tab="bestiary">📖 Bestiary</button>
-              <button class="adventure-tab-btn" data-tab="equipment">🎒 Equipment</button>
+              <button class="adventure-tab-btn" data-tab="loot">💰 Loot</button>
               <button class="adventure-tab-btn" data-tab="proficiencies">🥊 Proficiencies</button>
             </div>
             
@@ -512,70 +512,17 @@
                 <div class="muted">Defeat enemies to unlock their information...</div>
               </div>
             </div>
-            
-            <!-- Equipment Tab -->
-            <div id="equipmentTab" class="adventure-tab-content" style="display: none;">
-              <div class="equipment-section">
-                <h4>🍽️ Food Slots</h4>
-                <div class="food-slots">
-                  <div class="food-slot" id="foodSlot1" onclick="useFoodSlot(1)">
-                    <div class="food-icon">🍽️</div>
-                    <div class="food-name">Empty</div>
-                    <div class="food-cooldown" id="foodCooldown1"></div>
-                  </div>
-                  <div class="food-slot" id="foodSlot2" onclick="useFoodSlot(2)">
-                    <div class="food-icon">🍽️</div>
-                    <div class="food-name">Empty</div>
-                    <div class="food-cooldown" id="foodCooldown2"></div>
-                  </div>
-                  <div class="food-slot" id="foodSlot3" onclick="useFoodSlot(3)">
-                    <div class="food-icon">🍽️</div>
-                    <div class="food-name">Empty</div>
-                    <div class="food-cooldown" id="foodCooldown3"></div>
-                  </div>
-                </div>
-                <div class="food-actions">
-                  <button class="btn small" onclick="showActivity('cooking')">🍳 Go to Cooking</button>
-                </div>
-              </div>
-              
-              <div class="equipment-section">
-                <h4>📦 Food Inventory</h4>
-                <div class="food-inventory">
-                  <div class="food-item">
-                    <div class="food-item-icon">🥩</div>
-                    <div class="food-item-info">
-                      <div class="food-item-name">Raw Meat</div>
-                      <div class="food-item-count"><span id="inventoryRawMeatAdventure">0</span></div>
-                      <div class="food-item-desc">Restores 20 HP</div>
-                    </div>
-                    <button class="btn small" onclick="equipFood('meat', 1)">Equip Slot 1</button>
-                    <button class="btn small" onclick="equipFood('meat', 2)">Equip Slot 2</button>
-                    <button class="btn small" onclick="equipFood('meat', 3)">Equip Slot 3</button>
-                  </div>
-                  <div class="food-item">
-                    <div class="food-item-icon">🍖</div>
-                    <div class="food-item-info">
-                      <div class="food-item-name">Cooked Meat</div>
-                      <div class="food-item-count"><span id="inventoryCookedMeatAdventure">0</span></div>
-                      <div class="food-item-desc">Restores 40 HP</div>
-                    </div>
-                    <button class="btn small" onclick="equipFood('cookedMeat', 1)">Equip Slot 1</button>
-                    <button class="btn small" onclick="equipFood('cookedMeat', 2)">Equip Slot 2</button>
-                    <button class="btn small" onclick="equipFood('cookedMeat', 3)">Equip Slot 3</button>
-                  </div>
-                </div>
-              </div>
-              <div class="equipment-section">
-                <h4>⚔️ Weapons</h4>
-                <div id="weaponInventory"></div>
-              </div>
-              <div class="equipment-section">
-                <h4>🛡️ Armor</h4>
-                <div id="armorInventory"></div>
+
+            <!-- Loot Tab -->
+            <div id="lootTab" class="adventure-tab-content" style="display: none;">
+              <div class="muted warn">Items here are not safe. Retreat to claim; death forfeits them.</div>
+              <div class="session-loot-list" id="sessionLootList"></div>
+              <div class="loot-actions" style="text-align:right; margin-top:8px;">
+                <button class="btn small" id="claimLootBtn">Retreat & Claim</button>
+                <button class="btn small warn" id="forfeitLootBtn">Abandon</button>
               </div>
             </div>
-
+            
             <!-- Proficiencies Tab -->
             <div id="proficienciesTab" class="adventure-tab-content" style="display: none;">
               <div class="stat"><span>Fist Level</span><span id="fistLevel">1</span></div>
@@ -597,6 +544,32 @@
             <div class="map-content" id="mapContent">
               <!-- Zone accordions will be populated by JavaScript -->
             </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="activity-character" class="activity-content" style="display:none;">
+        <h2>🧙 Character</h2>
+        <div class="cards character-cards">
+          <div class="card">
+            <h4>Equipment</h4>
+            <div class="equip-slots">
+              <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
+              <div class="equip-slot" id="slot-head"><span class="slot-label">Head</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
+              <div class="equip-slot" id="slot-torso"><span class="slot-label">Torso</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
+              <div class="equip-slot" id="slot-food"><span class="slot-label">Food</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
+            </div>
+          </div>
+          <div class="card">
+            <h4>Inventory</h4>
+            <div id="inventoryFilters" class="filters">
+              <button class="btn small" data-filter="all">All</button>
+              <button class="btn small" data-filter="weapon">Weapons</button>
+              <button class="btn small" data-filter="armor">Armor</button>
+              <button class="btn small" data-filter="food">Food</button>
+              <button class="btn small" data-filter="mat">Materials</button>
+            </div>
+            <div class="inventory-list" id="inventoryList"></div>
           </div>
         </div>
       </section>

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -10,7 +10,7 @@ import { applyRandomAffixes, AFFIXES } from './affixes.js';
 import { gainProficiency, getProficiency } from './systems/proficiency.js';
 import { ZONES, getZoneById, getAreaById, isZoneUnlocked, isAreaUnlocked } from '../../data/zones.js'; // MAP-UI-UPDATE
 import { save } from './state.js'; // MAP-UI-UPDATE
-import { renderEquipmentPanel } from '../ui/panels/EquipmentPanel.js'; // WEAPONS-INTEGRATION
+import { addSessionLoot, claimSessionLoot, forfeitSessionLoot } from './systems/sessionLoot.js'; // EQUIP-CHAR-UI
 import {
   playSlashArc,
   playThrustLine,
@@ -553,7 +553,8 @@ export function updateAdventureCombat() {
       S.adventure.combatLog = S.adventure.combatLog || [];
       S.adventure.combatLog.push(`You deal ${dmg} damage to ${S.adventure.currentEnemy.name}`);
       const enemyState = { stunBar: S.adventure.enemyStunBar, hpMax: S.adventure.enemyMaxHP }; // STATUS-REFORM
-      performAttack(S, enemyState, { attackIsPhysical: true, physDamageDealt: dmg, usingPalm: S.equipment?.mainhand === 'palm' }, S); // STATUS-REFORM
+      const mainKey = typeof S.equipment?.mainhand === 'string' ? S.equipment.mainhand : S.equipment?.mainhand?.key;
+      performAttack(S, enemyState, { attackIsPhysical: true, physDamageDealt: dmg, usingPalm: mainKey === 'palm' }, S); // STATUS-REFORM
       S.adventure.enemyStunBar = enemyState.stunBar; // STATUS-REFORM
       const pos = getCombatPositions();
       if (pos) {
@@ -619,6 +620,8 @@ export function updateAdventureCombat() {
           S.adventure.inCombat = false;
           S.adventure.combatLog.push('You have been defeated!');
           log('Defeated in combat! Returning to safety...', 'bad');
+          forfeitSessionLoot(); // EQUIP-CHAR-UI
+          updateLootTab(); // EQUIP-CHAR-UI
           S.qi = 0;
           if (typeof globalThis.stopActivity === 'function') {
             globalThis.stopActivity('adventure');
@@ -687,31 +690,27 @@ function defeatEnemy() {
   updateBestiaryList();
   S.adventure.combatLog = S.adventure.combatLog || [];
   
+  const zone = ZONES[S.adventure.currentZone];
+  const area = zone?.areas?.[S.adventure.currentArea];
   const lootEntries = enemy.loot ? Object.entries(enemy.loot) : [];
   lootEntries.forEach(([item, qty]) => {
-    S[item] = (S[item] || 0) + qty;
+    addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'mat', qty, source: area?.name });
   });
 
   if (enemy.drops) {
     Object.entries(enemy.drops).forEach(([item, chance]) => {
       if (Math.random() < chance) {
-        S[item] = (S[item] || 0) + 1;
+        addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'mat', qty: 1, source: area?.name });
         lootEntries.push([item, 1]);
       }
     });
   }
 
   if (S.flags?.weaponsEnabled) { // WEAPONS-INTEGRATION
-    const zone = ZONES[S.adventure.currentZone];
-    const area = zone?.areas?.[S.adventure.currentArea];
     const tableKey = toLootTableKey(area?.id || zone?.id);
     const drop = rollLoot(tableKey);
     if (drop) {
-      if (WEAPONS[drop]) {
-        S.inventory.weapons.push({ key: drop, quality: 'common' });
-      } else {
-        S[drop] = (S[drop] || 0) + 1;
-      }
+      addSessionLoot({ key: drop, type: WEAPONS[drop] ? 'weapon' : 'mat', qty: 1, source: area?.name });
       lootEntries.push([drop, 1]);
     }
   }
@@ -742,11 +741,12 @@ function defeatEnemy() {
   const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
   S.adventure.enemyHP = enemyHP;
   S.adventure.enemyMaxHP = enemyMax;
-  
+
   if (S.activities.adventure && S.adventure.playerHP > 0 && !isBoss) {
     startAdventureCombat();
     updateActivityAdventure();
   }
+  updateLootTab(); // EQUIP-CHAR-UI
 }
 
 export function generateBossEnemy() {
@@ -983,6 +983,8 @@ export function retreatFromCombat() {
     S.adventure.enemyMaxHP = enemyMax;
     S.adventure.combatLog = S.adventure.combatLog || [];
     S.adventure.combatLog.push('You retreated from combat.');
+    claimSessionLoot(); // EQUIP-CHAR-UI
+    updateLootTab(); // EQUIP-CHAR-UI
     log('Retreated from combat safely.', 'neutral');
   }
 }
@@ -1042,9 +1044,8 @@ export function setupAdventureTabs() {
         content.classList.add('active');
         content.style.display = 'block';
       }
-      if (tabName === 'equipment') {
-        updateFoodSlots();
-        renderEquipmentPanel();
+      if (tabName === 'loot') {
+        updateLootTab();
       }
     };
   });
@@ -1170,6 +1171,19 @@ function updateBestiaryList() {
   });
 }
 
+export function updateLootTab() {
+  const list = document.getElementById('sessionLootList');
+  if (!list) return;
+  list.innerHTML = '';
+  (S.sessionLoot || []).forEach(item => {
+    const row = document.createElement('div');
+    row.className = 'loot-row';
+    const src = item.source ? ` (${item.source})` : '';
+    row.textContent = `${item.qty || 1} ${item.key}${src}`;
+    list.appendChild(row);
+  });
+}
+
 export function updateActivityAdventure() {
   ensureAdventure();
   if (!S.adventure.bestiary) {
@@ -1192,7 +1206,8 @@ export function updateActivityAdventure() {
   setText('totalKills', S.adventure.totalKills);
   setText('areasCompleted', S.adventure.areasCompleted);
   setText('zonesUnlocked', S.adventure.zonesUnlocked);
-  setText('currentWeapon', WEAPONS[S.equipment?.mainhand]?.displayName || 'Fists'); // WEAPONS-INTEGRATION
+  const weaponKey = typeof S.equipment?.mainhand === 'string' ? S.equipment.mainhand : S.equipment?.mainhand?.key;
+  setText('currentWeapon', WEAPONS[weaponKey]?.displayName || 'Fists'); // EQUIP-CHAR-UI
   const fistBase = 5 + getFistBonuses().damage;
   setText('baseDamage', fistBase);
   setText('physiqueDamageBonus', `+${Math.floor((S.stats.physique - 10) * 2)}`);

--- a/src/game/combat.js
+++ b/src/game/combat.js
@@ -32,7 +32,8 @@ export function processAttack(currentHP, damage, options = {}) {
 export function getEquippedWeapon(state) {
   // WEAPONS-INTEGRATION: respect feature flag and invalid keys
   if (!state.flags?.weaponsEnabled) return 'fist';
-  const key = state.equipment?.mainhand;
+  const eq = state.equipment?.mainhand;
+  const key = typeof eq === 'string' ? eq : eq?.key;
   return WEAPONS[key] ? key : 'fist';
 }
 

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -66,6 +66,33 @@ export const migrations = [
     if (save.activities && typeof save.activities.cooking === 'undefined') {
       save.activities.cooking = false;
     }
+  },
+  save => {
+    if (!Array.isArray(save.inventory)) {
+      const legacy = save.inventory || {};
+      save.inventory = [];
+      if (Array.isArray(legacy.weapons)) {
+        legacy.weapons.forEach(w => {
+          const key = w.key || w;
+          save.inventory.push({ id: Date.now() + Math.random(), key, type: 'weapon' });
+        });
+      }
+      if (Array.isArray(legacy.armor)) {
+        legacy.armor.forEach(a => {
+          const key = a.key || a;
+          save.inventory.push({ id: Date.now() + Math.random(), key, type: 'armor', slot: a.slot });
+        });
+      }
+    }
+    if (!save.equipment || typeof save.equipment !== 'object') {
+      save.equipment = { mainhand: { key: 'fist', type: 'weapon' }, head: null, torso: null, food: null };
+    } else {
+      if (!save.equipment.mainhand) save.equipment.mainhand = { key: 'fist', type: 'weapon' };
+      if (typeof save.equipment.head === 'undefined') save.equipment.head = null;
+      if (typeof save.equipment.torso === 'undefined') save.equipment.torso = null;
+      if (typeof save.equipment.food === 'undefined') save.equipment.food = null;
+    }
+    if (!Array.isArray(save.sessionLoot)) save.sessionLoot = [];
   }
 ];
 

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -98,8 +98,9 @@ export const defaultState = () => {
   },
   // Combat Proficiency
   proficiency: {},
-  equipment: { mainhand: 'fist', armor: null }, // WEAPONS-INTEGRATION
-  inventory: { weapons: [], armor: [] }, // WEAPONS-INTEGRATION
+  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, torso: null, food: null }, // EQUIP-CHAR-UI
+  inventory: [], // EQUIP-CHAR-UI
+  sessionLoot: [], // EQUIP-CHAR-UI
   flags: { weaponsEnabled: false },
   cultivation: {
     talent: 1.0, // Base cultivation talent multiplier

--- a/src/game/systems/inventory.js
+++ b/src/game/systems/inventory.js
@@ -1,0 +1,71 @@
+import { S, save } from '../state.js';
+import { WEAPONS } from '../../data/weapons.js';
+
+// EQUIP-CHAR-UI: basic inventory helpers
+export function addToInventory(item) {
+  S.inventory = S.inventory || [];
+  const id = item.id || Date.now() + Math.random();
+  S.inventory.push({ ...item, id });
+  save?.();
+  return id;
+}
+
+export function removeFromInventory(id) {
+  S.inventory = S.inventory || [];
+  const idx = S.inventory.findIndex(it => it.id === id);
+  if (idx >= 0) {
+    S.inventory.splice(idx, 1);
+    save?.();
+    return true;
+  }
+  return false;
+}
+
+export function canEquip(item) {
+  if (!item) return false;
+  switch (item.type) {
+    case 'weapon':
+      return { slot: 'mainhand' };
+    case 'armor':
+      if (item.slot === 'head' || item.slot === 'torso') return { slot: item.slot };
+      break;
+    case 'food':
+      return { slot: 'food' };
+  }
+  return false;
+}
+
+export function equipItem(item) {
+  const info = canEquip(item);
+  if (!info) return false;
+  const slot = info.slot;
+  // Simple requirement check placeholder
+  const existing = S.equipment[slot];
+  if (existing && existing.key) addToInventory(existing);
+  S.equipment[slot] = { key: item.key, type: item.type, slot: item.slot };
+  removeFromInventory(item.id);
+  console.log('[equip]', 'slot→', slot, 'item→', item.key);
+  if (slot === 'mainhand') {
+    const hud = document.getElementById('currentWeapon');
+    if (hud) hud.textContent = WEAPONS[item.key]?.displayName || item.key;
+    const chip = document.getElementById('weaponName');
+    if (chip) chip.textContent = WEAPONS[item.key]?.displayName || item.key;
+  }
+  save?.();
+  return true;
+}
+
+export function unequip(slot) {
+  const item = S.equipment[slot];
+  if (!item) return;
+  addToInventory(item);
+  S.equipment[slot] = null;
+  console.log('[equip]', 'slot→', slot, 'item→', 'none');
+  if (slot === 'mainhand') {
+    const hud = document.getElementById('currentWeapon');
+    if (hud) hud.textContent = 'Fists';
+    const chip = document.getElementById('weaponName');
+    if (chip) chip.textContent = 'fist';
+  }
+  save?.();
+}

--- a/src/game/systems/sessionLoot.js
+++ b/src/game/systems/sessionLoot.js
@@ -1,0 +1,35 @@
+import { S, save } from '../state.js';
+import { addToInventory } from './inventory.js';
+
+// EQUIP-CHAR-UI: session loot helpers
+export function addSessionLoot(item) {
+  S.sessionLoot = S.sessionLoot || [];
+  const id = item.id || Date.now() + Math.random();
+  S.sessionLoot.push({ ...item, id, qty: item.qty || 1 });
+  console.log('[loot-session] add', item);
+  save?.();
+}
+
+export function claimSessionLoot() {
+  S.sessionLoot = S.sessionLoot || [];
+  const count = S.sessionLoot.length;
+  S.sessionLoot.forEach(item => {
+    if (item.type === 'mat') {
+      S[item.key] = (S[item.key] || 0) + (item.qty || 1);
+    } else {
+      addToInventory(item);
+    }
+  });
+  S.sessionLoot = [];
+  console.log('[loot-session] claim', count);
+  save?.();
+  return count;
+}
+
+export function forfeitSessionLoot() {
+  const count = (S.sessionLoot || []).length;
+  S.sessionLoot = [];
+  console.log('[loot-session] forfeit', count);
+  save?.();
+  return count;
+}

--- a/src/ui/panels/CharacterPanel.js
+++ b/src/ui/panels/CharacterPanel.js
@@ -1,0 +1,96 @@
+import { S } from '../../game/state.js';
+import { WEAPONS } from '../../data/weapons.js';
+import { equipItem, unequip, removeFromInventory } from '../../game/systems/inventory.js';
+
+// EQUIP-CHAR-UI: render character equipment and inventory
+let currentFilter = 'all';
+let slotFilter = null;
+
+export function renderCharacterPanel() {
+  renderEquipment();
+  renderInventory();
+}
+
+function renderEquipment() {
+  const slots = [
+    { key: 'mainhand', label: 'Weapon' },
+    { key: 'head', label: 'Head' },
+    { key: 'torso', label: 'Torso' },
+    { key: 'food', label: 'Food' }
+  ];
+  slots.forEach(s => {
+    const el = document.getElementById(`slot-${s.key}`);
+    if (!el) return;
+    const item = S.equipment[s.key];
+    const name = item?.key ? (WEAPONS[item.key]?.displayName || item.key) : 'Empty';
+    el.querySelector('.slot-name').textContent = name;
+    el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory(); };
+    el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderCharacterPanel(); };
+  });
+}
+
+function createInventoryRow(item) {
+  const row = document.createElement('div');
+  row.className = 'inventory-row';
+  row.innerHTML = `<span class="inv-name">${item.key}</span> <span class="inv-qty">${item.qty || 1}</span>`;
+  const act = document.createElement('div');
+  act.className = 'inv-actions';
+  const equipBtn = document.createElement('button');
+  equipBtn.className = 'btn small';
+  equipBtn.textContent = 'Equip';
+  equipBtn.onclick = () => { equipItem(item); slotFilter = null; renderCharacterPanel(); };
+  act.appendChild(equipBtn);
+  const useBtn = document.createElement('button');
+  useBtn.className = 'btn small';
+  useBtn.textContent = item.type === 'food' ? 'Eat' : 'Use';
+  useBtn.onclick = () => {
+    if (item.type === 'food') {
+      const heal = item.key === 'cookedMeat' ? 40 : 20;
+      S.hp = Math.min(S.hpMax, (S.hp || 0) + heal);
+      item.qty = (item.qty || 1) - 1;
+      if (item.qty <= 0) removeFromInventory(item.id);
+    }
+    renderCharacterPanel();
+  };
+  act.appendChild(useBtn);
+  const scrapBtn = document.createElement('button');
+  scrapBtn.className = 'btn small warn';
+  scrapBtn.textContent = 'Scrap';
+  scrapBtn.onclick = () => { removeFromInventory(item.id); renderCharacterPanel(); };
+  act.appendChild(scrapBtn);
+  const detailsBtn = document.createElement('button');
+  detailsBtn.className = 'btn small';
+  detailsBtn.textContent = 'Details';
+  detailsBtn.onclick = () => alert(item.key);
+  act.appendChild(detailsBtn);
+  row.appendChild(act);
+  if (slotFilter && !canEquipToSlot(item, slotFilter)) row.classList.add('muted');
+  return row;
+}
+
+function canEquipToSlot(item, slot) {
+  switch (slot) {
+    case 'mainhand': return item.type === 'weapon';
+    case 'head':
+    case 'torso': return item.type === 'armor' && item.slot === slot;
+    case 'food': return item.type === 'food';
+  }
+  return false;
+}
+
+function renderInventory() {
+  const list = document.getElementById('inventoryList');
+  if (!list) return;
+  list.innerHTML = '';
+  const items = (S.inventory || []).filter(it => currentFilter === 'all' || it.type === currentFilter);
+  items.forEach(it => list.appendChild(createInventoryRow(it)));
+  const filterBtns = document.querySelectorAll('#inventoryFilters button');
+  filterBtns.forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.filter === currentFilter);
+    btn.onclick = () => { currentFilter = btn.dataset.filter; slotFilter = null; renderInventory(); };
+  });
+}
+
+export function setupCharacterTab() {
+  renderCharacterPanel();
+}


### PR DESCRIPTION
## Summary
- add Character activity with equipment slots and inventory management
- track session loot separately and handle claim/forfeit flow
- rework adventure loot flow and introduce in-run Loot tab

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a20c432a9483269e271140504bf377