### PR TITLE
Fix fist proficiency progression and damage scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - Added Iron Sword, Bronze Hammer, and Elder Wand weapons with elemental tags and proficiency requirements.
 - Peaceful Lands, Forest Edge, and Meadow Path can now drop these weapons at low rates.
+- Fixed fist proficiency progression and damage bonuses.

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -34,11 +34,14 @@ function logEnemyResists(enemy) {
 
 // Fist proficiency handling
 export function updateFistProficiencyDisplay() {
-  const { value, bonus } = getProficiency('fist', S);
-  setText('fistLevel', Math.floor(value));
-  setText('fistExp', value.toFixed(0));
-  setText('fistExpMax', '');
-  setFill('fistExpFill', Math.min(value / 100, 1));
+  const { value } = getProficiency('fist', S);
+  const level = Math.floor(value / 100);
+  const progress = value % 100;
+  setText('fistLevel', level);
+  setText('fistExp', progress.toFixed(0));
+  setText('fistExpMax', '100');
+  setFill('fistExpFill', progress / 100);
+  const bonus = 1 + level * 0.01;
   setText('fistBonus', bonus.toFixed(2));
 }
 
@@ -548,7 +551,7 @@ export function updateAdventureCombat() {
         { target: S.adventure.currentEnemy, element: null }
       );
       S.adventure.lastPlayerAttack = now;
-      gainProficiency(weapon.proficiencyKey, Math.round(playerAttack), S); // WEAPONS-INTEGRATION
+      gainProficiency(weapon.proficiencyKey, 1, S); // WEAPONS-INTEGRATION
       updateFistProficiencyDisplay();
       S.adventure.combatLog = S.adventure.combatLog || [];
       S.adventure.combatLog.push(`You deal ${dmg} damage to ${S.adventure.currentEnemy.name}`);

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -163,11 +163,11 @@ export function getStatEffects() {
 }
 
 export function getFistBonuses() {
-  const { bonus } = getProficiency('fist', S);
-  const base = 5;
+  const { value } = getProficiency('fist', S);
+  const level = Math.floor(value / 100);
   return {
-    damage: Math.round(base * (bonus - 1)),
-    speed: bonus - 1
+    damage: level,
+    speed: level * 0.01,
   };
 }
 


### PR DESCRIPTION
## Summary
- show fist proficiency level and XP progress separately
- award 1 proficiency XP per attack for stable progression
- scale fist damage and attack speed by level

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a20e919288832681049f319e65705f