### PR TITLE
feat: add shared card styling

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -82,9 +82,11 @@ way-of-ascension/
 │   │   │   ├── attack.js
 │   │   │   └── statusEngine.js
 │   │   ├── systems/
+│   │   │   ├── inventory.js
+│   │   │   ├── loot.js
 │   │   │   ├── proficiency.js
-│   │   │   ├── weapons.js
-│   │   │   └── loot.js
+│   │   │   ├── sessionLoot.js
+│   │   │   └── weapons.js
 │   │   ├── adventure.js
 │   │   ├── affixes.js
 │   │   ├── combat.js
@@ -97,6 +99,7 @@ way-of-ascension/
 │       ├── fx/
 │       │   └── fx.js
 │       └── panels/
+│           ├── CharacterPanel.js
 │           └── EquipmentPanel.js
 ├── ui/
 │   ├── components/
@@ -217,6 +220,16 @@ export function runMigrations(save) {
 **Key Functions**: `rollLoot()`, `toLootTableKey()`.
 **When to modify**: Adjust loot algorithms or add new drop behaviors.
 
+#### `systems/inventory.js` - Inventory Management
+**Purpose**: Manages player inventory and equipment slots.
+**Key Functions**: `addToInventory()`, `removeFromInventory()`, `equipItem()`, `unequip()`.
+**When to modify**: Change how items are stored or equipped.
+
+#### `systems/sessionLoot.js` - Session Loot Handling
+**Purpose**: Temporarily stores loot gained during a session until claimed or forfeited.
+**Key Functions**: `addSessionLoot()`, `claimSessionLoot()`, `forfeitSessionLoot()`.
+**When to modify**: Adjust how pending loot is managed between runs.
+
 ### Data Configuration (`data/`)
 
 #### `realms.js` - Cultivation Realms
@@ -329,6 +342,11 @@ function updateAll() {
 **Purpose**: Displays weapons, allowing equip, scrap, and detail actions.
 **Key Functions**: `equipWeapon()`, `renderEquipmentPanel()`.
 **When to modify**: Adjust weapon handling UI or extend equipment features.
+
+#### `panels/CharacterPanel.js` - Character Equipment & Inventory
+**Purpose**: Renders equipped items and the player's inventory with actions to equip, use, or discard items.
+**Key Functions**: `renderCharacterPanel()`, `setupCharacterTab()`.
+**When to modify**: Modify character equipment management or inventory UI behavior.
 
 ### UI Effects (`src/ui/fx/`)
 

--- a/style.css
+++ b/style.css
@@ -71,20 +71,6 @@ h1, h2, h3 {
     letter-spacing: 0.5px;
 }
 
-.cards {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.card {
-  background-color: var(--panel);
-  border-radius: 12px;
-  box-shadow: 0 10px 25px rgba(45, 37, 32, 0.2), 0 4px 8px rgba(45, 37, 32, 0.15);
-  border: 1px solid rgba(45, 37, 32, 0.35);
-  padding: 16px;
-}
-
 /* --- Standardized Progress Bar --- */
 .progress-bar-container {
   margin-bottom: 12px;
@@ -2235,12 +2221,21 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 .content{position:relative; overflow:auto; padding:16px 16px 100px 16px; background: transparent; z-index: 10}
 .content > section{display:none}
 
-/* STYLE-GUIDE-UPDATE: Cards with parchment texture */
+/* Shared card styling */
 .cards{display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:14px}
-.card{background: var(--panel); border:1px solid rgba(45, 37, 32, 0.35); border-radius:var(--radius); padding:14px; box-shadow: 0 10px 25px rgba(45, 37, 32, 0.2), 0 4px 8px rgba(45, 37, 32, 0.15); position: relative;}
-.card::before{content:''; position:absolute; inset:0; background: radial-gradient(circle at 25% 25%, rgba(139, 117, 95, 0.04) 0%, transparent 60%), radial-gradient(circle at 75% 75%, rgba(160, 140, 115, 0.03) 0%, transparent 50%); border-radius:var(--radius); pointer-events:none;}
+.card{
+  position: relative;
+  z-index: 1;
+  background: rgba(255,255,255,.82);
+  border: 1px solid rgba(0,0,0,.08);
+  border-radius: 12px;
+  box-shadow: 0 6px 16px rgba(0,0,0,.06);
+  backdrop-filter: blur(4px);
+  padding: 16px;
+}
 .card h4{margin:0 0 8px; font-size:15px}
 .muted{color:var(--muted); font-size:12px}
+.card, .card * { color: #2b2b2b; }
 
 /* Adventure Layout - MAP-UI-UPDATE */
 .adventure-layout {


### PR DESCRIPTION
## Summary
- Introduce reusable `.card` styling with translucent background, blur, and dark text for readability
- Document inventory, session loot, and character panel modules in project structure docs

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a2158ec9788326b32a4dd0d9e37397