### PR TITLE
Generalize weapon proficiency with HP-based scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## Unreleased
 - Added Iron Sword, Bronze Hammer, and Elder Wand weapons with elemental tags and proficiency requirements.
 - Peaceful Lands, Forest Edge, and Meadow Path can now drop these weapons at low rates.
+- Generalized weapon proficiency to all weapon types with enemy HP–based XP gains (max HP ÷ 30 per attack).
+- Each weapon level now grants +1 damage and +1% attack speed; 100 XP required per level.

--- a/docs/proficiency.md
+++ b/docs/proficiency.md
@@ -1,0 +1,9 @@
+# Weapon Proficiency
+
+Each weapon type tracks its own proficiency. Landing an attack grants experience based on the foe's durability:
+
+- **XP gain** = ceil(enemy max HP / 30) per successful attack.
+- **Level requirement** = 100 XP per proficiency level.
+- **Rewards per level**: +1 flat damage and +1% attack speed with that weapon.
+
+This scaling lets low‑tier enemies like Forest Rabbits award around 2 XP per hit for quick early progression while still rewarding tougher foes.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -66,6 +66,7 @@ way-of-ascension/
 │   │   └── weapons-guidlines.md
 │   ├── ai-verification-protocol.md
 │   ├── cultivation-ui-style.md
+│   ├── proficiency.md
 │   └── project-structure.md
 ├── node_modules/
 ├── scripts/
@@ -117,6 +118,9 @@ way-of-ascension/
 ```
 
 ## File Responsibilities
+
+### Documentation (`docs/`)
+- `proficiency.md` – Weapon proficiency XP formula and level benefits.
 
 ### Core Game Logic (`src/game/`)
 

--- a/index.html
+++ b/index.html
@@ -578,9 +578,10 @@
 
             <!-- Proficiencies Tab -->
             <div id="proficienciesTab" class="adventure-tab-content" style="display: none;">
-              <div class="stat"><span>Fist Level</span><span id="fistLevel">1</span></div>
-              <div class="stat"><span>Experience</span><span id="fistExp">0</span> / <span id="fistExpMax">100</span></div>
-              <div class="activity-progress-bar"><div class="progress-fill" id="fistExpFill"></div></div>
+              <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
+              <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
+              <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>
+              <div class="stat"><span>Bonus</span><span id="weaponBonus">1.00</span></div>
             </div>
           </div>
         </div>

--- a/ui/index.js
+++ b/ui/index.js
@@ -15,7 +15,7 @@ import {
   powerMult,
   calcAtk,
   calcDef,
-  getFistBonuses,
+  getWeaponProficiencyBonuses,
   calculatePlayerCombatAttack,
   calculatePlayerAttackRate
 } from '../src/game/engine.js';
@@ -39,7 +39,7 @@ import {
   startBossCombat,
   progressToNextArea,
   retreatFromCombat,
-  updateFistProficiencyDisplay,
+  updateWeaponProficiencyDisplay,
   updateFoodSlots,
   setupAdventureTabs
 } from '../src/game/adventure.js';


### PR DESCRIPTION
## Summary
- generalize weapon proficiency system for all weapons with per-weapon displays
- grant proficiency XP as `ceil(enemy max HP / 30)` per hit for faster early leveling and +1 damage/+1% speed each level
- document weapon proficiency XP gain and level requirements

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a20e919288832681049f319e65705f