### PR TITLE
Replace thunder icon with iconify hand icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
       
       <!-- Leveling Activities Group -->
       <div class="activity-group">
-        <h4 class="group-title">⚡ Training & Skills</h4>
+        <h4 class="group-title"><iconify-icon icon="ri:hand-line" class="ui-icon" width="20"></iconify-icon> Training & Skills</h4>
         <div class="activities leveling-activities" id="levelingActivities"></div>
       </div>
 

--- a/style.css
+++ b/style.css
@@ -3753,3 +3753,17 @@ tr:last-child td {
   display: none !important;
   background: none !important;
 }
+
+.ui-icon {
+  width: 20px;
+  height: 20px;
+  color: #5a5a5a;
+  vertical-align: -2px;
+}
+.nav-item.active .ui-icon {
+  color: var(--accent, #d8a316);
+}
+.nav-item:hover .ui-icon {
+  transform: translateY(-1px);
+  transition: transform .18s ease;
+}


### PR DESCRIPTION
## Summary
- Render Training & Skills header with `<iconify-icon icon="ri:hand-line">` instead of the old thunder symbol.
- Add global `.ui-icon` styles and active/hover nav state rules in `style.css` for consistent icon behaviour.

## Testing
- ⚠️ `npm test` (no tests specified)
- ✅ `npm run validate`
- ⚠️ `npm start` (manual verification of UI required)


------
https://chatgpt.com/codex/tasks/task_e_68a27d6e2d348326bcf864d24b521ced