### PR TITLE
feat: update lotus icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -3760,3 +3760,19 @@ tr:last-child td {
   display: none !important;
   background: none !important;
 }
+
+.ui-icon {
+  width: 20px;
+  height: 20px;
+  color: #5a5a5a;
+  vertical-align: -2px;
+}
+
+.nav-item.active .ui-icon {
+  color: var(--accent, #d8a316);
+}
+
+.nav-item:hover .ui-icon {
+  transform: translateY(-1px);
+  transition: transform .18s ease;
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -71,7 +71,7 @@ const sidebarActivities = [
   {
     id: 'cultivation',
     label: 'Cultivation',
-    icon: '<iconify-icon icon="mdi:lotus" class="ui-icon"></iconify-icon>',
+    icon: '<iconify-icon icon="twemoji:lotus" class="ui-icon" width="20"></iconify-icon>',
     group: 'leveling',
     levelId: 'cultivationLevel',
     initialLevel: 'Mortal 1',

--- a/ui/realm.js
+++ b/ui/realm.js
@@ -80,7 +80,9 @@ export function updateActivityCultivation() {
 
   const startBtn = document.getElementById('startCultivationActivity');
   if (startBtn) {
-    startBtn.textContent = S.activities.cultivation ? '🛑 Stop Cultivating' : '🧘 Start Cultivating';
+    startBtn.innerHTML = S.activities.cultivation
+      ? '🛑 Stop Cultivating'
+      : '<iconify-icon icon="twemoji:lotus" class="ui-icon" width="20"></iconify-icon> Start Cultivating';
     startBtn.onclick = () => S.activities.cultivation ? stopActivity('cultivation') : startActivity('cultivation');
   }
 


### PR DESCRIPTION
## Summary
- swap cultivation navigation icon to twemoji lotus
- show lotus icon on start cultivating button
- style shared UI icon class and nav icon states

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a27f40946c8326b29081fd58a43517