### PR TITLE
Replace thunder icon with iconify hand icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Way of Ascension — Idle Xianxia</title>
   <link rel="stylesheet" href="style.css" />
-  <script src="https://code.iconify.design/iconify-icon/2.1.0/iconify-icon.min.js"></script>
+  <script src="https://code.iconify.design/iconify-icon/1.0.7/iconify-icon.min.js"></script>
 </head>
 <body>
   <!-- SCENIC-UPDATE: drifting edge fog -->
@@ -74,7 +74,7 @@
       
       <!-- Leveling Activities Group -->
       <div class="activity-group">
-        <h4 class="group-title">⚡ Training & Skills</h4>
+        <h4 class="group-title"><iconify-icon icon="ri:hand-line" class="ui-icon" width="20"></iconify-icon> Training & Skills</h4>
         <div class="activities leveling-activities" id="levelingActivities"></div>
       </div>
 

--- a/style.css
+++ b/style.css
@@ -3753,3 +3753,17 @@ tr:last-child td {
   display: none !important;
   background: none !important;
 }
+
+.ui-icon {
+  width: 20px;
+  height: 20px;
+  color: #5a5a5a;
+  vertical-align: -2px;
+}
+.nav-item.active .ui-icon {
+  color: var(--accent, #d8a316);
+}
+.nav-item:hover .ui-icon {
+  transform: translateY(-1px);
+  transition: transform .18s ease;
+}


### PR DESCRIPTION
## Summary
- Render Training & Skills header with `<iconify-icon icon="ri:hand-line">` instead of the old thunder symbol.
- Add global `.ui-icon` styles and active/hover nav state rules in `style.css` for consistent icon behaviour.
- Fix Iconify script source to a valid CDN version so the hand icon loads correctly.

## Testing
- ❌ `npm test` (no test script)
- ✅ `npm run validate`
- ⚠️ `npm start` (server launched for manual UI check)


------
https://chatgpt.com/codex/tasks/task_e_68a27d6e2d348326bcf864d24b521ced