### PR TITLE
refactor: refresh stage colours

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,22 +12,22 @@
   --muted: #8b7f75; /* softened brown for secondary text */
   --accent: var(--accent-color); /* calming azure accents */
   --accent-2: #7b9ec6; /* soft accent variant */
-  --gold: #b8860b; /* Dark golden rod */
+  --gold: #c7a131; /* harmonised gold */
   --danger: #b32424; /* clearer alert red */
   --shadow: 0 10px 30px rgba(45, 37, 32, 0.25); /* Soft brown shadow */
   --radius: 16px;
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
-  --mortal-primary: #8b4513;
-  --mortal-secondary: #a0522d;
-  --foundation-primary: #228b22;
-  --foundation-secondary: #32cd32;
-  --core-primary: #4169e1;
-  --core-secondary: #6495ed;
-  --nascent-primary: #9932cc;
-  --nascent-secondary: #ba55d3;
-  --spirit-primary: #ff4500;
-  --spirit-secondary: #ff6347;
+  --mortal-primary: #a66c4c; /* lighter saddle brown */
+  --mortal-secondary: #b6825e; /* warm tan */
+  --foundation-primary: #399e34; /* mid jade green */
+  --foundation-secondary: #54b84c; /* light jade */
+  --core-primary: #6b80e5; /* softened royal blue */
+  --core-secondary: #88a0f1; /* pale periwinkle */
+  --nascent-primary: #b366d4; /* lighter violet */
+  --nascent-secondary: #c88ae3;
+  --spirit-primary: #ff7043; /* soft coral instead of harsh orange */
+  --spirit-secondary: #ff906a;
 
   /* Scenic background controls */
   --bg-dim: .97;      /* lower = darker */


### PR DESCRIPTION
## Summary
- lighten realm stage colours to match updated palette
- refine gold accent for harmony

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a2a0def4a483269970ebdda8a065e3