### PR TITLE
feat: update accent glow and button styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,6 +12,8 @@
   --muted: #8b7f75; /* softened brown for secondary text */
   --accent: var(--accent-color); /* calming azure accents */
   --accent-2: #7b9ec6; /* soft accent variant */
+  --accent-glow-light: rgba(87, 132, 186, 0.6);
+  --accent-glow-dark: rgba(87, 132, 186, 0.8);
   --gold: #b8860b; /* Dark golden rod */
   --danger: #b32424; /* clearer alert red */
   --shadow: 0 10px 30px rgba(45, 37, 32, 0.25); /* Soft brown shadow */
@@ -2224,11 +2226,33 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 }
 .btn:hover{
   background: linear-gradient(180deg, rgba(250, 245, 225, 0.8), rgba(225, 215, 195, 0.8));
-  transform:translateY(-1px); 
+  transform:translateY(-1px);
   box-shadow: 0 4px 8px rgba(0,0,0,0.15), inset 0 1px 1px rgba(255,255,255,0.6);
 }
-.btn.primary{background:linear-gradient(90deg,var(--accent-2),var(--accent)); border-color:transparent; color: #f8f5f0;}
-.btn.warn{background:#ebe0c8; border-color:var(--danger); color:var(--danger);}
+.btn.primary,
+.btn.btn-accent,
+.btn.start-cultivating{
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+  color: #f8f5f0;
+}
+.btn.primary:hover,
+.btn.btn-accent:hover,
+.btn.start-cultivating:hover{
+  background: var(--accent-color);
+  border-color: var(--accent-color);
+  filter: brightness(0.93);
+}
+.btn.warn{
+  background: var(--danger);
+  border-color: var(--danger);
+  color: #f8f5f0;
+}
+.btn.warn:hover{
+  background: var(--danger);
+  border-color: var(--danger);
+  filter: brightness(1.07);
+}
 .btn.ghost{background:transparent; box-shadow: none;}
 .btn.small{padding:4px 8px; font-size:12px}
 .grid{display:grid; gap:12px}


### PR DESCRIPTION
## Summary
- add `--accent-glow-light` and `--accent-glow-dark` variables for progress bar fills
- style primary buttons with accent color and darker hover; danger buttons use `--danger` with lighter hover

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a2a12ce3c483269214193cb1457a9c