### PR TITLE
feat: add ability bar and qi display to adventure

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,6 +439,10 @@
                     <div class="health-fill" id="playerHealthFill"></div>
                     <span class="health-text" id="playerHealthText">100/100</span>
                   </div>
+                  <div class="qi-bar">
+                    <div class="qi-fill" id="playerQiFill"></div>
+                    <span class="qi-text" id="playerQiText">0/0</span>
+                  </div>
                   <div class="combat-stats">
                     <span>ATK: <span id="playerAttack">10</span></span>
                     <span>Rate: <span id="playerAttackRate">1.0/s</span></span>
@@ -454,21 +458,31 @@
                     <div class="health-fill" id="enemyHealthFill"></div>
                     <span class="health-text" id="enemyHealthText">--/--</span>
                   </div>
+                  <div class="qi-bar">
+                    <div class="qi-fill" id="enemyQiFill"></div>
+                    <span class="qi-text" id="enemyQiText">--</span>
+                  </div>
                   <div class="combat-stats">
                     <span>ATK: <span id="enemyAttack">--</span></span>
                     <span>Rate: <span id="enemyAttackRate">--/s</span></span>
                   </div>
                 </div>
               </div>
-              
+
               <!-- Combat Actions -->
               <div class="combat-controls">
-                <button class="btn primary" id="startBattleButton">⚔️ Start Battle</button>
-                <button class="btn success" id="progressButton" disabled>🚀 Progress to Next Stage</button>
+                <button class="btn primary" id="startBattleButton">Start Battle</button>
+                <button class="btn success" id="progressButton" disabled>Clear Area</button>
                 <button class="btn danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
               </div>
+
+              <!-- Ability Bar -->
+              <div class="ability-bar-container">
+                <span class="ability-label">Ability Bar:</span>
+                <div class="ability-bar" id="abilityBar"></div>
+              </div>
             </div>
-            
+
             <!-- Combat Log -->
             <div class="combat-log" id="combatLog">
               <div class="log-entry">Select an area to begin your adventure...</div>

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -94,7 +94,15 @@ export const defaultState = () => {
     combatLog: ['Welcome to Peaceful Lands! Select an area to begin your adventure...'],
     location: 'Village Outskirts',
     progress: 0,
-    maxProgress: 100
+    maxProgress: 100,
+    abilities: [
+      { key: 'power_slash', name: 'Power Slash' },
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
   },
   // Combat Proficiency
   proficiency: {},

--- a/style.css
+++ b/style.css
@@ -2982,12 +2982,69 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
 }
 
+.qi-bar {
+  position: relative;
+  width: 100%;
+  height: 16px;
+  background: rgba(37, 99, 235, 0.3);
+  border-radius: 8px;
+  margin: 4px 0;
+  overflow: hidden;
+}
+
+.qi-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #3b82f6, #60a5fa);
+  border-radius: 8px;
+  transition: width 0.3s ease;
+  width: 0;
+}
+
+.qi-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-weight: bold;
+  font-size: 0.75em;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+}
+
 .combat-stats {
   display: flex;
   justify-content: space-around;
   font-size: 0.9em;
   color: #9ca3af;
   margin-top: 8px;
+}
+
+.ability-bar-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.ability-bar {
+  display: flex;
+  gap: 8px;
+}
+
+.ability-slot {
+  background: rgba(31, 41, 55, 0.8);
+  padding: 4px 8px;
+  border-radius: 4px;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.9em;
+}
+
+.ability-slot .slot-index {
+  font-weight: bold;
+  color: #9ca3af;
 }
 
 .combat-vs {


### PR DESCRIPTION
## Summary
- add qi resource bars for player and enemy in battle arena
- introduce placeholder ability bar with six slots
- seed adventure state with Power Slash ability slot

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a2a5aba6e48326aa284d2790ee7d86