### PR TITLE
Use panel color for log backgrounds

### DIFF
--- a/style.css
+++ b/style.css
@@ -3106,7 +3106,7 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 .combat-log {
   max-height: 120px;
   overflow-y: auto;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--panel);
   border-radius: 6px;
   padding: 12px;
   margin: 12px 0;
@@ -3355,12 +3355,12 @@ tr:last-child td {
   left:280px; 
   right:0; 
   bottom:0; 
-  height:80px; 
+  height:80px;
   border-top:1px solid var(--accent);
-  background: var(--parchment);
-  overflow:auto; 
-  padding:8px 12px; 
-  font-size:12px; 
+  background: var(--panel);
+  overflow:auto;
+  padding:8px 12px;
+  font-size:12px;
   z-index:10;
   box-shadow: 0 -2px 10px rgba(58, 45, 28, 0.1);
 }


### PR DESCRIPTION
## Summary
- Match combat log background to card panels
- Match footer log background to card panels

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a325de98148326b5233ebe0b98bfe4