### PR TITLE
refactor: remove dom helper re-export

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -108,7 +108,6 @@ way-of-ascension/
 ├── ui/
 │   ├── components/
 │   │   └── progressBar.js
-│   ├── dom.js
 │   ├── index.js
 │   └── realm.js
 ├── README.md

--- a/src/game/utils.js
+++ b/src/game/utils.js
@@ -1,5 +1,7 @@
 import { clamp } from './engine.js';
 
+export const qs = sel => document.querySelector(sel);
+
 export function setText(id, v) {
   const el = document.getElementById(id);
   if (el) el.textContent = v;

--- a/ui/dom.js
+++ b/ui/dom.js
@@ -1,4 +1,0 @@
-export const qs = sel => document.querySelector(sel);
-
-export { setText, setFill, log } from '../src/game/utils.js';
-

--- a/ui/index.js
+++ b/ui/index.js
@@ -29,7 +29,7 @@ import {
   initRealmUI,
   getRealmName
 } from './realm.js';
-import { qs, setText, setFill, log } from './dom.js';
+import { qs, setText, setFill, log } from '../src/game/utils.js';
 import { createProgressBar, updateProgressBar } from './components/progressBar.js';
 import { renderSidebarActivities } from '../src/ui/sidebar.js';
 import { initializeWeaponChip, updateWeaponChip } from '../src/ui/weaponChip.js';

--- a/ui/realm.js
+++ b/ui/realm.js
@@ -11,7 +11,7 @@ import {
   foundationGainPerSec,
   powerMult
 } from '../src/game/engine.js';
-import { qs, setText, log } from './dom.js';
+import { qs, setText, log } from '../src/game/utils.js';
 
 export function getRealmName(tier) {
   return REALMS[tier].name;


### PR DESCRIPTION
## Summary
- remove `ui/dom.js` and expose `qs` via `src/game/utils.js`
- update UI modules to import DOM helpers directly from utils
- tidy project structure docs to drop old helper reference

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`
- `npm start` (terminated after smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68a33007f38083268c1ff0a745fa65a1