### PR TITLE
Track proficiency per weapon type

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -51,6 +51,7 @@ way-of-ascension/
 │   └── zones.js
 ├── docs/
 │   ├── To-dos/
+│   │   ├── Balance.md
 │   │   ├── affixes-expansion.md
 │   │   ├── animations-per-weapon.md
 │   │   ├── boss-specific-affixes.md

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -1,3 +1,5 @@
+import { WEAPONS } from '../data/weapons.js';
+
 export const migrations = [
   save => {
     if(!save.laws){
@@ -95,6 +97,17 @@ export const migrations = [
       if (typeof save.equipment.food === 'undefined') save.equipment.food = null;
     }
     if (!Array.isArray(save.sessionLoot)) save.sessionLoot = [];
+  },
+  save => {
+    if (save.proficiency && typeof save.proficiency === 'object') {
+      const converted = {};
+      for (const [key, val] of Object.entries(save.proficiency)) {
+        const weapon = WEAPONS[key];
+        const typeKey = weapon?.proficiencyKey || key;
+        converted[typeKey] = (converted[typeKey] || 0) + val;
+      }
+      save.proficiency = converted;
+    }
   }
 ];
 

--- a/src/game/systems/proficiency.js
+++ b/src/game/systems/proficiency.js
@@ -1,11 +1,20 @@
-// Proficiency is stored on the player state as an object: { [weaponKey]: number }
+import { WEAPONS } from '../../data/weapons.js';
+
+// Proficiency is stored on the player state as an object: { [weaponType]: number }
+function resolveKey(key) {
+  const weapon = WEAPONS[key];
+  return weapon?.proficiencyKey || key;
+}
+
 export function gainProficiency(key, amount, state) {
   state.proficiency = state.proficiency || {};
-  state.proficiency[key] = (state.proficiency[key] || 0) + amount;
+  const typeKey = resolveKey(key);
+  state.proficiency[typeKey] = (state.proficiency[typeKey] || 0) + amount;
 }
 
 export function getProficiency(key, state) {
-  const value = (state.proficiency && state.proficiency[key]) || 0;
+  const typeKey = resolveKey(key);
+  const value = (state.proficiency && state.proficiency[typeKey]) || 0;
   // Soft cap: returns multiplier >1 but growth slows down
   const bonus = 1 + Math.pow(value, 0.6) * 0.01;
   return { value, bonus };


### PR DESCRIPTION
## Summary
- resolve proficiency tracking to use weapon type keys
- migrate existing saves from per-weapon to per-type proficiency
- document new Balance to-do for validation

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3a2b0ce44832689f91d12027a7f66