### PR TITLE
Track proficiency per weapon type

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -51,6 +51,7 @@ way-of-ascension/
 │   └── zones.js
 ├── docs/
 │   ├── To-dos/
+│   │   ├── Balance.md
 │   │   ├── affixes-expansion.md
 │   │   ├── animations-per-weapon.md
 │   │   ├── boss-specific-affixes.md

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -3,6 +3,7 @@ import { calculatePlayerCombatAttack, calculatePlayerAttackRate, getWeaponProfic
 import { initializeFight, processAttack, getEquippedWeapon } from './combat.js';
 import { rollLoot, toLootTableKey } from './systems/loot.js'; // WEAPONS-INTEGRATION
 import { WEAPONS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
+import { WEAPON_TYPES } from '../data/weaponTypes.js';
 import { performAttack, decayStunBar } from './combat/attack.js'; // STATUS-REFORM
 import { ENEMY_DATA } from '../../data/enemies.js';
 import { setText, setFill, log } from './utils.js';
@@ -39,7 +40,11 @@ export function updateWeaponProficiencyDisplay() {
   const { value } = getProficiency(weapon.proficiencyKey, S);
   const level = Math.floor(value / 100);
   const progress = value % 100;
-  setText('weaponLabel', `${weapon.displayName} Level`);
+  const type = WEAPON_TYPES[weapon.proficiencyKey];
+  let label = type?.displayName || weapon.proficiencyKey;
+  // crude pluralization: append 's' if not already plural
+  if (!label.endsWith('s')) label += 's';
+  setText('weaponLabel', `${label} Level`);
   setText('weaponLevel', level);
   setText('weaponExp', progress.toFixed(0));
   setText('weaponExpMax', '100');

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -1,3 +1,5 @@
+import { WEAPONS } from '../data/weapons.js';
+
 export const migrations = [
   save => {
     if(!save.laws){
@@ -95,6 +97,17 @@ export const migrations = [
       if (typeof save.equipment.food === 'undefined') save.equipment.food = null;
     }
     if (!Array.isArray(save.sessionLoot)) save.sessionLoot = [];
+  },
+  save => {
+    if (save.proficiency && typeof save.proficiency === 'object') {
+      const converted = {};
+      for (const [key, val] of Object.entries(save.proficiency)) {
+        const weapon = WEAPONS[key];
+        const typeKey = weapon?.proficiencyKey || key;
+        converted[typeKey] = (converted[typeKey] || 0) + val;
+      }
+      save.proficiency = converted;
+    }
   }
 ];
 

--- a/src/game/systems/proficiency.js
+++ b/src/game/systems/proficiency.js
@@ -1,11 +1,20 @@
-// Proficiency is stored on the player state as an object: { [weaponKey]: number }
+import { WEAPONS } from '../../data/weapons.js';
+
+// Proficiency is stored on the player state as an object: { [weaponType]: number }
+function resolveKey(key) {
+  const weapon = WEAPONS[key];
+  return weapon?.proficiencyKey || key;
+}
+
 export function gainProficiency(key, amount, state) {
   state.proficiency = state.proficiency || {};
-  state.proficiency[key] = (state.proficiency[key] || 0) + amount;
+  const typeKey = resolveKey(key);
+  state.proficiency[typeKey] = (state.proficiency[typeKey] || 0) + amount;
 }
 
 export function getProficiency(key, state) {
-  const value = (state.proficiency && state.proficiency[key]) || 0;
+  const typeKey = resolveKey(key);
+  const value = (state.proficiency && state.proficiency[typeKey]) || 0;
   // Soft cap: returns multiplier >1 but growth slows down
   const bonus = 1 + Math.pow(value, 0.6) * 0.01;
   return { value, bonus };


### PR DESCRIPTION
## Summary
- resolve proficiency tracking to use weapon type keys
- migrate existing saves from per-weapon to per-type proficiency
- document new Balance to-do for validation
- show weapon proficiency progress by type instead of specific weapon names

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate`
- manual check: mapped bronze hammer to hammer proficiency


------
https://chatgpt.com/codex/tasks/task_e_68a3a2b0ce44832689f91d12027a7f66