### PR TITLE
Refine header yin-yang orb sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1526,6 +1526,15 @@ header{
   clip-path: circle(50% at 50% 50%);
 }
 
+/* Header Yin-Yang: remove white backing and match green orb size */
+#qiOrb > svg {
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+}
+
 /* Make the Yin-Yang drawing fill the white circle exactly */
 .qi-orb .yin-yang-svg {
   display: block;


### PR DESCRIPTION
## Summary
- Remove white background behind header yin-yang icon
- Expand yin-yang SVG to fill orb so green backing matches symbol

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3b615a930832696caba51bb5c19c0