### PR TITLE
Display weapon icons in gear and proficiency views

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -63,6 +63,7 @@ way-of-ascension/
 │   │   ├── equipment.md
 │   │   ├── manual-system.md
 │   │   ├── manuals.md
+│   │   ├── Palms-and-fists.md
 │   │   ├── status-effects.md
 │   │   ├── ui-improvements.md
 │   │   └── weapons-guidlines.md
@@ -83,6 +84,7 @@ way-of-ascension/
 │   │   ├── statusesByElement.js
 │   │   ├── weapons.js
 │   │   ├── weaponTypes.js
+│   │   ├── weaponIcons.js
 │   │   ├── materials.stub.js
 │   │   ├── zones.js
 │   │   └── abilities.js
@@ -135,6 +137,7 @@ way-of-ascension/
 - `proficiency.md` – Weapon proficiency XP formula and level benefits.
 - `docs/To-dos/ui-improvements.md` – Planned UI improvements and enhancements.
 - `docs/To-dos/Balance.md` – Balance system notes and parameter guidelines.
+- `docs/To-dos/Palms-and-fists.md` – Concept notes for palm and fist weapon styles.
 - `parameters-and-formulas.md` – Base stats, cultivation stats, activity starting stats, damage formulas, and skill XP scaling reference.
 - `To-dos/Balance.md` – Notes on planned balance adjustments.
 
@@ -303,6 +306,10 @@ export const ZONES = [
 ];
 ```
 **When to modify**: Add new zones/areas, modify unlock requirements, adjust loot tables
+
+#### `weaponIcons.js` - Weapon Type Icons
+**Purpose**: Maps weapon type keys to Iconify icon names for UI display.
+**When to modify**: Add or update icons when introducing new weapon types.
 
 ### User Interface (`ui/`)
 

--- a/src/data/weaponIcons.js
+++ b/src/data/weaponIcons.js
@@ -1,0 +1,12 @@
+export const WEAPON_ICONS = {
+  sword: 'ph:sword-light',
+  hammer: 'akar-icons:hammer',
+  spear: 'mdi:spear',
+  fist: 'game-icons:fist',
+  nunchaku: 'game-icons:nunchaku',
+  palm: 'ph:hand-palm-thin',
+  wand: 'fluent:wand-16-regular',
+  focus: 'ri:focus-line',
+  chakram: 'game-icons:chakram',
+  scepter: 'game-icons:winged-scepter',
+};

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -4,6 +4,7 @@ import { initializeFight, processAttack, getEquippedWeapon } from './combat.js';
 import { rollLoot, toLootTableKey } from './systems/loot.js'; // WEAPONS-INTEGRATION
 import { WEAPONS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
 import { WEAPON_TYPES } from '../data/weaponTypes.js';
+import { WEAPON_ICONS } from '../data/weaponIcons.js';
 import { performAttack, decayStunBar } from './combat/attack.js'; // STATUS-REFORM
 import { ENEMY_DATA } from '../../data/enemies.js';
 import { setText, setFill, log } from './utils.js';
@@ -44,7 +45,12 @@ export function updateWeaponProficiencyDisplay() {
   let label = type?.displayName || weapon.proficiencyKey;
   // crude pluralization: append 's' if not already plural
   if (!label.endsWith('s')) label += 's';
-  setText('weaponLabel', `${label} Level`);
+  const icon = WEAPON_ICONS[weapon.proficiencyKey];
+  const labelEl = document.getElementById('weaponLabel');
+  if (labelEl) {
+    const text = `${label} Level`;
+    labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
+  }
   setText('weaponLevel', level);
   setText('weaponExp', progress.toFixed(0));
   setText('weaponExpMax', '100');

--- a/src/ui/panels/CharacterPanel.js
+++ b/src/ui/panels/CharacterPanel.js
@@ -1,5 +1,6 @@
 import { S, save } from '../../game/state.js';
 import { WEAPONS } from '../../data/weapons.js';
+import { WEAPON_ICONS } from '../../data/weaponIcons.js';
 import { equipItem, unequip, removeFromInventory } from '../../game/systems/inventory.js';
 
 // Consolidated equipment/inventory panel
@@ -23,7 +24,10 @@ function renderEquipment() {
     if (!el) return;
     const item = S.equipment[s.key];
     const name = item?.key ? (WEAPONS[item.key]?.displayName || item.key) : 'Empty';
-    el.querySelector('.slot-name').textContent = name;
+    const iconKey = item?.key ? WEAPONS[item.key]?.proficiencyKey : null;
+    const icon = iconKey ? WEAPON_ICONS[iconKey] : null;
+    const nameHtml = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${name}` : name;
+    el.querySelector('.slot-name').innerHTML = nameHtml;
     el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory(); };
     el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
   });
@@ -55,7 +59,10 @@ function showDetails(item) {
 function createInventoryRow(item) {
   const row = document.createElement('div');
   row.className = 'inventory-row';
-  row.innerHTML = `<span class="inv-name">${item.key}</span> <span class="inv-qty">${item.qty || 1}</span>`;
+  const iconKey = item.type === 'weapon' ? WEAPONS[item.key]?.proficiencyKey : null;
+  const icon = iconKey ? WEAPON_ICONS[iconKey] : null;
+  const nameHtml = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${item.key}` : item.key;
+  row.innerHTML = `<span class="inv-name">${nameHtml}</span> <span class="inv-qty">${item.qty || 1}</span>`;
   const act = document.createElement('div');
   act.className = 'inv-actions';
   if (['weapon', 'armor', 'food'].includes(item.type)) {

--- a/style.css
+++ b/style.css
@@ -4010,6 +4010,13 @@ tr:last-child td {
   transition: transform .18s ease;
 }
 
+.weapon-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+  vertical-align: -2px;
+}
+
 /* Ensure black text for the breakthrough button */
 #breakthroughBtnActivity {
   color: #000 !important;


### PR DESCRIPTION
## Summary
- map weapon types to Iconify icons
- show weapon icons in equipment slots, inventory, and proficiency label
- style weapon icons for consistent sizing

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3bd57fa708326b1e98f9e06a460fe