### PR TITLE
Use teal outline and mint glow for lotus silhouette

### DIFF
--- a/style.css
+++ b/style.css
@@ -739,16 +739,15 @@ html.reduce-motion .rune-ring .orbit {
 }
 
 .lotus-silhouette .silhouette-svg path {
+  --sil-stroke: #0f766e; /* teal-700 outline */
+  --sil-glow: #5eead4;   /* mint glow */
   fill: none;
-  stroke: rgba(31, 41, 55, 0.85);
-  stroke-width: 4;
+  stroke: var(--sil-stroke);
+  stroke-width: 3.2px;
   stroke-linejoin: round;
   stroke-linecap: round;
-  /* Strong light-blue outer glow (not soft) */
-  filter:
-    drop-shadow(0 0 2px rgba(59, 130, 246, 0.9))
-    drop-shadow(0 0 6px rgba(96, 165, 250, 0.85))
-    drop-shadow(0 0 10px rgba(147, 197, 253, 0.75));
+  /* Soft mint inner glow */
+  filter: drop-shadow(0 0 10px color-mix(in oklab, var(--sil-glow) 55%, transparent));
 }
 
 @keyframes liquidShimmer {


### PR DESCRIPTION
## Summary
- Align lotus silhouette outline with teal fill using a darker teal stroke and soft mint glow

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3d5ef22348326af64b2c0c99e07e0