### PR TITLE
Add armor stat and physical damage mitigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -586,6 +586,7 @@
               <div class="equip-slot" id="slot-torso"><span class="slot-label">Torso</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
               <div class="equip-slot" id="slot-food"><span class="slot-label">Food</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
             </div>
+            <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%">🛡 <span id="armorVal">0</span></div>
           </div>
           <div class="card">
             <h4>Inventory</h4>
@@ -834,6 +835,7 @@
             <h4>Combat Stats</h4>
             <div class="stat"><span>Your ATK</span><span id="atkVal2">5</span></div>
             <div class="stat"><span>Your DEF</span><span id="defVal2">2</span></div>
+            <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%"><span>🛡 Armor</span><span id="armorVal2">0</span></div>
             <div class="stat"><span>Estimated Win Chance</span><span id="winEst">—</span></div>
           </div>
         </div>

--- a/src/game/abilitySystem.js
+++ b/src/game/abilitySystem.js
@@ -84,11 +84,14 @@ function resolvePowerSlash(state) {
   const weapon = getEquippedWeapon(state);
   const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
   const raw = Math.round(1.3 * roll);
-  const enemyDef = state.adventure.currentEnemy?.defense || 0;
-  const damage = Math.max(1, Math.round(raw - enemyDef * 0.6));
-  state.adventure.enemyHP = processAttack(state.adventure.enemyHP, damage, { target: state.adventure.currentEnemy, element: null });
-  state.adventure.combatLog.push(`You used Power Slash for ${damage} Physical damage.`);
-  if (damage > 0) {
+  let dealt = 0;
+  state.adventure.enemyHP = processAttack(
+    state.adventure.enemyHP,
+    raw,
+    { target: state.adventure.currentEnemy, type: 'physical', onDamage: d => (dealt = d) }
+  );
+  state.adventure.combatLog.push(`You used Power Slash for ${dealt} Physical damage.`);
+  if (dealt > 0) {
     const healed = Math.min(5, state.hpMax - state.hp);
     state.hp += healed;
     state.adventure.playerHP = state.hp;

--- a/src/game/combat.js
+++ b/src/game/combat.js
@@ -2,6 +2,22 @@ import { initHp } from './helpers.js';
 import { WEAPONS, WEAPON_CONFIG, WEAPON_FLAGS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
 import { getProficiency } from './systems/proficiency.js';
 
+/** Tunables */
+export const ARMOR_K = 10;           // how "strong" armor is vs damage size
+export const ARMOR_CAP = 0.90;       // 90% maximum mitigation
+export const MIN_POST_ARMOR = 0;     // allow 0; set to 1 if you prefer "always chip"
+
+/** Returns the mitigated physical damage AFTER armor (integer). */
+export function applyArmor(rawPhysDamage, armor) {
+  if (rawPhysDamage <= 0 || armor <= 0) return Math.max(0, Math.round(rawPhysDamage));
+
+  const denom = armor + ARMOR_K * rawPhysDamage;
+  const mit = Math.min(ARMOR_CAP, Math.max(0, armor / Math.max(1, denom)));
+  const after = rawPhysDamage * (1 - mit);
+  const rounded = Math.round(after);
+  return Math.max(MIN_POST_ARMOR, rounded);
+}
+
 export function initializeFight(enemy) {
   const { hp: enemyHP, hpMax: enemyMax } = initHp(enemy.hp || 0);
   const atk = Math.round(enemy.atk ?? enemy.attack ?? 0);
@@ -24,9 +40,15 @@ export function applyResists(damage, element, target) {
 }
 
 export function processAttack(currentHP, damage, options = {}) {
-  const { element, target } = options;
-  const adjusted = applyResists(damage, element, target);
-  return Math.max(0, Math.round(currentHP - adjusted));
+  const { element, target, type, onDamage } = options;
+  let adjusted = applyResists(damage, element, target);
+  if (type === 'physical') {
+    const armor = target?.stats?.armor ?? target?.armor ?? target?.defense ?? 0;
+    adjusted = applyArmor(adjusted, armor);
+  }
+  const final = Math.max(0, Math.round(adjusted));
+  if (typeof onDamage === 'function') onDamage(final);
+  return Math.max(0, Math.round(currentHP - final));
 }
 
 export function getEquippedWeapon(state) {

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -36,7 +36,8 @@ export const defaultState = () => {
     criticalChance: 0.05, // Base critical hit chance
     attackSpeed: 1.0,    // Base attack speed multiplier
     cooldownReduction: 0, // Cooldown reduction percentage
-    adventureSpeed: 1.0  // Adventure/exploration speed multiplier
+    adventureSpeed: 1.0, // Adventure/exploration speed multiplier
+    armor: 0            // Total armor from gear and bonuses
   },
   disciples:1,
   gather:{herbs:0, ore:0, wood:0},

--- a/src/ui/panels/CharacterPanel.js
+++ b/src/ui/panels/CharacterPanel.js
@@ -1,13 +1,14 @@
 import { S, save } from '../../game/state.js';
 import { WEAPONS } from '../../data/weapons.js';
 import { WEAPON_ICONS } from '../../data/weaponIcons.js';
-import { equipItem, unequip, removeFromInventory } from '../../game/systems/inventory.js';
+import { equipItem, unequip, removeFromInventory, recomputePlayerTotals } from '../../game/systems/inventory.js';
 
 // Consolidated equipment/inventory panel
 let currentFilter = 'all';
 let slotFilter = null;
 
 export function renderEquipmentPanel() {
+  recomputePlayerTotals();
   renderEquipment();
   renderInventory();
 }
@@ -31,6 +32,8 @@ function renderEquipment() {
     el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory(); };
     el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
   });
+  const armorEl = document.getElementById('armorVal');
+  if (armorEl) armorEl.textContent = S.stats?.armor || 0;
 }
 
 function weaponDetailsText(item) {

--- a/ui/index.js
+++ b/ui/index.js
@@ -442,7 +442,9 @@ function updateAll(){
   
   // Combat stats
   setText('atkVal', calcAtk()); setText('defVal', calcDef());
+  setText('armorVal', S.stats?.armor || 0);
   setText('atkVal2', calcAtk()); setText('defVal2', calcDef());
+  setText('armorVal2', S.stats?.armor || 0);
   
   // Activity system display
   if (!S.activities) {
@@ -2151,7 +2153,7 @@ function techSlash(){
   if(!S.combat.hunt){ log('No active hunt','bad'); return; }
   if(S.combat.cds.slash>0){ log('Sword Slash on cooldown','bad'); return; }
   const dmg = calcAtk()*3;
-  S.combat.hunt.enemyHP = processAttack(S.combat.hunt.enemyHP, dmg);
+  S.combat.hunt.enemyHP = processAttack(S.combat.hunt.enemyHP, dmg, { type: 'physical' });
   S.combat.cds.slash = 8; log('You unleash Sword Slash!','good'); updateHuntUI();
 }
 function techGuard(){
@@ -2163,7 +2165,7 @@ function techBurst(){
   if(!S.combat.hunt){ log('No active hunt','bad'); return; }
   if(S.combat.cds.burst>0){ log('Qi Burst on cooldown','bad'); return; }
   const need = 0.25*qCap(); if(S.qi < need){ log('Not enough Qi for Burst (25% required)','bad'); return; }
-  S.qi -= need; const dmg = need/3 + calcAtk(); S.combat.hunt.enemyHP = processAttack(S.combat.hunt.enemyHP, dmg); S.combat.cds.burst = 15; log('Qi Burst detonates!','good'); updateHuntUI();
+  S.qi -= need; const dmg = need/3 + calcAtk(); S.combat.hunt.enemyHP = processAttack(S.combat.hunt.enemyHP, dmg, { type: 'physical' }); S.combat.cds.burst = 15; log('Qi Burst detonates!','good'); updateHuntUI();
 }
 
 function updateWinEst(){
@@ -2312,10 +2314,10 @@ function tick(){
     const ourDPS = Math.max(1, atk - h.eDef*0.6);
     let enemyDPS = Math.max(0, h.eAtk - def*0.7);
     if(guardActive) enemyDPS *= 0.5;
-    h.enemyHP = processAttack(h.enemyHP, ourDPS);
+    h.enemyHP = processAttack(h.enemyHP, ourDPS, { type: 'physical' });
     if(h.regen) h.enemyHP += h.enemyMax * h.regen;
     h.enemyHP = clamp(h.enemyHP, 0, h.enemyMax);
-    S.hp = processAttack(S.hp, enemyDPS);
+    S.hp = processAttack(S.hp, enemyDPS, { target: S, type: 'physical' });
     if(h.enemyHP<=0){ resolveHunt(true); }
     else if(S.hp<=1){ resolveHunt(false); }
     updateHuntUI();


### PR DESCRIPTION
## Summary
- Introduce armor stat and applyArmor utility with tunable constants
- Mitigate physical damage for players and enemies via armor stage in combat pipeline
- Track armor from equipped gear and display totals in UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`
- `node --input-type=module <applyArmor>`
- `node --input-type=module <processAttack>`


------
https://chatgpt.com/codex/tasks/task_e_68a3e645da988326ac9b441b5e2d4404