### PR TITLE
feat: show character stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -579,6 +579,21 @@
         <h2>🧙 Character</h2>
         <div class="cards character-cards">
           <div class="card">
+            <h4>Stats</h4>
+            <div class="stat"><span>HP</span><span id="stat-hp">100/100</span></div>
+            <div class="stat"><span>Attack</span><span id="stat-atkBase">5</span></div>
+            <div class="stat"><span>Defense</span><span id="stat-defBase">2</span></div>
+            <div class="stat"><span>Physique</span><span id="stat-physique">10</span></div>
+            <div class="stat"><span>Mind</span><span id="stat-mind">10</span></div>
+            <div class="stat"><span>Agility</span><span id="stat-agility">10</span></div>
+            <div class="stat"><span>Dexterity</span><span id="stat-dexterity">10</span></div>
+            <div class="stat"><span>Comprehension</span><span id="stat-comprehension">10</span></div>
+            <div class="stat"><span>Crit Chance</span><span id="stat-criticalChance">5%</span></div>
+            <div class="stat"><span>Attack Speed</span><span id="stat-attackSpeed">1.00</span></div>
+            <div class="stat"><span>Cooldown Reduction</span><span id="stat-cooldownReduction">0%</span></div>
+            <div class="stat"><span>Adventure Speed</span><span id="stat-adventureSpeed">1.00</span></div>
+          </div>
+          <div class="card">
             <h4>Equipment</h4>
             <div class="equip-slots">
               <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>

--- a/src/ui/panels/CharacterPanel.js
+++ b/src/ui/panels/CharacterPanel.js
@@ -10,6 +10,31 @@ let slotFilter = null;
 export function renderEquipmentPanel() {
   renderEquipment();
   renderInventory();
+  renderStats();
+}
+
+function renderStats() {
+  if (!S.stats) return;
+  const defs = [
+    { id: 'hp', value: () => `${S.hp}/${S.hpMax}` },
+    { id: 'atkBase', value: () => S.atkBase },
+    { id: 'defBase', value: () => S.defBase },
+    { id: 'physique', stat: 'physique' },
+    { id: 'mind', stat: 'mind' },
+    { id: 'agility', stat: 'agility' },
+    { id: 'dexterity', stat: 'dexterity' },
+    { id: 'comprehension', stat: 'comprehension' },
+    { id: 'criticalChance', stat: 'criticalChance', format: v => `${(v * 100).toFixed(1)}%` },
+    { id: 'attackSpeed', stat: 'attackSpeed', format: v => v.toFixed(2) },
+    { id: 'cooldownReduction', stat: 'cooldownReduction', format: v => `${Math.round(v * 100)}%` },
+    { id: 'adventureSpeed', stat: 'adventureSpeed', format: v => v.toFixed(2) }
+  ];
+  defs.forEach(d => {
+    const el = document.getElementById(`stat-${d.id}`);
+    if (!el) return;
+    const val = d.value ? d.value() : (S.stats[d.stat] ?? 0);
+    el.textContent = d.format ? d.format(val) : val;
+  });
 }
 
 function renderEquipment() {


### PR DESCRIPTION
## Summary
- add stats card in Character tab
- render current character stats from game state including HP, attack, and defense

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3d83960cc8326bc137cc4c5ff4a7f