### PR TITLE
feat: add qi shield system

### DIFF
--- a/docs/parameters-and-formulas.md
+++ b/docs/parameters-and-formulas.md
@@ -2,6 +2,7 @@
 
 ## Base Stats
 - **HP**: 100
+- **Qi Shield**: 0
 - **Base Attack**: 5
 - **Base Defense**: 2
 - **Starting Stats**:
@@ -25,7 +26,7 @@ All attribute levels grant **+1% talent**.
 | Attribute | Bonus per Level |
 | --- | --- |
 | Physique | +5 HP, +1 carry capacity |
-| Mind | +6% energy shield |
+| Mind | +1% Qi Shield refill efficiency, +6% Qi Shield capacity |
 | Agility | +2% dodge chance |
 
 ## Physique-Derived Bonuses
@@ -45,6 +46,12 @@ All attribute levels grant **+1% talent**.
 ### Talent and Comprehension
 - **Talent** acts as a direct multiplier on cultivation progress. Higher Talent means proportionally faster foundation gain.
 - **Comprehension** boosts cultivation efficiency and learning speed. Each point above 10 adds +5% foundation gain via `(1 + (Comprehension - 10) * 0.05)` and grants +4% learning speed.
+
+## Qi Shield
+- Absorbs damage before HP and does not regenerate during combat.
+- Max Shield: `baseShield × (1 + Mind × 0.06)`.
+- Refill cost per shield point: `cost = 2 / (1 + Mind × 0.01)`, floored to 25% of base.
+- Refill occurs after encounters or periodically out of combat, consuming Qi.
 
 ## Attack Damage Calculation
 1. `baseDamage = random(min, max) * attackRate`

--- a/index.html
+++ b/index.html
@@ -57,7 +57,9 @@
       <div class="chip">Realm: <span id="realmName">Mortal 1</span></div>
       <div class="chip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
       <div class="chip">Stones: <span id="stonesVal">0</span></div>
-      <div class="chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span></div>
+      <div class="chip hp-chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span>
+        <div class="hp-bar"><div class="fill" id="hpFill"></div><div class="shield-fill" id="shieldFill"></div></div>
+      </div>
       <div class="chip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
     </div>
     <div class="right-actions">
@@ -578,6 +580,7 @@
           <div class="card">
             <h4>Stats</h4>
             <div class="stat"><span>HP</span><span id="stat-hp">100/100</span></div>
+            <div class="stat"><span>Shield</span><span id="stat-shield">0/0</span></div>
             <div class="stat"><span>Attack</span><span id="stat-atkBase">5</span></div>
             <div class="stat"><span>Defense</span><span id="stat-defBase">2</span></div>
             <div class="stat"><span>Physique</span><span id="stat-physique">10</span></div>

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -1,6 +1,6 @@
 import { S } from './state.js';
 import { calculatePlayerCombatAttack, calculatePlayerAttackRate, getWeaponProficiencyBonuses, qCap } from './engine.js';
-import { initializeFight, processAttack, getEquippedWeapon } from './combat.js';
+import { initializeFight, processAttack, getEquippedWeapon, refillShieldFromQi } from './combat.js';
 import { rollLoot, toLootTableKey } from './systems/loot.js'; // WEAPONS-INTEGRATION
 import { WEAPONS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
 import { ABILITIES } from '../data/abilities.js';
@@ -746,6 +746,8 @@ export function updateAdventureCombat() {
             btn.disabled = false;
           }
           updateActivityAdventure();
+          const { gained, qiSpent } = refillShieldFromQi(S);
+          if (gained > 0) log(`Your Qi reforms ${gained} shield (${qiSpent.toFixed(1)} Qi).`);
         }
       }
     }
@@ -852,6 +854,9 @@ function defeatEnemy() {
   const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
   S.adventure.enemyHP = enemyHP;
   S.adventure.enemyMaxHP = enemyMax;
+
+  const { gained, qiSpent } = refillShieldFromQi(S);
+  if (gained > 0) log(`Your Qi reforms ${gained} shield (${qiSpent.toFixed(1)} Qi).`);
 
   if (S.activities.adventure && S.adventure.playerHP > 0 && !isBoss) {
     startAdventureCombat();

--- a/src/game/combat.js
+++ b/src/game/combat.js
@@ -7,6 +7,39 @@ export const ARMOR_K = 10;           // how "strong" armor is vs damage size
 export const ARMOR_CAP = 0.90;       // 90% maximum mitigation
 export const MIN_POST_ARMOR = 0;     // allow 0; set to 1 if you prefer "always chip"
 
+export const QI_PER_SHIELD_BASE = 2.0;
+export const MIND_EFF_PER_POINT = 0.01;
+export const MIN_COST_MULT = 0.25;
+
+export function qiCostPerShield(mind) {
+  const mult = 1 / (1 + mind * MIND_EFF_PER_POINT);
+  const clampedMult = Math.max(MIN_COST_MULT, mult);
+  return QI_PER_SHIELD_BASE * clampedMult;
+}
+
+export function refillShieldFromQi(entity) {
+  if (!entity || entity.autoFillShieldFromQi === false) return { gained: 0, qiSpent: 0 };
+  entity.shield = entity.shield || { current: 0, max: 0 };
+  const missing = Math.max(0, entity.shield.max - entity.shield.current);
+  if (missing === 0) return { gained: 0, qiSpent: 0 };
+  const cost = qiCostPerShield(entity.stats?.mind || 0);
+  const maxGained = Math.floor((entity.qi || 0) / cost);
+  const gained = Math.min(missing, maxGained);
+  const spent = gained * cost;
+  entity.qi -= spent;
+  entity.shield.current += gained;
+  return { gained, qiSpent: spent };
+}
+
+export function routeDamageThroughQiShield(incoming, target) {
+  if (incoming <= 0) return 0;
+  const shield = target?.shield;
+  if (!shield || shield.current <= 0) return incoming;
+  const absorbed = Math.min(shield.current, incoming);
+  shield.current -= absorbed;
+  return incoming - absorbed;
+}
+
 /** Returns the mitigated physical damage AFTER armor (integer). */
 export function applyArmor(rawPhysDamage, armor) {
   if (rawPhysDamage <= 0 || armor <= 0) return Math.max(0, Math.round(rawPhysDamage));
@@ -46,6 +79,7 @@ export function processAttack(currentHP, damage, options = {}) {
     const armor = target?.stats?.armor ?? target?.armor ?? target?.defense ?? 0;
     adjusted = applyArmor(adjusted, armor);
   }
+  adjusted = routeDamageThroughQiShield(adjusted, target);
   const final = Math.max(0, Math.round(adjusted));
   if (typeof onDamage === 'function') onDamage(final);
   return Math.max(0, Math.round(currentHP - final));

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -108,6 +108,11 @@ export const migrations = [
       }
       save.proficiency = converted;
     }
+  },
+  save => {
+    if (!save.shield) save.shield = { current: 0, max: 0 };
+    if (typeof save.autoFillShieldFromQi === 'undefined') save.autoFillShieldFromQi = true;
+    if (save.shield.current > save.shield.max) save.shield.current = save.shield.max;
   }
 ];
 

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -21,6 +21,8 @@ export const defaultState = () => {
   qiRegenMult: 0, // Qi regeneration multiplier from buildings/bonuses
   foundation: 0,
   ...initHp(100),
+  shield: { current: 0, max: 0 },
+  autoFillShieldFromQi: true,
   stunBar: 0, // STATUS-REFORM player stun accumulation
   realm: { tier: 0, stage: 1 },
   wood:0, cores:0,

--- a/src/game/systems/inventory.js
+++ b/src/game/systems/inventory.js
@@ -4,12 +4,19 @@ import { WEAPONS } from '../../data/weapons.js';
 // EQUIP-CHAR-UI: basic inventory helpers
 export function recomputePlayerTotals(player = S) {
   let armor = 0;
+  let shieldMax = 0;
   const equipped = Object.values(player.equipment || {});
   for (const item of equipped) {
     if (item && item.defense?.armor) armor += item.defense.armor;
+    if (item && item.shield?.max) shieldMax += item.shield.max;
   }
   player.stats = player.stats || {};
   player.stats.armor = armor;
+  player.shield = player.shield || { current: 0, max: 0 };
+  const mind = player.stats.mind || 0;
+  const shieldMult = 1 + mind * 0.06;
+  player.shield.max = Math.round(shieldMax * shieldMult);
+  player.shield.current = Math.min(player.shield.current, player.shield.max);
 }
 
 export function addToInventory(item) {

--- a/src/ui/panels/CharacterPanel.js
+++ b/src/ui/panels/CharacterPanel.js
@@ -18,6 +18,7 @@ function renderStats() {
   if (!S.stats) return;
   const defs = [
     { id: 'hp', value: () => `${S.hp}/${S.hpMax}` },
+    { id: 'shield', value: () => `${S.shield?.current || 0}/${S.shield?.max || 0}` },
     { id: 'atkBase', value: () => S.atkBase },
     { id: 'defBase', value: () => S.defBase },
     { id: 'physique', stat: 'physique' },

--- a/style.css
+++ b/style.css
@@ -1630,6 +1630,10 @@ h1{font-size:20px; margin:0; letter-spacing:.5px}
 .topbar{display:flex; gap:14px; flex-wrap:wrap}
 /* STYLE-GUIDE-UPDATE: Parchment chip style */
 .chip{background:var(--panel); border:1px solid var(--accent); padding:8px 12px; border-radius:999px; font-size:12px; box-shadow: inset 0 1px 3px rgba(139, 117, 95, 0.2);}
+.hp-chip{display:flex; flex-direction:column; align-items:flex-start;}
+.hp-chip .hp-bar{position:relative; width:100px; height:8px; background:rgba(239,68,68,0.3); border-radius:4px; margin-top:2px;}
+.hp-chip .hp-bar .fill{height:100%; background:linear-gradient(90deg,#ef4444,#f87171); border-radius:4px; transition:width 0.3s ease; width:0%;}
+.hp-chip .hp-bar .shield-fill{position:absolute; top:0; left:0; height:2px; background:cyan; border-radius:4px; width:0%; transition:width 0.3s ease;}
 
 main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -19,7 +19,7 @@ import {
   calculatePlayerCombatAttack,
   calculatePlayerAttackRate
 } from '../src/game/engine.js';
-import { initializeFight, processAttack } from '../src/game/combat.js';
+import { initializeFight, processAttack, refillShieldFromQi } from '../src/game/combat.js';
 import { applyRandomAffixes } from '../src/game/affixes.js';
 import {
   updateRealmUI,
@@ -439,6 +439,7 @@ function updateAll(){
   setText('hpVal', fmt(S.hp)); setText('hpMax', fmt(S.hpMax));
   setText('hpValL', fmt(S.hp)); setText('hpMaxL', fmt(S.hpMax));
   setFill('hpFill', S.hp / S.hpMax);
+  setFill('shieldFill', S.shield?.max ? S.shield.current / S.shield.max : 0);
   
   // Combat stats
   setText('atkVal', calcAtk()); setText('defVal', calcDef());
@@ -2187,6 +2188,8 @@ function tick(){
   if (!(S.adventure?.inCombat) && !S.combat.hunt) {
     S.hp = clamp(S.hp + 1, 0, S.hpMax);
     if (S.adventure) S.adventure.playerHP = S.hp;
+    const { gained, qiSpent } = refillShieldFromQi(S);
+    if (gained > 0) log(`Your Qi reforms ${gained} shield (${qiSpent.toFixed(1)} Qi).`);
   }
 
   // Gathering


### PR DESCRIPTION
## Summary
- add Qi Shield stat with automatic refill and damage routing
- overlay shield bar on HP and show shield in character stats
- document Qi Shield formulas, Mind efficiency, and Mind-based capacity scaling

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a3eca74de8832696805be1a64fe3e5