### PR TITLE
refactor: centralize game state selectors

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -108,6 +108,7 @@ way-of-ascension/
 │   │   ├── engine.js
 │   │   ├── helpers.js
 │   │   ├── abilitySystem.js
+│   │   ├── selectors.js
 │   │   ├── migrations.js
 │   │   ├── state.js
 │   │   └── utils.js
@@ -230,12 +231,18 @@ S = {
 - `chanceToHit(accuracy, dodge)` – computes final hit probability.
 
 #### `abilitySystem.js` - Active Ability Handling
-**Purpose**: Manages ability slots, casting validation, cooldown timers, and resolving ability effects.
+**Purpose**: Manages casting validation, cooldown timers, and resolving ability effects.
 **Key Functions**:
-- `getAbilitySlots(state)` – derive six ability slots from the equipped weapon.
 - `tryCastAbility(key)` – validate and trigger ability casts, deduct Qi, start cooldowns.
 - `tickAbilityCooldowns(dt)` – decrement cooldown timers each game tick.
 - `processAbilityQueue(state)` – resolve queued ability actions like Power Slash damage and healing.
+
+#### `selectors.js` - Centralized State Selectors
+**Purpose**: Provides derived state accessors. Never read state fields directly; use selectors.
+**Key Functions**:
+- `getEquippedWeapon(state)` – retrieve the currently equipped weapon.
+- `getAbilitySlots(state)` – derive six ability slots from the equipped weapon.
+- `getWeaponProficiencyBonuses(state)` – compute damage and speed bonuses from proficiency.
 
 #### `migrations.js` - Save Migration System
 **Purpose**: Handle save data structure changes between versions

--- a/src/game/abilitySystem.js
+++ b/src/game/abilitySystem.js
@@ -1,36 +1,7 @@
 import { ABILITIES } from '../data/abilities.js';
-import { getEquippedWeapon, processAttack } from './combat.js';
+import { processAttack } from './combat.js';
+import { getEquippedWeapon } from './selectors.js';
 import { S } from './state.js';
-
-/**
- * Get ability slots derived from currently equipped weapon.
- * @param {any} state
- * @returns {Array<import('../data/abilities.js').AbilityDef>}
- */
-export function getAbilitySlots(state = S) {
-  const slots = [];
-  const weapon = getEquippedWeapon(state);
-  const abilityKey = weapon.abilityKeys?.[0];
-  for (let i = 0; i < 6; i++) {
-    if (i === 0 && abilityKey) {
-      const def = ABILITIES[abilityKey];
-      const meetsReq = def && (!def.requiresWeaponType || def.requiresWeaponType === weapon.typeKey);
-      if (meetsReq) {
-        const cooldown = state.abilityCooldowns?.[abilityKey] || 0;
-        slots.push({
-          keybind: i + 1,
-          abilityKey,
-          isReady: cooldown <= 0 && state.qi >= def.costQi,
-          cooldownRemainingMs: cooldown,
-          insufficientQi: state.qi < def.costQi,
-        });
-        continue;
-      }
-    }
-    slots.push({ keybind: i + 1, abilityKey: undefined, isReady: false, cooldownRemainingMs: 0, insufficientQi: false });
-  }
-  return slots;
-}
 
 export function tryCastAbility(abilityKey, state = S) {
   const ability = ABILITIES[abilityKey];

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -1,6 +1,7 @@
 import { S } from './state.js';
-import { calculatePlayerCombatAttack, calculatePlayerAttackRate, getWeaponProficiencyBonuses, qCap } from './engine.js';
-import { initializeFight, processAttack, getEquippedWeapon, refillShieldFromQi } from './combat.js';
+import { calculatePlayerCombatAttack, calculatePlayerAttackRate, qCap } from './engine.js';
+import { initializeFight, processAttack, refillShieldFromQi } from './combat.js';
+import { getEquippedWeapon, getAbilitySlots } from './selectors.js';
 import { rollLoot, toLootTableKey } from './systems/loot.js'; // WEAPONS-INTEGRATION
 import { WEAPONS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
 import { ABILITIES } from '../data/abilities.js';
@@ -8,7 +9,7 @@ import { WEAPON_TYPES } from '../data/weaponTypes.js';
 import { WEAPON_ICONS } from '../data/weaponIcons.js';
 import { performAttack, decayStunBar } from './combat/attack.js'; // STATUS-REFORM
 import { chanceToHit } from './combat/hit.js';
-import { getAbilitySlots, tryCastAbility, processAbilityQueue } from './abilitySystem.js';
+import { tryCastAbility, processAbilityQueue } from './abilitySystem.js';
 import { ENEMY_DATA } from '../../data/enemies.js';
 import { setText, setFill, log } from './utils.js';
 import { applyRandomAffixes, AFFIXES } from './affixes.js';

--- a/src/game/combat.js
+++ b/src/game/combat.js
@@ -1,6 +1,5 @@
 import { initHp } from './helpers.js';
 import { WEAPONS, WEAPON_CONFIG, WEAPON_FLAGS } from '../data/weapons.js'; // WEAPONS-INTEGRATION
-import { getProficiency } from './systems/proficiency.js';
 
 /** Tunables */
 export const ARMOR_K = 10;           // how "strong" armor is vs damage size
@@ -83,13 +82,5 @@ export function processAttack(currentHP, damage, options = {}) {
   const final = Math.max(0, Math.round(adjusted));
   if (typeof onDamage === 'function') onDamage(final);
   return Math.max(0, Math.round(currentHP - final));
-}
-
-export function getEquippedWeapon(state) {
-  // WEAPONS-INTEGRATION: respect feature flag and invalid keys
-  if (!state.flags?.weaponsEnabled) return WEAPONS.fist;
-  const eq = state.equipment?.mainhand;
-  const key = typeof eq === 'string' ? eq : eq?.key;
-  return WEAPONS[key] || WEAPONS.fist;
 }
 

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,9 +1,7 @@
 import { REALMS } from '../../data/realms.js';
 import { LAWS } from '../../data/laws.js';
 import { S } from './state.js';
-import { getProficiency } from './systems/proficiency.js';
-import { getEquippedWeapon } from './combat.js';
-import { WEAPONS } from '../data/weapons.js';
+import { getWeaponProficiencyBonuses } from './selectors.js';
 
 export const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
 
@@ -160,16 +158,6 @@ export function getStatEffects() {
     totalAttackSpeed: S.stats.attackSpeed * (1 + (S.stats.dexterity - 10) * 0.04),
     totalCooldownReduction: S.stats.cooldownReduction + (S.stats.dexterity - 10) * 0.02,
     totalAdventureSpeed: S.stats.adventureSpeed * (1 + (S.stats.dexterity - 10) * 0.03)
-  };
-}
-
-export function getWeaponProficiencyBonuses(state = S) {
-  const weapon = getEquippedWeapon(state);
-  const { value } = getProficiency(weapon.proficiencyKey, state);
-  const level = Math.floor(value / 100);
-  return {
-    damage: level,
-    speed: level * 0.01,
   };
 }
 

--- a/src/game/selectors.js
+++ b/src/game/selectors.js
@@ -1,0 +1,50 @@
+// Centralized state selectors.
+// Never read state fields directly; use selectors.
+
+import { WEAPONS } from '../data/weapons.js';
+import { ABILITIES } from '../data/abilities.js';
+import { getProficiency } from './systems/proficiency.js';
+import { S } from './state.js';
+
+export function getEquippedWeapon(state = S) {
+  // WEAPONS-INTEGRATION: respect feature flag and invalid keys
+  if (!state.flags?.weaponsEnabled) return WEAPONS.fist;
+  const eq = state.equipment?.mainhand;
+  const key = typeof eq === 'string' ? eq : eq?.key;
+  return WEAPONS[key] || WEAPONS.fist;
+}
+
+export function getAbilitySlots(state = S) {
+  const slots = [];
+  const weapon = getEquippedWeapon(state);
+  const abilityKey = weapon.abilityKeys?.[0];
+  for (let i = 0; i < 6; i++) {
+    if (i === 0 && abilityKey) {
+      const def = ABILITIES[abilityKey];
+      const meetsReq = def && (!def.requiresWeaponType || def.requiresWeaponType === weapon.typeKey);
+      if (meetsReq) {
+        const cooldown = state.abilityCooldowns?.[abilityKey] || 0;
+        slots.push({
+          keybind: i + 1,
+          abilityKey,
+          isReady: cooldown <= 0 && state.qi >= def.costQi,
+          cooldownRemainingMs: cooldown,
+          insufficientQi: state.qi < def.costQi,
+        });
+        continue;
+      }
+    }
+    slots.push({ keybind: i + 1, abilityKey: undefined, isReady: false, cooldownRemainingMs: 0, insufficientQi: false });
+  }
+  return slots;
+}
+
+export function getWeaponProficiencyBonuses(state = S) {
+  const weapon = getEquippedWeapon(state);
+  const { value } = getProficiency(weapon.proficiencyKey, state);
+  const level = Math.floor(value / 100);
+  return {
+    damage: level,
+    speed: level * 0.01,
+  };
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -15,10 +15,10 @@ import {
   powerMult,
   calcAtk,
   calcDef,
-  getWeaponProficiencyBonuses,
   calculatePlayerCombatAttack,
   calculatePlayerAttackRate
 } from '../src/game/engine.js';
+import { getWeaponProficiencyBonuses } from '../src/game/selectors.js';
 import { initializeFight, processAttack, refillShieldFromQi } from '../src/game/combat.js';
 import { applyRandomAffixes } from '../src/game/affixes.js';
 import {


### PR DESCRIPTION
## Summary
- add `selectors.js` for centralized state selectors like `getEquippedWeapon`, `getAbilitySlots`, and `getWeaponProficiencyBonuses`
- update ability, adventure, engine, and UI modules to use selectors instead of direct state access
- document selector usage and directive to avoid reading state fields directly

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a4a8e2e0408326bae755cbe651cc4d