### PR TITLE
refactor: isolate weapon drop generation logic

### DIFF
--- a/src/data/lootTables.weapons.js
+++ b/src/data/lootTables.weapons.js
@@ -1,38 +1,12 @@
 import { ZONES } from './zones.js';
-import { generateWeapon } from '../features/weaponGeneration/logic.js';
 
 /** @typedef {{ typeKey:string, materialKey?:string, weight:number }} WeaponLootRow */
 
 /** Minimal v1: starting zone only */
-const TABLES /** @type {Record<string, WeaponLootRow[]>} */ = {
+export const WEAPON_LOOT_TABLES /** @type {Record<string, WeaponLootRow[]>} */ = {
   [ZONES.STARTING]: [
     // v1 guarantee: only Iron Sword can drop here
     { typeKey: 'sword', materialKey: 'iron', weight: 100 },
   ],
   // other zones → add later
 };
-
-function pickWeighted(rows){
-  const total = rows.reduce((s, r) => s + r.weight, 0);
-  let r = Math.random() * total;
-  for (const row of rows) {
-    r -= row.weight;
-    if (r <= 0) return row;
-  }
-  return rows[rows.length - 1];
-}
-
-/**
- * Roll a single weapon drop for the given zone.
- * Returns a generated weapon item or null (no drop).
- */
-export function rollWeaponDropForZone(zoneKey){
-  const rows = TABLES[zoneKey];
-  if (!rows || rows.length === 0) return null;
-
-  const row = pickWeighted(rows);
-  return generateWeapon({
-    typeKey: row.typeKey,
-    materialKey: row.materialKey, // naming only in v1, stats come from type
-  });
-}

--- a/src/features/weaponGeneration/selectors.js
+++ b/src/features/weaponGeneration/selectors.js
@@ -1,5 +1,28 @@
 import { weaponGenerationState } from './state.js';
+import { WEAPON_LOOT_TABLES } from '../../data/lootTables.weapons.js';
+import { generateWeapon } from './logic.js';
 
 export function getGeneratedWeapon(state = weaponGenerationState) {
   return state.generated;
+}
+
+function pickWeighted(rows){
+  const total = rows.reduce((s, r) => s + r.weight, 0);
+  let r = Math.random() * total;
+  for (const row of rows) {
+    r -= row.weight;
+    if (r <= 0) return row;
+  }
+  return rows[rows.length - 1];
+}
+
+export function rollWeaponDropForZone(zoneKey){
+  const rows = WEAPON_LOOT_TABLES[zoneKey];
+  if (!rows || rows.length === 0) return null;
+
+  const row = pickWeighted(rows);
+  return generateWeapon({
+    typeKey: row.typeKey,
+    materialKey: row.materialKey,
+  });
 }

--- a/src/game/systems/loot.js
+++ b/src/game/systems/loot.js
@@ -1,6 +1,6 @@
 // WEAPONS-INTEGRATION: basic loot table rolling
 import { LOOT_TABLES } from '../../data/lootTables.js';
-import { rollWeaponDropForZone } from '../../data/lootTables.weapons.js';
+import { rollWeaponDropForZone } from '../../features/weaponGeneration/selectors.js';
 import { ZONES } from '../../data/zones.js';
 
 export function toLootTableKey(id = '') {


### PR DESCRIPTION
## Summary
- move weapon drop selector into weaponGeneration module
- expose weapon loot tables as data only
- update loot system to use new selector

## Testing
- `npm test` (fails: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a503d86a188326b59010d8eaf47253