### PR TITLE
Refactor proficiency into feature module

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -85,6 +85,15 @@ way-of-ascension/
 │   │   ├── zones.js
 │   │   └── abilities.js
 │   ├── features/
+│   │   ├── proficiency/
+│   │   │   ├── data/
+│   │   │   │   └── .gitkeep
+│   │   │   ├── logic.js
+│   │   │   ├── mutators.js
+│   │   │   ├── selectors.js
+│   │   │   ├── state.js
+│   │   │   └── ui/
+│   │   │       └── weaponProficiencyDisplay.js
 │   │   └── weaponGeneration/
 │   │       ├── data/
 │   │       │   ├── materials.stub.js
@@ -105,7 +114,6 @@ way-of-ascension/
 │   │   ├── systems/
 │   │   │   ├── inventory.js
 │   │   │   ├── loot.js
-│   │   │   ├── proficiency.js
 │   │   │   └── sessionLoot.js
 │   │   ├── adventure.js
 │   │   ├── affixes.js
@@ -246,7 +254,6 @@ S = {
 **Key Functions**:
 - `getEquippedWeapon(state)` – retrieve the currently equipped weapon.
 - `getAbilitySlots(state)` – derive six ability slots from the equipped weapon.
-- `getWeaponProficiencyBonuses(state)` – compute damage and speed bonuses from proficiency.
 
 #### `migrations.js` - Save Migration System
 **Purpose**: Handle save data structure changes between versions
@@ -387,6 +394,30 @@ function updateAll() {
 #### `src/ui/weaponChip.js` - Weapon Chip HUD
 **Purpose**: Initializes and updates the weapon display chip in the top HUD.
 **When to modify**: Change weapon HUD logic or appearance.
+
+#### `src/features/proficiency/state.js` - Proficiency Feature State
+**Purpose**: Maintains the player's proficiency map keyed by weapon type.
+**When to modify**: Adjust underlying storage of proficiency values.
+
+#### `src/features/proficiency/logic.js` - Proficiency Calculations
+**Purpose**: Provides core functions for gaining and querying proficiency.
+**Key Functions**:
+- `gainProficiency(key, amount, state)` – increment proficiency for a weapon type.
+- `getProficiency(key, state)` – retrieve proficiency value and bonus multiplier.
+
+#### `src/features/proficiency/mutators.js` - Proficiency Mutators
+**Purpose**: State-aware wrappers around proficiency logic.
+**Key Functions**: `gainProficiency(key, amount, state)`.
+
+#### `src/features/proficiency/selectors.js` - Proficiency Selectors
+**Purpose**: Read-only helpers to derive proficiency data and bonuses.
+**Key Functions**:
+- `getProficiency(key, state)` – get stored proficiency and bonus.
+- `getWeaponProficiencyBonuses(state)` – compute damage and speed bonuses for the equipped weapon.
+
+#### `src/features/proficiency/ui/weaponProficiencyDisplay.js` - Proficiency HUD
+**Purpose**: Updates HUD elements showing weapon proficiency levels and progress.
+**When to modify**: Adjust proficiency display or formatting.
 
 ### UI Effects (`src/ui/fx/`)
 

--- a/src/features/proficiency/logic.js
+++ b/src/features/proficiency/logic.js
@@ -1,4 +1,4 @@
-import { WEAPONS } from '../../features/weaponGeneration/data/weapons.js';
+import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 
 // Proficiency is stored on the player state as an object: { [weaponType]: number }
 function resolveKey(key) {

--- a/src/features/proficiency/mutators.js
+++ b/src/features/proficiency/mutators.js
@@ -1,0 +1,6 @@
+import { proficiencyState } from './state.js';
+import { gainProficiency as applyGain } from './logic.js';
+
+export function gainProficiency(key, amount, state = proficiencyState) {
+  applyGain(key, amount, state);
+}

--- a/src/features/proficiency/selectors.js
+++ b/src/features/proficiency/selectors.js
@@ -1,0 +1,16 @@
+import { proficiencyState } from './state.js';
+import { getProficiency as resolveProficiency } from './logic.js';
+import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+
+export function getProficiency(key, state = proficiencyState) {
+  return resolveProficiency(key, state);
+}
+
+export function getWeaponProficiencyBonuses(state = proficiencyState) {
+  const equipped = state.flags?.weaponsEnabled ? state.equipment?.mainhand : 'fist';
+  const key = typeof equipped === 'string' ? equipped : equipped?.key;
+  const weapon = WEAPONS[key] || WEAPONS.fist;
+  const { value } = getProficiency(weapon.proficiencyKey, state);
+  const level = Math.floor(value / 100);
+  return { damage: level, speed: level * 0.01 };
+}

--- a/src/features/proficiency/state.js
+++ b/src/features/proficiency/state.js
@@ -1,0 +1,3 @@
+export const proficiencyState = {
+  proficiency: {},
+};

--- a/src/features/proficiency/ui/weaponProficiencyDisplay.js
+++ b/src/features/proficiency/ui/weaponProficiencyDisplay.js
@@ -1,0 +1,28 @@
+import { S } from '../../../game/state.js';
+import { getEquippedWeapon } from '../../../game/selectors.js';
+import { getProficiency } from '../selectors.js';
+import { WEAPON_TYPES } from '../../weaponGeneration/data/weaponTypes.js';
+import { WEAPON_ICONS } from '../../weaponGeneration/data/weaponIcons.js';
+import { setText, setFill } from '../../../game/utils.js';
+
+export function updateWeaponProficiencyDisplay(state = S) {
+  const weapon = getEquippedWeapon(state);
+  const { value } = getProficiency(weapon.proficiencyKey, state);
+  const level = Math.floor(value / 100);
+  const progress = value % 100;
+  const type = WEAPON_TYPES[weapon.proficiencyKey];
+  let label = type?.displayName || weapon.proficiencyKey;
+  if (!label.endsWith('s')) label += 's';
+  const icon = WEAPON_ICONS[weapon.proficiencyKey];
+  const labelEl = document.getElementById('weaponLabel');
+  if (labelEl) {
+    const text = `${label} Level`;
+    labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
+  }
+  setText('weaponLevel', level);
+  setText('weaponExp', progress.toFixed(0));
+  setText('weaponExpMax', '100');
+  setFill('weaponExpFill', progress / 100);
+  const bonus = 1 + level * 0.01;
+  setText('weaponBonus', bonus.toFixed(2));
+}

--- a/src/game/adventure.js
+++ b/src/game/adventure.js
@@ -5,15 +5,15 @@ import { getEquippedWeapon, getAbilitySlots } from './selectors.js';
 import { rollLoot, toLootTableKey } from './systems/loot.js'; // WEAPONS-INTEGRATION
 import { WEAPONS } from '../features/weaponGeneration/data/weapons.js'; // WEAPONS-INTEGRATION
 import { ABILITIES } from '../data/abilities.js';
-import { WEAPON_TYPES } from '../features/weaponGeneration/data/weaponTypes.js';
-import { WEAPON_ICONS } from '../features/weaponGeneration/data/weaponIcons.js';
 import { performAttack, decayStunBar } from './combat/attack.js'; // STATUS-REFORM
 import { chanceToHit } from './combat/hit.js';
 import { tryCastAbility, processAbilityQueue } from './abilitySystem.js';
 import { ENEMY_DATA } from '../../data/enemies.js';
-import { setText, setFill, log } from './utils.js';
+import { setText, log } from './utils.js';
 import { applyRandomAffixes, AFFIXES } from './affixes.js';
-import { gainProficiency, getProficiency } from './systems/proficiency.js';
+import { gainProficiency } from '../features/proficiency/mutators.js';
+import { getProficiency } from '../features/proficiency/selectors.js';
+import { updateWeaponProficiencyDisplay } from '../features/proficiency/ui/weaponProficiencyDisplay.js';
 import { ZONES, getZoneById, getAreaById, isZoneUnlocked, isAreaUnlocked } from '../../data/zones.js'; // MAP-UI-UPDATE
 import { save } from './state.js'; // MAP-UI-UPDATE
 import { addSessionLoot, claimSessionLoot, forfeitSessionLoot } from './systems/sessionLoot.js'; // EQUIP-CHAR-UI
@@ -36,30 +36,6 @@ function logEnemyResists(enemy) {
     console.log('[resist]', enemy.type, enemy.resists);
     loggedResistTypes.add(enemy.type);
   }
-}
-
-// Weapon proficiency handling
-export function updateWeaponProficiencyDisplay() {
-  const weapon = getEquippedWeapon(S);
-  const { value } = getProficiency(weapon.proficiencyKey, S);
-  const level = Math.floor(value / 100);
-  const progress = value % 100;
-  const type = WEAPON_TYPES[weapon.proficiencyKey];
-  let label = type?.displayName || weapon.proficiencyKey;
-  // crude pluralization: append 's' if not already plural
-  if (!label.endsWith('s')) label += 's';
-  const icon = WEAPON_ICONS[weapon.proficiencyKey];
-  const labelEl = document.getElementById('weaponLabel');
-  if (labelEl) {
-    const text = `${label} Level`;
-    labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
-  }
-  setText('weaponLevel', level);
-  setText('weaponExp', progress.toFixed(0));
-  setText('weaponExpMax', '100');
-  setFill('weaponExpFill', progress / 100);
-  const bonus = 1 + level * 0.01;
-  setText('weaponBonus', bonus.toFixed(2));
 }
 
 function getCombatPositions() {

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,7 +1,7 @@
 import { REALMS } from '../../data/realms.js';
 import { LAWS } from '../../data/laws.js';
 import { S } from './state.js';
-import { getWeaponProficiencyBonuses } from './selectors.js';
+import { getWeaponProficiencyBonuses } from '../features/proficiency/selectors.js';
 
 export const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
 
@@ -117,7 +117,7 @@ export function calcAtk(){
     };
   }
   const lawBonuses = getLawBonuses();
-  const profBonus = getWeaponProficiencyBonuses().damage;
+  const profBonus = getWeaponProficiencyBonuses(S).damage;
   return Math.floor((S.atkBase + profBonus + S.tempAtk + baseAtk + stageBonus + S.karma.atk*100) * lawBonuses.atk);
 }
 
@@ -164,7 +164,7 @@ export function getStatEffects() {
 export function calculatePlayerCombatAttack() {
   const baseAttack = 5;
   const realmBonus = REALMS[S.realm.tier].atk * S.realm.stage;
-  const profBonus = getWeaponProficiencyBonuses().damage;
+  const profBonus = getWeaponProficiencyBonuses(S).damage;
   return baseAttack + profBonus + realmBonus;
 }
 
@@ -172,7 +172,7 @@ export function calculatePlayerAttackRate() {
   const baseRate = 1.0;
   const dexterityBonus = (S.stats.dexterity - 10) * 0.05;
   const attackSpeedBonus = S.stats.attackSpeed || 0;
-  const profBonus = getWeaponProficiencyBonuses().speed;
+  const profBonus = getWeaponProficiencyBonuses(S).speed;
   return baseRate + dexterityBonus + (attackSpeedBonus / 100) + profBonus;
 }
 

--- a/src/game/selectors.js
+++ b/src/game/selectors.js
@@ -3,7 +3,6 @@
 
 import { WEAPONS } from '../features/weaponGeneration/data/weapons.js';
 import { ABILITIES } from '../data/abilities.js';
-import { getProficiency } from './systems/proficiency.js';
 import { S } from './state.js';
 
 export function getEquippedWeapon(state = S) {
@@ -39,12 +38,3 @@ export function getAbilitySlots(state = S) {
   return slots;
 }
 
-export function getWeaponProficiencyBonuses(state = S) {
-  const weapon = getEquippedWeapon(state);
-  const { value } = getProficiency(weapon.proficiencyKey, state);
-  const level = Math.floor(value / 100);
-  return {
-    damage: level,
-    speed: level * 0.01,
-  };
-}

--- a/ui/index.js
+++ b/ui/index.js
@@ -18,7 +18,6 @@ import {
   calculatePlayerCombatAttack,
   calculatePlayerAttackRate
 } from '../src/game/engine.js';
-import { getWeaponProficiencyBonuses } from '../src/game/selectors.js';
 import { initializeFight, processAttack, refillShieldFromQi } from '../src/game/combat.js';
 import { applyRandomAffixes } from '../src/game/affixes.js';
 import {
@@ -40,7 +39,6 @@ import {
   startBossCombat,
   progressToNextArea,
   retreatFromCombat,
-  updateWeaponProficiencyDisplay,
   updateFoodSlots,
   instakillCurrentEnemy,
   setupAdventureTabs,
@@ -48,6 +46,7 @@ import {
   updateAbilityBar
 
 } from '../src/game/adventure.js';
+import { updateWeaponProficiencyDisplay } from '../src/features/proficiency/ui/weaponProficiencyDisplay.js';
 import { forfeitSessionLoot } from '../src/game/systems/sessionLoot.js'; // EQUIP-CHAR-UI
 import { renderEquipmentPanel, setupEquipmentTab } from '../src/ui/panels/CharacterPanel.js'; // EQUIP-CHAR-UI
 import { ZONES } from '../data/zones.js'; // MAP-UI-UPDATE


### PR DESCRIPTION
## Summary
- Move weapon proficiency logic into `src/features/proficiency` with dedicated state, mutators and selectors.
- Extract `updateWeaponProficiencyDisplay` into its own UI module under the new feature.
- Update adventure and engine modules to consume proficiency APIs from the feature directory.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a5073be2dc832697e9ee6e5b163cf2