### PR TITLE
feat: add game controller orchestrator

### DIFF
--- a/src/features/proficiency/ui/weaponProficiencyDisplay.js
+++ b/src/features/proficiency/ui/weaponProficiencyDisplay.js
@@ -1,9 +1,10 @@
-import { S } from '../../../game/state.js';
-import { getEquippedWeapon } from '../../../game/selectors.js';
-import { getProficiency } from '../selectors.js';
-import { WEAPON_TYPES } from '../../weaponGeneration/data/weaponTypes.js';
-import { WEAPON_ICONS } from '../../weaponGeneration/data/weaponIcons.js';
-import { setText, setFill } from '../../../game/utils.js';
+import { S } from "../../../game/state.js";
+import { on } from "../../../shared/events.js";
+import { getEquippedWeapon } from "../../../game/selectors.js";
+import { getProficiency } from "../selectors.js";
+import { WEAPON_TYPES } from "../../weaponGeneration/data/weaponTypes.js";
+import { WEAPON_ICONS } from "../../weaponGeneration/data/weaponIcons.js";
+import { setText, setFill } from "../../../game/utils.js";
 
 export function updateWeaponProficiencyDisplay(state = S) {
   const weapon = getEquippedWeapon(state);
@@ -25,4 +26,12 @@ export function updateWeaponProficiencyDisplay(state = S) {
   setFill('weaponExpFill', progress / 100);
   const bonus = 1 + level * 0.01;
   setText('weaponBonus', bonus.toFixed(2));
+}
+
+export function mountProficiencyUI(state) {
+  function render() {
+    updateWeaponProficiencyDisplay(state);
+  }
+  on("RENDER", render);
+  render();
 }

--- a/src/game/GameController.js
+++ b/src/game/GameController.js
@@ -1,0 +1,56 @@
+import { emit } from "../shared/events.js";
+import { loadSave, saveDebounced } from "../shared/saveLoad.js";
+
+// feature slices (add more as features migrate)
+import { proficiencyState } from "../features/proficiency/state.js";
+import { weaponGenerationState } from "../features/weaponGeneration/state.js";
+
+// TODO: keep legacy engine until migrated
+// import engineTick from "./engine.js";
+
+export function createGameController() {
+  const state = {
+    app: { mode: "town", lastTick: performance.now() },
+    // compose feature slices (clone to avoid sharing module singletons)
+    proficiency: structuredClone(proficiencyState),
+    weaponGen: structuredClone(weaponGenerationState),
+
+    // TODO: keep legacy root pieces here until migrated (adventure, combat, etc.)
+  };
+
+  // hydrate from save
+  const hydrated = loadSave(state);
+  Object.assign(state, hydrated);
+
+  let running = false;
+  let acc = 0;
+  const stepMs = 100; // fixed timestep
+
+  function start() {
+    if (running) return; running = true;
+    state.app.lastTick = performance.now();
+    requestAnimationFrame(loop);
+  }
+
+  function loop(now) {
+    if (!running) return;
+    const dt = now - state.app.lastTick;
+    state.app.lastTick = now;
+    acc += dt;
+
+    while (acc >= stepMs) {
+      // Keep legacy engine call inside while (commented until wired)
+      // engineTick(state);
+      emit("TICK", { stepMs, now });
+      acc -= stepMs;
+    }
+
+    emit("RENDER");      // UIs should read via selectors on this pulse
+    saveDebounced(state);
+    requestAnimationFrame(loop);
+  }
+
+  function setMode(next) { state.app.mode = next; emit("MODE_CHANGED", next); }
+
+  return { state, start, setMode };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+import { createGameController } from "./game/GameController.js";
+import { mountProficiencyUI } from "./features/proficiency/ui/weaponProficiencyDisplay.js";
+
+const game = createGameController();
+game.start();
+
+mountProficiencyUI(game.state);
+
+// Optionally expose for debug:
+// window.game = game;

--- a/src/shared/events.js
+++ b/src/shared/events.js
@@ -1,0 +1,4 @@
+const listeners = new Map(); // type -> Set<fn>
+export function on(type, fn){ if(!listeners.has(type)) listeners.set(type, new Set()); listeners.get(type).add(fn); }
+export function off(type, fn){ listeners.get(type)?.delete(fn); }
+export function emit(type, payload){ listeners.get(type)?.forEach(fn => fn(payload)); }

--- a/src/shared/saveLoad.js
+++ b/src/shared/saveLoad.js
@@ -1,0 +1,4 @@
+const KEY = "woa:save:v1";
+export function loadSave(defaultState){ try{ const raw = localStorage.getItem(KEY); return raw ? {...defaultState, ...JSON.parse(raw)} : defaultState; }catch{ return defaultState; } }
+let saveTimer;
+export function saveDebounced(state){ clearTimeout(saveTimer); saveTimer = setTimeout(() => { try{ localStorage.setItem(KEY, JSON.stringify(state)); }catch{} }, 300); }


### PR DESCRIPTION
## Summary
- add pub/sub event utilities and save helpers
- introduce GameController to coordinate tick, render, and state hydration
- mount proficiency UI via new RENDER pulse

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: undocumented files)


------
https://chatgpt.com/codex/tasks/task_e_68a51e29d45c832699a35358c84381a4