### PR TITLE
Bridge legacy engine and centralize feature UI mounting

### DIFF
--- a/src/features/index.js
+++ b/src/features/index.js
@@ -1,0 +1,13 @@
+// src/features/index.js
+// Add feature UI mounts here as features migrate.
+
+import { mountProficiencyUI } from "./proficiency/ui/weaponProficiencyDisplay.js";
+// If/when present:
+// import { mountWeaponGenUI } from "./weaponGeneration/ui/weaponGenerationDisplay.js";
+
+export function mountAllFeatureUIs(state) {
+  // Mount order can matter if some UIs depend on global elements;
+  // keep it deterministic.
+  mountProficiencyUI(state);
+  // mountWeaponGenUI?.(state);
+}

--- a/src/game/GameController.js
+++ b/src/game/GameController.js
@@ -1,30 +1,27 @@
 import { emit } from "../shared/events.js";
 import { loadSave, saveDebounced } from "../shared/saveLoad.js";
 
-// feature slices (add more as features migrate)
+// feature slices
 import { proficiencyState } from "../features/proficiency/state.js";
 import { weaponGenerationState } from "../features/weaponGeneration/state.js";
 
-// TODO: keep legacy engine until migrated
-// import engineTick from "./engine.js";
+// TEMP bridge to legacy world:
+import engineTick from "./engine.js";
 
 export function createGameController() {
   const state = {
     app: { mode: "town", lastTick: performance.now() },
-    // compose feature slices (clone to avoid sharing module singletons)
     proficiency: structuredClone(proficiencyState),
     weaponGen: structuredClone(weaponGenerationState),
-
-    // TODO: keep legacy root pieces here until migrated (adventure, combat, etc.)
+    // legacy root pieces remain attached to `state` until migrated
   };
 
-  // hydrate from save
   const hydrated = loadSave(state);
   Object.assign(state, hydrated);
 
   let running = false;
   let acc = 0;
-  const stepMs = 100; // fixed timestep
+  const stepMs = 100;
 
   function start() {
     if (running) return; running = true;
@@ -39,14 +36,17 @@ export function createGameController() {
     acc += dt;
 
     while (acc >= stepMs) {
-      // Keep legacy engine call inside while (commented until wired)
-      // engineTick(state);
+      // --- TEMP BRIDGE: keep legacy world advancing ---
+      engineTick(state);
+
+      // --- New world: per-feature listeners advance here ---
       emit("TICK", { stepMs, now });
+
       acc -= stepMs;
     }
 
-    emit("RENDER");      // UIs should read via selectors on this pulse
-    saveDebounced(state);
+    emit("RENDER");          // UIs pull via selectors
+    saveDebounced(state);    // keep autosave behaviour
     requestAnimationFrame(loop);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,8 @@
 import { createGameController } from "./game/GameController.js";
-import { mountProficiencyUI } from "./features/proficiency/ui/weaponProficiencyDisplay.js";
+import { mountAllFeatureUIs } from "./features/index.js";
 
 const game = createGameController();
+mountAllFeatureUIs(game.state);
 game.start();
 
-mountProficiencyUI(game.state);
-
-// Optionally expose for debug:
-// window.game = game;
+// window.game = game; // optional for debug


### PR DESCRIPTION
## Summary
- Run legacy `engineTick` inside the controller loop before emitting `TICK` events
- Add `mountAllFeatureUIs` to mount migrated feature UIs centrally
- Entry mounts feature UIs then starts the game controller

## Testing
- ⚠️ `npm test` (fails: no test specified)
- ⚠️ `npm run validate` (fails: requires documenting new files)


------
https://chatgpt.com/codex/tasks/task_e_68a521583c688326ac5e3c07f584660e