### PR TITLE
Replace hunt automation with adventure and adjust meditation

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -250,7 +250,7 @@ S = {
   buildingBonuses: { /* calculated bonuses */ },
   
   // Auto systems
-  auto: { meditate: true, brewQi: false, hunt: false }
+  auto: { meditate: true, brewQi: false, adventure: false }
 }
 ```
 

--- a/index.html
+++ b/index.html
@@ -824,40 +824,12 @@
       <section id="tab-combat">
         <div class="cards">
           <div class="card">
-            <h4>Spirit Beast Hunts</h4>
-            <p class="muted">Hunt beasts for stones and loot. Affixes add spice.</p>
-            <div class="row">
-              <select id="beastSelect" class="btn"></select>
-              <button class="btn primary" id="huntBtn">⚔️ Start Hunt</button>
-            </div>
-            <div class="muted" id="huntStatus">No active hunt.</div>
-            <div class="progress-wrap" style="margin-top:10px">
-              <span class="badge">Enemy HP</span>
-              <div class="bar" style="flex:1"><div class="fill" id="enemyFill"></div></div>
-              <span id="enemyHpTxt">—</span>
-            </div>
-            <div class="progress-wrap" style="margin-top:6px">
-              <span class="badge">Your HP</span>
-              <div class="bar" style="flex:1"><div class="fill" id="ourFill"></div></div>
-              <span id="ourHpTxt">—</span>
-            </div>
-            <p class="muted">Affixes: <span id="affixList">None</span></p>
-            <div class="row" style="margin-top:8px">
-              <button class="btn small" id="techSlash">🗡️ Sword Slash</button>
-              <button class="btn small" id="techGuard">🛡️ Guard</button>
-              <button class="btn small" id="techBurst">💥 Qi Burst</button>
-            </div>
-            <p class="muted" id="techStatus"></p>
-          </div>
-
-          <div class="card">
             <h4>Combat Stats</h4>
             <div class="stat"><span>Your ATK</span><span id="atkVal2">5</span></div>
             <div class="stat"><span>Your DEF</span><span id="defVal2">2</span></div>
             <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%"><span>🛡 Armor</span><span id="armorVal2">0</span></div>
             <div class="stat"><span>Accuracy</span><span id="accuracyVal2">0</span></div>
             <div class="stat"><span>Dodge</span><span id="dodgeVal2">0</span></div>
-            <div class="stat"><span>Estimated Win Chance</span><span id="winEst">—</span></div>
           </div>
         </div>
       </section>

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -47,7 +47,7 @@ export const defaultState = () => {
   gather:{herbs:0, ore:0, wood:0},
   yieldMult:{herbs:0, ore:0, wood:0},
   alchemy:{level:1, xp:0, queue:[], maxSlots:1, successBonus:0, unlocked:false, knownRecipes:['qi']}, // Start with only Qi recipe
-  combat:{hunt:null, cds:{slash:0,guard:0,burst:0}, guardUntil:0, techniques:{}},
+  combat:{ techniques:{} },
   abilityCooldowns:{},
   actionQueue:[],
   bought:{},
@@ -55,7 +55,7 @@ export const defaultState = () => {
   karma:{qiRegen:0, yield:0, atk:0, def:0},
   // Auto systems - players now begin with meditation disabled and must
   // explicitly start cultivating via the UI.
-  auto:{meditate:false, brewQi:false, hunt:false},
+  auto:{meditate:false, brewQi:false, adventure:false},
   // Activity System - only one can be active at a time
   activities: {
     cultivation: false,


### PR DESCRIPTION
## Summary
- Drop obsolete hunting UI and logic
- Add auto-adventure toggle and state tracking
- Prevent auto meditation while any activity runs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a5bdd07c308326b18fd0ae6e0c0ff5