### PR TITLE
feat: add cooking feature slice

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -115,6 +115,13 @@ way-of-ascension/
 │   │   │   ├── state.js
 │   │   │   ├── statusEngine.js
 │   │   │   └── ui/
+│   │   ├── cooking/
+│   │   │   ├── logic.js
+│   │   │   ├── mutators.js
+│   │   │   ├── selectors.js
+│   │   │   ├── state.js
+│   │   │   └── ui/
+│   │   │       └── cookingDisplay.js
 │   │   ├── inventory/
 │   │   │   ├── data/
 │   │   │   ├── logic.js
@@ -152,6 +159,15 @@ way-of-ascension/
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
 │   │   │   └── ui/
+│   │   ├── sect/
+│   │   │   ├── data/
+│   │   │   │   └── buildings.js
+│   │   │   ├── logic.js
+│   │   │   ├── mutators.js
+│   │   │   ├── selectors.js
+│   │   │   ├── state.js
+│   │   │   └── ui/
+│   │   │       └── sectScreen.js
 │   │   └── weaponGeneration/
 │   │       ├── data/
 │   │       │   ├── materials.stub.js
@@ -608,3 +624,18 @@ Paths added:
 - `src/features/combat/statusEngine.js` – Internal status effect stacking and duration handler.
 - `src/features/combat/data/status.js` – Definitions for all status effects.
 - `src/features/combat/data/statusesByElement.js` – Maps elements to their default status applications.
+
+### Cooking Feature (`src/features/cooking/`)
+- `src/features/cooking/state.js` – Cooking level, experience, and success bonus.
+- `src/features/cooking/mutators.js` – Manage cooking actions and food slot equipment.
+- `src/features/cooking/selectors.js` – Access success bonus and other cooking state.
+- `src/features/cooking/logic.js` – Handle cooking, food slot usage, and UI updates.
+- `src/features/cooking/ui/cookingDisplay.js` – Sidebar display for cooking progress.
+
+### Sect Feature (`src/features/sect/`)
+- `src/features/sect/state.js` – Sect buildings and resources.
+- `src/features/sect/mutators.js` – Mutators for building and upgrading sect structures.
+- `src/features/sect/selectors.js` – Accessors for sect data.
+- `src/features/sect/logic.js` – Core sect calculations and mechanics.
+- `src/features/sect/data/buildings.js` – Building definitions and costs.
+- `src/features/sect/ui/sectScreen.js` – UI for managing the sect.

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -32,6 +32,7 @@ import {
 } from '../../ui/fx/fx.js';
 import { updateZoneButtons, updateAreaGrid } from './ui/zoneUI.js';
 import { updateAdventureProgressBar } from './ui/progressBar.js';
+import { updateFoodSlots } from '../cooking/logic.js';
 
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 
@@ -1023,30 +1024,6 @@ export function setupAdventureTabs() {
   tabsInitialized = true;
 }
 
-export function updateFoodSlots() {
-  if (!S.foodSlots) {
-    S.foodSlots = {
-      slot1: null,
-      slot2: null,
-      slot3: null,
-      lastUsed: 0,
-      cooldown: 5000
-    };
-  }
-  setText('rawMeatCount', S.meat || 0);
-  setText('inventoryRawMeat', S.meat || 0);
-  setText('inventoryCookedMeat', S.cookedMeat || 0);
-  setText('inventoryRawMeatAdventure', S.meat || 0);
-  setText('inventoryCookedMeatAdventure', S.cookedMeat || 0);
-  const cookInput = document.getElementById('cookAmount');
-  if (cookInput) {
-    cookInput.max = S.meat || 0;
-    if (parseInt(cookInput.value) > (S.meat || 0)) {
-      cookInput.value = Math.max(1, S.meat || 0);
-    }
-  }
-}
-
 function findEnemyInfo(type) {
   for (const zone of ZONES) {
     for (const area of zone.areas) {
@@ -1178,7 +1155,7 @@ export function updateActivityAdventure() {
   updateBattleDisplay();
   updateAbilityBar();
   updateAdventureCombat();
-  updateFoodSlots();
+  updateFoodSlots(S);
   updateProgressButton();
   updateBestiaryList();
 }

--- a/src/features/cooking/logic.js
+++ b/src/features/cooking/logic.js
@@ -1,0 +1,119 @@
+import { setText, log } from '../../game/utils.js';
+
+export function updateFoodSlots(state) {
+  if (!state.foodSlots) {
+    state.foodSlots = {
+      slot1: null,
+      slot2: null,
+      slot3: null,
+      lastUsed: 0,
+      cooldown: 5000,
+    };
+  }
+  setText('rawMeatCount', state.meat || 0);
+  setText('inventoryRawMeat', state.meat || 0);
+  setText('inventoryCookedMeat', state.cookedMeat || 0);
+  setText('inventoryRawMeatAdventure', state.meat || 0);
+  setText('inventoryCookedMeatAdventure', state.cookedMeat || 0);
+  const cookInput = document.getElementById('cookAmount');
+  if (cookInput) {
+    cookInput.max = state.meat || 0;
+    if (parseInt(cookInput.value) > (state.meat || 0)) {
+      cookInput.value = Math.max(1, state.meat || 0);
+    }
+  }
+}
+
+export function cookMeat(amount, state) {
+  const amt = parseInt(amount) || 1;
+  if ((state.meat || 0) < amt) {
+    log('Not enough raw meat!', 'bad');
+    return;
+  }
+  const yieldBonus = (state.cooking.level - 1) * 0.1;
+  let cookedAmount = amt;
+  for (let i = 0; i < amt; i++) {
+    if (Math.random() < yieldBonus) cookedAmount++;
+  }
+  state.meat -= amt;
+  state.cookedMeat = (state.cookedMeat || 0) + cookedAmount;
+  const expGain = amt * 10;
+  state.cooking.exp += expGain;
+  while (state.cooking.exp >= state.cooking.expMax) {
+    state.cooking.exp -= state.cooking.expMax;
+    state.cooking.level++;
+    state.cooking.expMax = Math.floor(state.cooking.expMax * 1.2);
+    log(`Cooking level increased to ${state.cooking.level}!`, 'good');
+  }
+  const bonusText = cookedAmount > amt ? ` (+${cookedAmount - amt} bonus)` : '';
+  log(`Cooked ${amt} meat into ${cookedAmount} cooked meat${bonusText}!`, 'good');
+  updateFoodSlots(state);
+}
+
+export function equipFood(foodType, slotNumber, state) {
+  if (!state.foodSlots) {
+    state.foodSlots = {
+      slot1: null,
+      slot2: null,
+      slot3: null,
+      lastUsed: 0,
+      cooldown: 5000,
+    };
+  }
+  const slotKey = `slot${slotNumber}`;
+  if (foodType === 'meat' && (state.meat || 0) === 0) {
+    log('No raw meat to equip!', 'bad');
+    return;
+  }
+  if (foodType === 'cookedMeat' && (state.cookedMeat || 0) === 0) {
+    log('No cooked meat to equip!', 'bad');
+    return;
+  }
+  state.foodSlots[slotKey] = foodType;
+  log(`Equipped ${foodType === 'meat' ? 'raw meat' : 'cooked meat'} to slot ${slotNumber}!`, 'good');
+}
+
+export function useFoodSlot(slotNumber, state) {
+  if (!state.foodSlots) return;
+  const slotKey = `slot${slotNumber}`;
+  const foodType = state.foodSlots[slotKey];
+  if (!foodType) {
+    log('No food equipped in this slot!', 'bad');
+    return;
+  }
+  const now = Date.now();
+  if (now - state.foodSlots.lastUsed < state.foodSlots.cooldown) {
+    const remaining = Math.ceil((state.foodSlots.cooldown - (now - state.foodSlots.lastUsed)) / 1000);
+    log(`Food is on cooldown! ${remaining}s remaining.`, 'bad');
+    return;
+  }
+  if (foodType === 'meat' && (state.meat || 0) === 0) {
+    log('No raw meat available!', 'bad');
+    return;
+  }
+  if (foodType === 'cookedMeat' && (state.cookedMeat || 0) === 0) {
+    log('No cooked meat available!', 'bad');
+    return;
+  }
+  if (state.hp >= state.hpMax) {
+    log('HP is already full!', 'bad');
+    return;
+  }
+  let healAmount = 0;
+  if (foodType === 'meat') {
+    state.meat--;
+    healAmount = 20;
+  } else if (foodType === 'cookedMeat') {
+    state.cookedMeat--;
+    healAmount = 40;
+  }
+  const oldHP = state.hp;
+  state.hp = Math.min(state.hpMax, state.hp + healAmount);
+  const actualHeal = state.hp - oldHP;
+  state.foodSlots.lastUsed = now;
+  log(`Used ${foodType === 'meat' ? 'raw meat' : 'cooked meat'} and restored ${actualHeal} HP!`, 'good');
+  if (state.adventure && state.adventure.inCombat) {
+    state.adventure.playerHP = state.hp;
+  }
+  updateFoodSlots(state);
+}

--- a/src/features/cooking/mutators.js
+++ b/src/features/cooking/mutators.js
@@ -1,0 +1,14 @@
+import { S } from '../../game/state.js';
+import { cookMeat as logicCookMeat, equipFood as logicEquipFood, useFoodSlot as logicUseFoodSlot } from './logic.js';
+
+export function cookMeat(amount, state = S) {
+  logicCookMeat(amount, state);
+}
+
+export function equipFood(foodType, slot, state = S) {
+  logicEquipFood(foodType, slot, state);
+}
+
+export function useFoodSlot(slot, state = S) {
+  logicUseFoodSlot(slot, state);
+}

--- a/src/features/cooking/selectors.js
+++ b/src/features/cooking/selectors.js
@@ -1,0 +1,14 @@
+import { S } from '../../game/state.js';
+
+export function getCookingState(state = S) {
+  return state.cooking || { level: 1, exp: 0, expMax: 100, successBonus: 0 };
+}
+
+export function getCookingSuccessBonus(state = S) {
+  return getCookingState(state).successBonus || 0;
+}
+
+export function getCookingYieldBonus(state = S) {
+  const lvl = getCookingState(state).level || 1;
+  return (lvl - 1) * 0.1;
+}

--- a/src/features/cooking/state.js
+++ b/src/features/cooking/state.js
@@ -1,0 +1,6 @@
+export const cookingState = {
+  level: 1,
+  exp: 0,
+  expMax: 100,
+  successBonus: 0,
+};

--- a/src/features/cooking/ui/cookingDisplay.js
+++ b/src/features/cooking/ui/cookingDisplay.js
@@ -1,0 +1,46 @@
+import { S } from '../../../game/state.js';
+import { setText, setFill } from '../../../game/utils.js';
+import { on } from '../../../shared/events.js';
+import { getCookingYieldBonus } from '../selectors.js';
+import { cookMeat, equipFood, useFoodSlot } from '../mutators.js';
+import { updateFoodSlots } from '../logic.js';
+
+export function updateActivityCooking(state = S) {
+  if (!state.cooking) {
+    state.cooking = { level: 1, exp: 0, expMax: 100, successBonus: 0 };
+  }
+  setText('cookingLevel', state.cooking.level);
+  setText('cookingExp', state.cooking.exp);
+  setText('cookingExpMax', state.cooking.expMax);
+  const yieldBonus = getCookingYieldBonus(state) * 100;
+  setText('cookingYieldBonus', `${yieldBonus}%`);
+  setText('currentYieldBonus', yieldBonus);
+  const progressFill = document.getElementById('cookingProgressFill');
+  if (progressFill) {
+    progressFill.style.width = (state.cooking.exp / state.cooking.expMax * 100) + '%';
+  }
+  const cookButton = document.getElementById('cookMeatButton');
+  if (cookButton) {
+    cookButton.disabled = (state.meat || 0) === 0;
+  }
+  updateFoodSlots(state);
+}
+
+export function updateCookingSidebar(state = S) {
+  if (!state.cooking) return;
+  setText('cookingLevelSidebar', `Level ${state.cooking.level}`);
+  setFill('cookingProgressFillSidebar', state.cooking.exp / state.cooking.expMax);
+  setText('cookingProgressTextSidebar', `${state.cooking.exp} / ${state.cooking.expMax} XP`);
+}
+
+export function mountCookingUI(state = S) {
+  on('RENDER', () => {
+    updateActivityCooking(state);
+    updateCookingSidebar(state);
+  });
+  window.cookMeat = amount => cookMeat(amount, state);
+  window.equipFood = (type, slot) => equipFood(type, slot, state);
+  window.useFoodSlot = slot => useFoodSlot(slot, state);
+  updateActivityCooking(state);
+  updateCookingSidebar(state);
+}

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -3,12 +3,14 @@
 
 import { mountProficiencyUI } from "./proficiency/ui/weaponProficiencyDisplay.js";
 import { mountSectUI } from "./sect/ui/sectScreen.js";
+import { mountCookingUI } from "./cooking/ui/cookingDisplay.js";
 // Example placeholder for later:
 // import { mountWeaponGenUI } from "./weaponGeneration/ui/weaponGenerationDisplay.js";
 
 export function mountAllFeatureUIs(state) {
   mountProficiencyUI(state);
   mountSectUI(state);
+  mountCookingUI(state);
   // mountWeaponGenUI?.(state);
 }
 

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -3,6 +3,7 @@ import { LAWS } from './data/laws.js';
 import { progressionState } from './state.js';
 import { getWeaponProficiencyBonuses } from '../proficiency/selectors.js';
 import { getBuildingBonuses } from '../sect/selectors.js';
+import { getCookingSuccessBonus } from '../cooking/selectors.js';
 
 export const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
 
@@ -194,11 +195,11 @@ export function breakthroughChance(state = progressionState){
   base = base * stageMultiplier - realmPenalty;
 
   const ward = state.pills.ward>0 ? 0.15 : 0;
-  const alchemyBonus = state.alchemy.successBonus * 0.1;
+  const cookingBonus = getCookingSuccessBonus(state) * 0.1;
   const buildingBonus = getBuildingBonuses(state).breakthroughBonus || 0;
   const cultivationBonus = (state.cultivation.talent - 1) * 0.1;
 
-  const totalChance = base + ward + alchemyBonus + buildingBonus + cultivationBonus;
+  const totalChance = base + ward + cookingBonus + buildingBonus + cultivationBonus;
 
   return clamp(totalChance, 0.01, 0.95);
 }

--- a/src/features/progression/state.js
+++ b/src/features/progression/state.js
@@ -26,7 +26,6 @@ export const progressionState = {
   tempDef: 0,
   karma: { qiRegen: 0, atk: 0, def: 0 },
   pills: { ward: 0 },
-  alchemy: { successBonus: 0 },
   stats: {
     physique: 10,
     mind: 10,

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -63,7 +63,9 @@ export const migrations = [
   },
   save => {
     if (typeof save.cooking === 'undefined') {
-      save.cooking = { level: 1, exp: 0, expMax: 100 };
+      save.cooking = { level: 1, exp: 0, expMax: 100, successBonus: 0 };
+    } else if (typeof save.cooking.successBonus === 'undefined') {
+      save.cooking.successBonus = 0;
     }
     if (save.activities && typeof save.activities.cooking === 'undefined') {
       save.activities.cooking = false;

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -79,7 +79,8 @@ export const defaultState = () => {
   cooking: {
     level: 1,
     exp: 0,
-    expMax: 100
+    expMax: 100,
+    successBonus: 0,
   },
   adventure: {
     currentZone: 0,

--- a/ui/index.js
+++ b/ui/index.js
@@ -35,10 +35,10 @@ import { initializeWeaponChip, updateWeaponChip } from '../src/features/inventor
 import {
   updateActivityAdventure,
   updateAdventureCombat,
-  updateFoodSlots,
   setupAdventureTabs,
   updateAbilityBar
 } from '../src/features/adventure/logic.js';
+import { updateActivityCooking, updateCookingSidebar } from '../src/features/cooking/ui/cookingDisplay.js';
 import {
   startAdventureCombat,
   startBossCombat,
@@ -257,9 +257,7 @@ function updateAll(){
   setText('miningProgressText', `${fmt(S.mining.exp)} / ${fmt(S.mining.expMax)} XP`);
   setText('miningLevel', `Level ${S.mining.level}`);
 
-  setFill('cookingProgressFillSidebar', S.cooking.exp / S.cooking.expMax);
-  setText('cookingProgressTextSidebar', `${fmt(S.cooking.exp)} / ${fmt(S.cooking.expMax)} XP`);
-  setText('cookingLevelSidebar', `Level ${S.cooking.level}`);
+  updateCookingSidebar();
 
   const currentZone = ZONES[S.adventure.currentZone];
   const currentArea = currentZone ? currentZone.areas[S.adventure.currentArea] : null;
@@ -921,193 +919,6 @@ function updateMiningRateDisplays() {
 }
 
 
-function updateActivityCooking() {
-  // Initialize cooking data if not exists
-  if (!S.cooking) {
-    S.cooking = {
-      level: 1,
-      exp: 0,
-      expMax: 100
-    };
-  }
-  
-  // Initialize food slots if not exists
-  if (!S.foodSlots) {
-    S.foodSlots = {
-      slot1: null,
-      slot2: null,
-      slot3: null,
-      lastUsed: 0,
-      cooldown: 5000
-    };
-  }
-  
-  // Initialize meat if not exists
-  if (S.meat === undefined) S.meat = 0;
-  if (S.cookedMeat === undefined) S.cookedMeat = 0;
-  
-  // Update cooking skill display
-  setText('cookingLevel', S.cooking.level);
-  setText('cookingExp', S.cooking.exp);
-  setText('cookingExpMax', S.cooking.expMax);
-  
-  const yieldBonus = (S.cooking.level - 1) * 10;
-  setText('cookingYieldBonus', yieldBonus + '%');
-  setText('currentYieldBonus', yieldBonus);
-  
-  // Update progress bar
-  const progressFill = document.getElementById('cookingProgressFill');
-  if (progressFill) {
-    progressFill.style.width = (S.cooking.exp / S.cooking.expMax * 100) + '%';
-  }
-  
-  // Update cook button
-  const cookButton = document.getElementById('cookMeatButton');
-  if (cookButton) {
-    cookButton.disabled = (S.meat || 0) === 0;
-  }
-  
-  // Update food slots
-  updateFoodSlots();
-}
-
-// Food System Functions
-function cookMeat() {
-  const amount = parseInt(document.getElementById('cookAmount').value) || 1;
-  
-  if ((S.meat || 0) < amount) {
-    log('Not enough raw meat!', 'bad');
-    return;
-  }
-  
-  // Calculate yield with cooking bonus
-  const yieldBonus = (S.cooking.level - 1) * 0.1; // 10% per level
-  let cookedAmount = amount;
-  
-  // Apply yield bonus (chance for extra cooked meat)
-  for (let i = 0; i < amount; i++) {
-    if (Math.random() < yieldBonus) {
-      cookedAmount++;
-    }
-  }
-  
-  // Consume raw meat and produce cooked meat
-  S.meat -= amount;
-  S.cookedMeat = (S.cookedMeat || 0) + cookedAmount;
-  
-  // Add cooking experience
-  const expGain = amount * 10; // 10 exp per meat cooked
-  S.cooking.exp += expGain;
-  
-  // Check for level up
-  while (S.cooking.exp >= S.cooking.expMax) {
-    S.cooking.exp -= S.cooking.expMax;
-    S.cooking.level++;
-    S.cooking.expMax = Math.floor(S.cooking.expMax * 1.2); // 20% increase per level
-    log(`Cooking level increased to ${S.cooking.level}!`, 'good');
-  }
-  
-  const bonusText = cookedAmount > amount ? ` (+${cookedAmount - amount} bonus)` : '';
-  log(`Cooked ${amount} meat into ${cookedAmount} cooked meat${bonusText}!`, 'good');
-  
-  updateAll();
-}
-
-function equipFood(foodType, slotNumber) {
-  if (!S.foodSlots) {
-    S.foodSlots = {
-      slot1: null,
-      slot2: null,
-      slot3: null,
-      lastUsed: 0,
-      cooldown: 5000
-    };
-  }
-  
-  const slotKey = `slot${slotNumber}`;
-  
-  // Check if we have the food
-  if (foodType === 'meat' && (S.meat || 0) === 0) {
-    log('No raw meat to equip!', 'bad');
-    return;
-  }
-  if (foodType === 'cookedMeat' && (S.cookedMeat || 0) === 0) {
-    log('No cooked meat to equip!', 'bad');
-    return;
-  }
-  
-  // Equip the food
-  S.foodSlots[slotKey] = foodType;
-  
-  log(`Equipped ${foodType === 'meat' ? 'raw meat' : 'cooked meat'} to slot ${slotNumber}!`, 'good');
-  updateAll();
-}
-
-function useFoodSlot(slotNumber) {
-  if (!S.foodSlots) return;
-  
-  const slotKey = `slot${slotNumber}`;
-  const foodType = S.foodSlots[slotKey];
-  
-  if (!foodType) {
-    log('No food equipped in this slot!', 'bad');
-    return;
-  }
-  
-  // Check cooldown
-  const now = Date.now();
-  if (now - S.foodSlots.lastUsed < S.foodSlots.cooldown) {
-    const remaining = Math.ceil((S.foodSlots.cooldown - (now - S.foodSlots.lastUsed)) / 1000);
-    log(`Food is on cooldown! ${remaining}s remaining.`, 'bad');
-    return;
-  }
-  
-  // Check if we have the food
-  if (foodType === 'meat' && (S.meat || 0) === 0) {
-    log('No raw meat available!', 'bad');
-    return;
-  }
-  if (foodType === 'cookedMeat' && (S.cookedMeat || 0) === 0) {
-    log('No cooked meat available!', 'bad');
-    return;
-  }
-  
-  // Check if HP is full
-  if (S.hp >= S.hpMax) {
-    log('HP is already full!', 'bad');
-    return;
-  }
-  
-  // Consume food and restore HP
-  let healAmount = 0;
-  if (foodType === 'meat') {
-    S.meat--;
-    healAmount = 20;
-  } else if (foodType === 'cookedMeat') {
-    S.cookedMeat--;
-    healAmount = 40;
-  }
-  
-  const oldHP = S.hp;
-  S.hp = Math.min(S.hpMax, S.hp + healAmount);
-  const actualHeal = S.hp - oldHP;
-  
-  S.foodSlots.lastUsed = now;
-  
-  log(`Used ${foodType === 'meat' ? 'raw meat' : 'cooked meat'} and restored ${actualHeal} HP!`, 'good');
-  
-  // Update adventure HP if in combat
-  if (S.adventure && S.adventure.inCombat) {
-    S.adventure.playerHP = S.hp;
-  }
-  
-  updateAll();
-}
-
-
-
-
-
 // Update sidebar activity displays
 function updateSidebarActivities() {
   // Update cultivation
@@ -1158,18 +969,7 @@ function updateSidebarActivities() {
     }
   }
   
-  // Update cooking (alchemy system)
-  if (S.alchemy) {
-    setText('cookingLevelSidebar', `Level ${S.alchemy.level}`);
-    const cookingFill = document.getElementById('cookingProgressFillSidebar');
-    if (cookingFill) {
-      // Calculate alchemy experience progress (if xp and level system exists)
-      const expRequired = S.alchemy.level * 100; // Basic progression formula
-      const progressPct = S.alchemy.xp ? Math.floor((S.alchemy.xp % expRequired) / expRequired * 100) : 0;
-      cookingFill.style.width = progressPct + '%';
-      setText('cookingProgressTextSidebar', progressPct + '%');
-    }
-  }
+  updateCookingSidebar();
   
   // Update sect status indicator
   const sectStatus = document.getElementById('sectStatus');


### PR DESCRIPTION
## Summary
- add dedicated cooking slice with state, mutators, selectors, and UI mount
- move food slot logic from adventure into cooking module and expose success bonus to progression via selector
- clean up old cooking code and wire sidebar/UI to new feature
- ensure adventure logic passes game state to cooking updater
- document cooking and sect modules in project structure

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`

------
https://chatgpt.com/codex/tasks/task_e_68a5d4f46c9883268305376e55f465ff