### PR TITLE
refactor: centralize realm ui under progression feature

### DIFF
--- a/docs/ai-verification-protocol.md
+++ b/docs/ai-verification-protocol.md
@@ -83,7 +83,7 @@ const coreFiles = [
   'src/features/progression/logic.js',
   'src/features/adventure/logic.js',
   'ui/index.js',
-  'ui/realm.js',
+  'src/features/progression/ui/realm.js',
   'index.html',
   'style.css'
 ];

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -158,7 +158,9 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── index.js
 │   │   │   └── ui/
+│   │   │       └── realm.js
 │   │   ├── sect/
 │   │   │   ├── data/
 │   │   │   │   └── buildings.js
@@ -208,8 +210,7 @@ way-of-ascension/
 ├── ui/
 │   ├── components/
 │   │   └── progressBar.js
-│   ├── index.js
-│   └── realm.js
+│   └── index.js
 ├── README.md
 ├── CHANGELOG.md
 ├── eslint.config.mjs
@@ -490,7 +491,7 @@ function updateAll() {
 
 **When to modify**: Add new UI elements, modify display logic, add event handlers
 
-#### `realm.js` - Realm UI Components
+#### `src/features/progression/ui/realm.js` - Realm UI Components
 **Purpose**: Realm-specific UI components and cultivation displays
 **When to modify**: Add new realm UI features, modify cultivation interface
 
@@ -549,6 +550,9 @@ function updateAll() {
 #### `src/features/progression/selectors.js` - Progression Selectors
 **Purpose**: Expose derived values like qi capacity, regeneration, and law bonuses.
 **Key Functions**: `qCap(state)`, `qiRegenPerSec(state)`, `getLawBonuses(state)`.
+
+#### `src/features/progression/index.js` - Progression Feature Exports
+**Purpose**: Re-exports realm UI hooks and mutators for easier consumption.
 
 #### `src/features/progression/logic.js` - Progression Calculations
 **Purpose**: Core formulas for cultivation and combat stats.

--- a/src/features/progression/index.js
+++ b/src/features/progression/index.js
@@ -1,0 +1,9 @@
+export {
+  updateRealmUI,
+  updateActivityCultivation,
+  updateBreakthrough,
+  initRealmUI,
+  getRealmName,
+} from './ui/realm.js';
+
+export { advanceRealm, checkLawUnlocks, awardLawPoints } from './mutators.js';

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -1,8 +1,8 @@
 /* Realm-specific logic and UI updates */
 
-import { REALMS } from '../src/features/progression/data/realms.js';
-import { LAWS } from '../src/features/progression/data/laws.js';
-import { S } from '../src/game/state.js';
+import { REALMS } from '../data/realms.js';
+import { LAWS } from '../data/laws.js';
+import { S } from '../../../game/state.js';
 import {
   qCap,
   qiRegenPerSec,
@@ -10,9 +10,9 @@ import {
   foundationGainPerSec,
   powerMult,
   breakthroughChance
-} from '../src/features/progression/selectors.js';
-import { advanceRealm, checkLawUnlocks, awardLawPoints } from '../src/features/progression/mutators.js';
-import { qs, setText, log } from '../src/game/utils.js';
+} from '../selectors.js';
+import { advanceRealm, checkLawUnlocks, awardLawPoints } from '../mutators.js';
+import { qs, setText, log } from '../../../game/utils.js';
 
 export function getRealmName(tier) {
   return REALMS[tier].name;
@@ -426,4 +426,3 @@ export function initRealmUI(){
   if (breakthroughBtn) breakthroughBtn.addEventListener('click', tryBreakthrough);
 }
 
-export { advanceRealm, checkLawUnlocks, awardLawPoints };

--- a/ui/index.js
+++ b/ui/index.js
@@ -24,10 +24,10 @@ import {
   updateRealmUI,
   updateActivityCultivation,
   updateBreakthrough,
-  checkLawUnlocks,
   initRealmUI,
-  getRealmName
-} from './realm.js';
+  getRealmName,
+  checkLawUnlocks,
+} from '../src/features/progression/index.js';
 import { qs, setText, setFill, log } from '../src/game/utils.js';
 import { createProgressBar, updateProgressBar } from './components/progressBar.js';
 import { renderSidebarActivities } from '../src/ui/sidebar.js';
@@ -592,7 +592,7 @@ function stopActivity(activityName) {
   updateActivityContent();
 }
 
-// Expose activity controls globally so other modules like realm.js can access
+// Expose activity controls globally so other modules like the progression realm UI can access
 // them when binding UI event handlers. Without this, the cultivation start/stop
 // button fails to toggle the activity state.
 window.startActivity = startActivity;


### PR DESCRIPTION
## Summary
- move realm UI module into `src/features/progression/ui`
- export realm update hooks through a new progression index
- fix progression realm imports to reference game state and utilities
- update docs and imports to reflect new structure

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: undocumented karma files)*

------
https://chatgpt.com/codex/tasks/task_e_68a6011d5478832694bdb36402ae2a96