### PR TITLE
feat: add mining feature slice

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -169,6 +169,12 @@ way-of-ascension/
 │   │   │   └── ui/
 │   │   │       └── sectScreen.js
 │   │   ├── karma/
+│   │   │   ├── logic.js
+│   │   │   ├── mutators.js
+│   │   │   ├── selectors.js
+│   │   │   ├── state.js
+│   │   │   └── ui/
+│   │   │       └── karmaDisplay.js
 │   │   ├── alchemy/
 │   │   │   ├── data/
 │   │   │   │   └── recipes.js
@@ -177,8 +183,16 @@ way-of-ascension/
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
 │   │   │   └── ui/
-│   │   │       └── karmaDisplay.js
 │   │   │       └── alchemyDisplay.js
+│   │   ├── mining/
+│   │   │   ├── logic.js
+│   │   │   ├── mutators.js
+│   │   │   ├── selectors.js
+│   │   │   ├── state.js
+│   │   │   └── ui/
+│   │   │       └── miningDisplay.js
+│   │   ├── physique/
+│   │   │   └── state.js
 │   │   └── weaponGeneration/
 │   │       ├── data/
 │   │       │   ├── materials.stub.js
@@ -641,6 +655,16 @@ Paths added:
 - `src/features/karma/mutators.js` – Modifies karma points and upgrade values.
 - `src/features/karma/selectors.js` – Accessors for karma points and bonus values.
 - `src/features/karma/ui/karmaDisplay.js` – Displays karma information in the cultivation stats tab.
+
+### Mining Feature (`src/features/mining/`)
+- `src/features/mining/state.js` – Tracks mining level, experience, unlocked resources and yields.
+- `src/features/mining/logic.js` – Handles mining rates, resource gains and experience progression.
+- `src/features/mining/mutators.js` – External wrappers to modify mining state.
+- `src/features/mining/selectors.js` – Provides accessors for mining state and derived rates.
+- `src/features/mining/ui/miningDisplay.js` – Updates mining activity and sidebar displays.
+
+### Physique Feature (`src/features/physique/`)
+- `src/features/physique/state.js` – Stores level, experience and stamina for physique training.
 =======
 ### Alchemy Feature
 - `src/features/alchemy/data/recipes.js` – Basic pill recipes with brew times and rewards.

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -6,6 +6,7 @@ import { mountSectUI } from "./sect/ui/sectScreen.js";
 import { mountKarmaUI } from "./karma/ui/karmaDisplay.js";
 import { mountAlchemyUI } from "./alchemy/ui/alchemyDisplay.js";
 import { mountCookingUI } from "./cooking/ui/cookingDisplay.js";
+import { mountMiningUI } from "./mining/ui/miningDisplay.js";
 
 // Example placeholder for later:
 // import { mountWeaponGenUI } from "./weaponGeneration/ui/weaponGenerationDisplay.js";
@@ -16,6 +17,7 @@ export function mountAllFeatureUIs(state) {
   mountKarmaUI(state);
   mountAlchemyUI(state);
   mountCookingUI(state);
+  mountMiningUI(state);
   // mountWeaponGenUI?.(state);
 }
 

--- a/src/features/mining/logic.js
+++ b/src/features/mining/logic.js
@@ -1,0 +1,46 @@
+import { S } from '../../game/state.js';
+import { log } from '../../game/utils.js';
+
+export function getMiningRate(resource, state = S) {
+  const baseRates = {
+    stones: 3,
+    iron: 1.5,
+    ice: 0.75,
+  };
+  const levelBonus = state.mining?.level ? state.mining.level * 0.1 : 0;
+  return (baseRates[resource] || 1) * (1 + levelBonus);
+}
+
+export function selectResource(resource, state = S) {
+  if (!state.mining) return;
+  if (state.mining.unlockedResources?.includes(resource)) {
+    state.mining.selectedResource = resource;
+    state.mining.resourcesGained = 0;
+    log?.(`Switched mining to ${resource}`, 'good');
+  }
+}
+
+export function advanceMining(state = S) {
+  if (!state.activities?.mining || !state.mining?.selectedResource) return;
+  const totalRate = getMiningRate(state.mining.selectedResource, state);
+  switch (state.mining.selectedResource) {
+    case 'stones':
+      state.stones = (state.stones || 0) + totalRate;
+      break;
+    case 'iron':
+      state.iron = (state.iron || 0) + totalRate;
+      break;
+    case 'ice':
+      state.ice = (state.ice || 0) + totalRate;
+      break;
+  }
+  state.mining.resourcesGained = (state.mining.resourcesGained || 0) + totalRate;
+  const expGain = 0.5;
+  state.mining.exp += expGain;
+  if (state.mining.exp >= state.mining.expMax) {
+    state.mining.level++;
+    state.mining.exp = 0;
+    state.mining.expMax = Math.floor(state.mining.expMax * 1.3);
+    log?.(`Mining level up! Level ${state.mining.level}`, 'good');
+  }
+}

--- a/src/features/mining/mutators.js
+++ b/src/features/mining/mutators.js
@@ -1,0 +1,10 @@
+import { S } from '../../game/state.js';
+import { selectResource as logicSelectResource, advanceMining as logicAdvanceMining } from './logic.js';
+
+export function selectResource(resource, state = S) {
+  logicSelectResource(resource, state);
+}
+
+export function advanceMining(state = S) {
+  logicAdvanceMining(state);
+}

--- a/src/features/mining/selectors.js
+++ b/src/features/mining/selectors.js
@@ -1,0 +1,17 @@
+import { S } from '../../game/state.js';
+import { getMiningRate as logicGetMiningRate } from './logic.js';
+
+export function getMiningState(state = S) {
+  return state.mining || {
+    level: 1,
+    exp: 0,
+    expMax: 100,
+    unlockedResources: ['stones'],
+    selectedResource: 'stones',
+    resourcesGained: 0,
+  };
+}
+
+export function getMiningRate(resource, state = S) {
+  return logicGetMiningRate(resource, state);
+}

--- a/src/features/mining/state.js
+++ b/src/features/mining/state.js
@@ -1,0 +1,8 @@
+export const miningState = {
+  level: 1,
+  exp: 0,
+  expMax: 100,
+  unlockedResources: ['stones'],
+  selectedResource: 'stones',
+  resourcesGained: 0,
+};

--- a/src/features/mining/ui/miningDisplay.js
+++ b/src/features/mining/ui/miningDisplay.js
@@ -1,0 +1,86 @@
+import { S } from '../../../game/state.js';
+import { setText } from '../../../game/utils.js';
+import { on } from '../../../shared/events.js';
+import { getMiningRate } from '../logic.js';
+import { log } from '../../../game/utils.js';
+
+export function updateActivityMining(state = S) {
+  if (!state.mining) return;
+  setText('miningLevelActivity', state.mining.level);
+  setText('miningExpActivity', Math.floor(state.mining.exp));
+  setText('miningExpMaxActivity', state.mining.expMax);
+
+  const resourceNames = { stones: 'Spirit Stones', iron: 'Iron Ore', ice: 'Ice Crystal' };
+  const current = state.activities.mining ? (resourceNames[state.mining.selectedResource] || 'Unknown') : 'Nothing';
+  setText('currentlyMining', current);
+
+  const miningFillActivity = document.getElementById('miningFillActivity');
+  if (miningFillActivity) {
+    miningFillActivity.style.width = (state.mining.exp / state.mining.expMax * 100) + '%';
+  }
+
+  const startBtn = document.getElementById('startMiningActivity');
+  if (startBtn) {
+    startBtn.textContent = state.activities.mining ? '🛑 Stop Mining' : '⛏️ Start Mining';
+    startBtn.onclick = () => state.activities.mining ? window.stopActivity('mining') : window.startActivity('mining');
+  }
+
+  const ironOption = document.getElementById('ironOption');
+  const iceOption = document.getElementById('iceOption');
+  if (ironOption) ironOption.style.display = state.mining.level >= 3 ? 'block' : 'none';
+  if (iceOption) iceOption.style.display = state.mining.level >= 15 ? 'block' : 'none';
+
+  const selectedRadio = document.querySelector(`input[name="miningResource"][value="${state.mining.selectedResource}"]`);
+  if (selectedRadio) selectedRadio.checked = true;
+
+  const miningStatsCard = document.getElementById('miningStatsCard');
+  if (miningStatsCard) miningStatsCard.style.display = state.activities.mining ? 'block' : 'none';
+
+  if (state.activities.mining) {
+    setText('resourcesGained', state.mining.resourcesGained || 0);
+    const baseRate = getMiningRate(state.mining.selectedResource, state);
+    setText('currentMiningRate', `${baseRate.toFixed(1)}/sec`);
+  }
+
+  updateMiningRateDisplays(state);
+}
+
+function updateMiningRateDisplays(state = S) {
+  const stonesRate = getMiningRate('stones', state);
+  const ironRate = getMiningRate('iron', state);
+  const iceRate = getMiningRate('ice', state);
+  setText('stonesRate', `+${stonesRate.toFixed(1)}/sec`);
+  setText('ironRate', `+${ironRate.toFixed(1)}/sec`);
+  setText('iceRate', `+${iceRate.toFixed(1)}/sec`);
+}
+
+export function updateMiningSidebar(state = S) {
+  if (!state.mining) return;
+  setText('miningLevel', `Level ${state.mining.level}`);
+  const miningFill = document.getElementById('miningProgressFill');
+  if (miningFill) {
+    const progressPct = Math.floor(state.mining.exp / state.mining.expMax * 100);
+    miningFill.style.width = progressPct + '%';
+    setText('miningProgressText', progressPct + '%');
+  }
+}
+
+export function mountMiningUI(state = S) {
+  on('RENDER', () => {
+    updateActivityMining(state);
+    updateMiningSidebar(state);
+  });
+
+  const miningResourceInputs = document.querySelectorAll('input[name="miningResource"]');
+  miningResourceInputs.forEach(input => {
+    input.addEventListener('change', e => {
+      if (!state.mining) return;
+      state.mining.selectedResource = e.target.value;
+      state.mining.resourcesGained = 0;
+      log(`Switched mining to ${e.target.value === 'stones' ? 'Spirit Stones' : e.target.value === 'iron' ? 'Iron Ore' : 'Ice Crystal'}`, 'good');
+    });
+  });
+
+  updateActivityMining(state);
+  updateMiningSidebar(state);
+}

--- a/src/features/physique/state.js
+++ b/src/features/physique/state.js
@@ -1,0 +1,7 @@
+export const physiqueState = {
+  level: 1,
+  exp: 0,
+  expMax: 100,
+  stamina: 100,
+  maxStamina: 100,
+};

--- a/src/game/state.js
+++ b/src/game/state.js
@@ -3,6 +3,8 @@ import { runMigrations, SAVE_VERSION } from './migrations.js';
 import { sectState } from '../features/sect/state.js';
 import { recalculateBuildingBonuses } from '../features/sect/mutators.js';
 import { karmaState } from '../features/karma/state.js';
+import { miningState } from '../features/mining/state.js';
+import { physiqueState } from '../features/physique/state.js';
 
 export function loadSave(){
   try{
@@ -68,15 +70,8 @@ export const defaultState = () => {
     cooking: false
   },
   // Activity data containers
-  physique: { level: 1, exp: 0, expMax: 100, stamina: 100, maxStamina: 100 },
-  mining: {
-    level: 1,
-    exp: 0,
-    expMax: 100,
-    unlockedResources: ['stones'],
-    selectedResource: 'stones',
-    resourcesGained: 0
-  },
+  physique: structuredClone(physiqueState),
+  mining: structuredClone(miningState),
   cooking: {
     level: 1,
     exp: 0,

--- a/ui/index.js
+++ b/ui/index.js
@@ -52,6 +52,7 @@ import { renderEquipmentPanel, setupEquipmentTab } from '../src/features/invento
 import { ZONES } from '../src/features/adventure/data/zones.js'; // MAP-UI-UPDATE
 import { setReduceMotion } from '../src/ui/fx/fx.js';
 import { tickAbilityCooldowns } from '../src/features/ability/mutators.js';
+import { advanceMining } from '../src/features/mining/logic.js';
 
 // Global variables
 const progressBars = {};
@@ -237,10 +238,6 @@ function updateAll(){
   setFill('physiqueProgressFill', S.physique.exp / S.physique.expMax);
   setText('physiqueProgressText', `${fmt(S.physique.exp)} / ${fmt(S.physique.expMax)} XP`);
   setText('physiqueLevel', `Level ${S.physique.level}`);
-
-  setFill('miningProgressFill', S.mining.exp / S.mining.expMax);
-  setText('miningProgressText', `${fmt(S.mining.exp)} / ${fmt(S.mining.expMax)} XP`);
-  setText('miningLevel', `Level ${S.mining.level}`);
 
   updateCookingSidebar();
 
@@ -809,93 +806,6 @@ function updateActivityPhysique() {
   }
 }
 
-function updateActivityMining() {
-  // Only update if mining activity is initialized
-  if (!S.mining) return;
-  
-  setText('miningLevelActivity', S.mining.level);
-  setText('miningExpActivity', Math.floor(S.mining.exp));
-  setText('miningExpMaxActivity', S.mining.expMax);
-  
-  // Update currently mining display
-  const resourceNames = {
-    stones: 'Spirit Stones',
-    iron: 'Iron Ore',
-    ice: 'Ice Crystal'
-  };
-  
-  if (S.activities.mining) {
-    setText('currentlyMining', resourceNames[S.mining.selectedResource] || 'Unknown');
-  } else {
-    setText('currentlyMining', 'Nothing');
-  }
-  
-  const miningFillActivity = document.getElementById('miningFillActivity');
-  if (miningFillActivity) {
-    miningFillActivity.style.width = (S.mining.exp / S.mining.expMax * 100) + '%';
-  }
-  
-  const startBtn = document.getElementById('startMiningActivity');
-  if (startBtn) {
-    startBtn.textContent = S.activities.mining ? '🛑 Stop Mining' : '⛏️ Start Mining';
-    startBtn.onclick = () => S.activities.mining ? stopActivity('mining') : startActivity('mining');
-  }
-  
-  // Update resource selection visibility based on level
-  const ironOption = document.getElementById('ironOption');
-  const iceOption = document.getElementById('iceOption');
-  
-  if (ironOption) {
-    ironOption.style.display = S.mining.level >= 3 ? 'block' : 'none';
-  }
-  
-  if (iceOption) {
-    iceOption.style.display = S.mining.level >= 15 ? 'block' : 'none';
-  }
-  
-  // Update selected resource radio button
-  const selectedRadio = document.querySelector(`input[name="miningResource"][value="${S.mining.selectedResource}"]`);
-  if (selectedRadio) {
-    selectedRadio.checked = true;
-  }
-  
-  // Show/hide mining stats card
-  const miningStatsCard = document.getElementById('miningStatsCard');
-  if (miningStatsCard) {
-    miningStatsCard.style.display = S.activities.mining ? 'block' : 'none';
-  }
-  
-  // Update mining stats
-  if (S.activities.mining) {
-    setText('resourcesGained', S.mining.resourcesGained || 0);
-    const baseRate = getMiningRate(S.mining.selectedResource);
-    setText('currentMiningRate', `${baseRate.toFixed(1)}/sec`);
-  }
-  
-  // Update resource rate displays
-  updateMiningRateDisplays();
-}
-
-function getMiningRate(resource) {
-  const baseRates = {
-    stones: 3,
-    iron: 1.5,
-    ice: 0.75
-  };
-  
-  const levelBonus = S.mining.level * 0.1;
-  return (baseRates[resource] || 1) * (1 + levelBonus);
-}
-
-function updateMiningRateDisplays() {
-  const stonesRate = getMiningRate('stones');
-  const ironRate = getMiningRate('iron');
-  const iceRate = getMiningRate('ice');
-
-  setText('stonesRate', `+${stonesRate.toFixed(1)}/sec`);
-  setText('ironRate', `+${ironRate.toFixed(1)}/sec`);
-  setText('iceRate', `+${iceRate.toFixed(1)}/sec`);
-}
 
 
 // Update sidebar activity displays
@@ -921,17 +831,6 @@ function updateSidebarActivities() {
     }
   }
 
-  // Update mining
-  if (S.mining) {
-    setText('miningLevel', `Level ${S.mining.level}`);
-    const miningFill = document.getElementById('miningProgressFill');
-    if (miningFill) {
-      const progressPct = Math.floor(S.mining.exp / S.mining.expMax * 100);
-      miningFill.style.width = progressPct + '%';
-      setText('miningProgressText', progressPct + '%');
-    }
-  }
-  
   // Update adventure
   if (S.adventure) {
     const currentZone = ZONES[S.adventure.currentZone];
@@ -1336,40 +1235,7 @@ function tick(){
   }
   
   // Passive mining progression
-  if(S.activities.mining && S.mining && S.mining.selectedResource) {
-    const totalRate = getMiningRate(S.mining.selectedResource);
-    
-    // Add resources based on selected type
-    switch(S.mining.selectedResource) {
-      case 'stones':
-        S.stones += totalRate;
-        break;
-      case 'iron':
-        if (!S.iron) S.iron = 0;
-        S.iron += totalRate;
-        break;
-      case 'ice':
-        if (!S.ice) S.ice = 0;
-        S.ice += totalRate;
-        break;
-    }
-    
-    // Track resources gained for display
-    if (!S.mining.resourcesGained) S.mining.resourcesGained = 0;
-    S.mining.resourcesGained += totalRate;
-    
-    // Mining experience gain (slower than active training)
-    const expGain = 0.5; // 0.5 exp per second
-    S.mining.exp += expGain;
-    
-    // Level up check
-    if (S.mining.exp >= S.mining.expMax) {
-      S.mining.level++;
-      S.mining.exp = 0;
-      S.mining.expMax = Math.floor(S.mining.expMax * 1.3);
-      log(`Mining level up! Level ${S.mining.level}`, 'good');
-    }
-  }
+  advanceMining(S);
   
   // Physique training progression
   if(S.activities.physique && S.physique) {
@@ -1464,19 +1330,6 @@ function initActivityListeners() {
   // Session-based training event listeners
   document.getElementById('startTrainingSession')?.addEventListener('click', startTrainingSession);
   document.getElementById('hitButton')?.addEventListener('click', executeHit);
-  
-  // Mining resource selection event listeners
-  const miningResourceInputs = document.querySelectorAll('input[name="miningResource"]');
-  miningResourceInputs.forEach(input => {
-    input.addEventListener('change', (e) => {
-      if (S.mining) {
-        S.mining.selectedResource = e.target.value;
-        S.mining.resourcesGained = 0; // Reset counter when switching resources
-        log(`Switched mining to ${e.target.value === 'stones' ? 'Spirit Stones' : e.target.value === 'iron' ? 'Iron Ore' : 'Ice Crystal'}`, 'good');
-        updateActivityMining();
-      }
-    });
-  });
   
   // Adventure Map button event listener - MAP-UI-UPDATE
   document.getElementById('mapButton')?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- create dedicated mining slice with state, logic, selectors, mutators and UI component
- mount mining UI and integrate mining/physique state into game state
- clean up legacy mining logic from main UI

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a638cd0e14832695bfabb9bd319341