### PR TITLE
feat: add feature registry and remove legacy engine tick

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Other folders such as `scripts/` (build or deployment scripts), `browser-tools-m
 
 #### Runtime Orchestration: GameController
 
-`GameController` is the orchestrator for the runtime: it boots the game, runs the fixed‑step main loop, emits events and handles simple routing such as `state.app.mode`. It deliberately avoids business logic; each feature owns its own rules. A temporary bridge calls `engineTick(state)` each step so legacy systems continue to advance while migration is in progress.
+`GameController` is the orchestrator for the runtime: it boots the game, runs the fixed‑step main loop, emits events and handles simple routing such as `state.app.mode`. It deliberately avoids business logic; each feature owns its own rules. Features register `init` and `tick` hooks with a central registry; the controller invokes these ticks each step.
 
 #### Events Bus
 
@@ -39,7 +39,7 @@ Selectors read from state and mutators write to state. User interfaces never mut
 
 #### Migration Process (Incremental)
 
-Keep `progression/logic.js` intact for now; the controller calls it every step. Migrate features one at a time (loot → inventory → affixes → ability → combat → adventure → engine). After a feature is migrated, remove its responsibilities from `progression/logic.js` and replace them with `TICK` listeners or feature‑local logic.
+Keep `progression/logic.js` intact for now; migrate features one at a time (loot → inventory → affixes → ability → combat → adventure → engine). After a feature is migrated, remove its responsibilities from `progression/logic.js` and replace them with registered `tick` hooks or `TICK` listeners.
 
 #### PR Checklist (Short)
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -88,6 +88,7 @@ way-of-ascension/
 │   │   │   ├── selectors.js
 │   │   │   └── state.js
 │   │   ├── index.js
+│   │   ├── registry.js
 │   │   ├── ability/
 │   │   │   ├── data/
 │   │   │   │   └── abilities.js
@@ -121,6 +122,7 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       └── cookingDisplay.js
 │   │   ├── inventory/
@@ -129,6 +131,7 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       ├── CharacterPanel.js
 │   │   │       └── weaponChip.js
@@ -140,6 +143,7 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       └── lootTab.js
 │   │   ├── proficiency/
@@ -149,6 +153,7 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       └── weaponProficiencyDisplay.js
 │   │   ├── progression/
@@ -169,6 +174,7 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       └── sectScreen.js
 │   │   ├── karma/
@@ -185,6 +191,7 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       └── alchemyDisplay.js
 │   │   ├── mining/
@@ -207,6 +214,7 @@ way-of-ascension/
 │   │       │   ├── weaponIcons.js
 │   │       │   ├── weaponTypes.js
 │   │       │   └── weapons.js
+│   │       ├── index.js
 │   │       ├── logic.js
 │   │       ├── mutators.js
 │   │       ├── selectors.js
@@ -543,6 +551,9 @@ function updateAll() {
 **Purpose**: Initializes and updates the weapon display chip in the top HUD.
 **When to modify**: Change weapon HUD logic or appearance.
 
+#### `src/features/proficiency/index.js` - Proficiency Feature Registration
+**Purpose**: Registers the proficiency slice and hooks into the feature registry.
+
 #### `src/features/proficiency/state.js` - Proficiency Feature State
 **Purpose**: Maintains the player's proficiency map keyed by weapon type.
 **When to modify**: Adjust underlying storage of proficiency values.
@@ -630,6 +641,7 @@ Paths added:
 - `src/shared/events.js`
 - `src/shared/saveLoad.js`
 - `src/features/index.js` – UI bootstrap
+- `src/features/registry.js` – Feature registration hooks
 - `src/index.js` – entry that bootstraps and starts the controller
 - `docs/ARCHITECTURE.md`
 - `docs/To-dos/stats-to-implement.md`
@@ -645,6 +657,9 @@ Paths added:
 
 #### `src/features/index.js` - Feature UI Bootstrap
 **Purpose**: Central place to mount all feature user interfaces.
+
+#### `src/features/registry.js` - Feature Registry
+**Purpose**: Collects feature `init` and `tick` hooks and exposes helpers to initialise slices and advance ticks.
 
 #### `src/index.js` - Entrypoint
 **Purpose**: Minimal bootstrap that creates the controller, mounts feature UIs and starts the game.
@@ -689,6 +704,7 @@ Paths added:
 - `src/features/physique/ui/physiqueDisplay.js` – Renders physique progress and bonuses in the UI.
 
 ### Alchemy Feature
+- `src/features/alchemy/index.js` – Registers alchemy hooks.
 - `src/features/alchemy/data/recipes.js` – Basic pill recipes with brew times and rewards.
 - `src/features/alchemy/logic.js` – Tick handler that advances brew timers.
 - `src/features/alchemy/mutators.js` – Start/complete brews and unlock new recipes.
@@ -703,7 +719,15 @@ Paths added:
 - `src/features/cooking/logic.js` – Handle cooking, food slot usage, and UI updates.
 - `src/features/cooking/ui/cookingDisplay.js` – Sidebar display for cooking progress.
 
+### Weapon Generation Feature (`src/features/weaponGeneration/`)
+- `src/features/weaponGeneration/index.js` – Registers weapon generation hooks.
+- `src/features/weaponGeneration/state.js` – Holds the currently generated weapon.
+- `src/features/weaponGeneration/logic.js` – Generates weapons from base types and materials.
+- `src/features/weaponGeneration/mutators.js` – Writes generated weapons into state.
+- `src/features/weaponGeneration/selectors.js` – Helpers to roll and access generated weapons.
+
 ### Sect Feature (`src/features/sect/`)
+- `src/features/sect/index.js` – Registers sect hooks.
 - `src/features/sect/state.js` – Sect buildings and resources.
 - `src/features/sect/mutators.js` – Mutators for building and upgrading sect structures.
 - `src/features/sect/selectors.js` – Accessors for sect data.

--- a/src/features/alchemy/index.js
+++ b/src/features/alchemy/index.js
@@ -1,0 +1,9 @@
+import { registerFeature } from "../registry.js";
+import { alchemyState } from "./state.js";
+import { tickAlchemy } from "./logic.js";
+
+registerFeature({
+  id: "alchemy",
+  init: () => structuredClone(alchemyState),
+  tick: tickAlchemy,
+});

--- a/src/features/proficiency/index.js
+++ b/src/features/proficiency/index.js
@@ -1,0 +1,7 @@
+import { registerFeature } from "../registry.js";
+import { proficiencyState } from "./state.js";
+
+registerFeature({
+  id: "proficiency",
+  init: () => structuredClone(proficiencyState),
+});

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -177,4 +177,3 @@ export function breakthroughChance(state = progressionState){
   return clamp(totalChance, 0.01, 0.95);
 }
 
-export default function engineTick() {}

--- a/src/features/registry.js
+++ b/src/features/registry.js
@@ -1,0 +1,28 @@
+const registeredFeatures = [];
+
+export function registerFeature(feature) {
+  registeredFeatures.push(feature);
+}
+
+export function initFeatureState() {
+  const slices = {};
+  for (const { id, init } of registeredFeatures) {
+    if (typeof init === 'function') {
+      const slice = init();
+      if (slice !== undefined) {
+        slices[id] = slice;
+      }
+    }
+  }
+  return slices;
+}
+
+export function tickFeatures(state, stepMs) {
+  for (const { tick } of registeredFeatures) {
+    if (typeof tick === 'function') {
+      tick(state, stepMs);
+    }
+  }
+}
+
+export { registeredFeatures };

--- a/src/features/sect/index.js
+++ b/src/features/sect/index.js
@@ -1,0 +1,7 @@
+import { registerFeature } from "../registry.js";
+import { sectState } from "./state.js";
+
+registerFeature({
+  id: "sect",
+  init: () => structuredClone(sectState),
+});

--- a/src/features/weaponGeneration/index.js
+++ b/src/features/weaponGeneration/index.js
@@ -1,0 +1,7 @@
+import { registerFeature } from "../registry.js";
+import { weaponGenerationState } from "./state.js";
+
+registerFeature({
+  id: "weaponGen",
+  init: () => structuredClone(weaponGenerationState),
+});

--- a/src/game/GameController.js
+++ b/src/game/GameController.js
@@ -1,24 +1,18 @@
 import { emit } from "../shared/events.js";
 import { loadSave, saveDebounced } from "../shared/saveLoad.js";
-
-// feature slices
-import { proficiencyState } from "../features/proficiency/state.js";
-import { weaponGenerationState } from "../features/weaponGeneration/state.js";
-import { sectState } from "../features/sect/state.js";
 import { recalculateBuildingBonuses } from "../features/sect/mutators.js";
-import { alchemyState } from "../features/alchemy/state.js";
-import { tickAlchemy } from "../features/alchemy/logic.js";
+import { initFeatureState, tickFeatures } from "../features/registry.js";
 
-// TEMP bridge to legacy world:
-import engineTick from "../features/progression/logic.js";
+// Register feature hooks
+import "../features/proficiency/index.js";
+import "../features/weaponGeneration/index.js";
+import "../features/sect/index.js";
+import "../features/alchemy/index.js";
 
 export function createGameController() {
   const state = {
     app: { mode: "town", lastTick: performance.now() },
-    proficiency: structuredClone(proficiencyState),
-    weaponGen: structuredClone(weaponGenerationState),
-    sect: structuredClone(sectState),
-    alchemy: structuredClone(alchemyState),
+    ...initFeatureState(),
     // legacy root pieces remain attached to `state` until migrated
   };
 
@@ -43,11 +37,7 @@ export function createGameController() {
     acc += dt;
 
     while (acc >= stepMs) {
-      // --- TEMP BRIDGE: keep legacy world advancing ---
-      engineTick(state);
-
-      // --- Feature ticks ---
-      tickAlchemy(state, stepMs);
+      tickFeatures(state, stepMs);
 
       // --- New world: per-feature listeners advance here ---
       emit("TICK", { stepMs, now });


### PR DESCRIPTION
## Summary
- add feature registry to collect init and tick hooks
- register proficiency, weapon generation, sect, and alchemy features
- use registry ticks in GameController and drop legacy engineTick

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a653814c9c8326ba544cc4353f84a1