### PR TITLE
refactor: centralize proficiency xp logic

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -14,9 +14,7 @@ import { ENEMY_DATA } from './data/enemies.js';
 import { setText, log } from '../../shared/utils/dom.js';
 import { applyRandomAffixes } from '../affixes/logic.js';
 import { AFFIXES } from '../affixes/data/affixes.js';
-import { gainProficiency } from '../proficiency/mutators.js';
-import { getProficiency } from '../proficiency/selectors.js';
-import { updateWeaponProficiencyDisplay } from '../proficiency/ui/weaponProficiencyDisplay.js';
+import { gainProficiency, gainProficiencyFromEnemy } from '../proficiency/mutators.js';
 import { ZONES, getZoneById, getAreaById, isZoneUnlocked, isAreaUnlocked } from './data/zones.js'; // MAP-UI-UPDATE
 import { addSessionLoot, claimSessionLoot, forfeitSessionLoot } from '../loot/mutators.js'; // EQUIP-CHAR-UI
 import { updateLootTab } from '../loot/ui/lootTab.js';
@@ -488,9 +486,7 @@ export function updateAdventureCombat() {
           { target: S.adventure.currentEnemy, type: 'physical' },
           S
         );
-        const xpGain = Math.max(1, Math.ceil(S.adventure.enemyMaxHP / 30));
-        gainProficiency(weapon.proficiencyKey, xpGain, S); // WEAPONS-INTEGRATION
-        updateWeaponProficiencyDisplay();
+        gainProficiencyFromEnemy(weapon.proficiencyKey, S.adventure.enemyMaxHP, S); // WEAPONS-INTEGRATION
         S.adventure.combatLog = S.adventure.combatLog || [];
         S.adventure.combatLog.push(`You deal ${dealt} damage to ${S.adventure.currentEnemy.name}`);
         const enemyState = { stunBar: S.adventure.enemyStunBar, hpMax: S.adventure.enemyMaxHP }; // STATUS-REFORM
@@ -677,7 +673,6 @@ function defeatEnemy() {
     const bonusXP = Math.max(1, Math.round(enemy.hp / 10));
     const weapon = getEquippedWeapon(S);
     gainProficiency(weapon.proficiencyKey, bonusXP, S);
-    updateWeaponProficiencyDisplay();
     S.adventure.combatLog.push(`💀 Boss defeated! Bonus XP: ${bonusXP}`);
   }
   
@@ -1148,7 +1143,6 @@ export function updateActivityAdventure() {
   }
   const baseAttack = Math.round(calculatePlayerCombatAttack(S));
   setText('baseDamage', baseAttack);
-  updateWeaponProficiencyDisplay();
   updateZoneButtons(selectZone);
   updateAreaGrid(selectArea);
   updateAdventureProgressBar(selectAreaById); // MAP-UI-UPDATE

--- a/src/features/proficiency/logic.js
+++ b/src/features/proficiency/logic.js
@@ -6,6 +6,10 @@ function resolveKey(key) {
   return weapon?.proficiencyKey || key;
 }
 
+export function calculateProficiencyXP(enemyMaxHP) {
+  return Math.max(1, Math.ceil(enemyMaxHP / 30));
+}
+
 export function gainProficiency(key, amount, state) {
   state.proficiency = state.proficiency || {};
   const typeKey = resolveKey(key);

--- a/src/features/proficiency/mutators.js
+++ b/src/features/proficiency/mutators.js
@@ -1,6 +1,13 @@
 import { proficiencyState } from './state.js';
-import { gainProficiency as applyGain } from './logic.js';
+import { gainProficiency as applyGain, calculateProficiencyXP } from './logic.js';
+import { updateWeaponProficiencyDisplay } from './ui/weaponProficiencyDisplay.js';
 
 export function gainProficiency(key, amount, state = proficiencyState) {
   applyGain(key, amount, state);
+  updateWeaponProficiencyDisplay(state);
+}
+
+export function gainProficiencyFromEnemy(key, enemyMaxHP, state = proficiencyState) {
+  const xp = calculateProficiencyXP(enemyMaxHP);
+  gainProficiency(key, xp, state);
 }


### PR DESCRIPTION
## Summary
- Move proficiency XP calculation into proficiency logic
- Expose helper to award XP and refresh UI in proficiency mutators
- Use new helper in adventure combat and boss rewards

## Testing
- `npm test` (fails: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a674b4bd80832686ca429f9043c23d