### PR TITLE
refactor: share number formatting utility

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -245,7 +245,8 @@ way-of-ascension/
 │   │   ├── selectors.js
 │   │   └── utils/
 │   │       ├── dom.js
-│   │       └── hp.js
+│   │       ├── hp.js
+│   │       └── number.js
 │   └── ui/
 │       └── sidebar.js
 ├── ui/
@@ -333,6 +334,9 @@ Utility functions for querying elements, updating text/fill styles and logging t
 
 #### `utils/hp.js` - HP Utilities
 Contains `initHp()` to create `{ hp, hpMax }` objects from a maximum value.
+
+#### `utils/number.js` - Number Formatting Helpers
+Formats large numbers with shorthand suffixes (k, m, b, t).
 
 #### `src/features/progression/logic.js` - Game Calculations
 **Purpose**: Core progression mechanics and calculations
@@ -660,6 +664,7 @@ Paths added:
 - `src/index.js` – entry that bootstraps and starts the controller
 - `docs/ARCHITECTURE.md`
 - `docs/To-dos/stats-to-implement.md`
+- `src/shared/utils/number.js` - number formatting helper
 
 #### `src/game/GameController.js` - Game Orchestrator
 **Purpose**: Boots the game, runs the fixed-step loop, emits events and handles simple routing.

--- a/src/shared/utils/number.js
+++ b/src/shared/utils/number.js
@@ -1,0 +1,7 @@
+export const fmt = n=>{
+  if (n>=1e12) return (n/1e12).toFixed(2)+'t';
+  if (n>=1e9) return (n/1e9).toFixed(2)+'b';
+  if (n>=1e6) return (n/1e6).toFixed(2)+'m';
+  if (n>=1e3) return (n/1e3).toFixed(2)+'k';
+  return Math.floor(n).toString();
+};

--- a/ui/index.js
+++ b/ui/index.js
@@ -29,6 +29,7 @@ import {
   checkLawUnlocks,
 } from '../src/features/progression/index.js';
 import { qs, setText, setFill, log } from '../src/shared/utils/dom.js';
+import { fmt } from '../src/shared/utils/number.js';
 import { createProgressBar, updateProgressBar } from './components/progressBar.js';
 import { renderSidebarActivities } from '../src/ui/sidebar.js';
 import { initializeWeaponChip, updateWeaponChip } from '../src/features/inventory/ui/weaponChip.js';
@@ -62,14 +63,6 @@ let selectedActivity = 'cultivation'; // Current selected activity for the sideb
 
 
 
-
-const fmt = n=>{
-  if (n>=1e12) return (n/1e12).toFixed(2)+'t';
-  if (n>=1e9) return (n/1e9).toFixed(2)+'b';
-  if (n>=1e6) return (n/1e6).toFixed(2)+'m';
-  if (n>=1e3) return (n/1e3).toFixed(2)+'k';
-  return Math.floor(n).toString();
-}
 
 // Import enemy data from the enemies module
 import { ENEMY_DATA } from '../src/features/adventure/data/enemies.js';


### PR DESCRIPTION
## Summary
- move number formatting logic into shared utils module
- replace inline fmt definition in UI with shared import
- document new shared utility in project structure

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`
- `npx eslint src/shared/utils/number.js ui/index.js` *(fails: RECIPES, KARMA_UPS undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a67b14141083269173228d2137b22f