### PR TITLE
refactor: modularize karma upgrades UI

### DIFF
--- a/src/features/karma/ui/karmaDisplay.js
+++ b/src/features/karma/ui/karmaDisplay.js
@@ -1,6 +1,39 @@
-import { on } from '../../../shared/events.js';
+import { on, emit } from '../../../shared/events.js';
 import { setText } from '../../../shared/utils/dom.js';
 import { getKarmaPoints, getKarmaBonuses } from '../selectors.js';
+
+// Fallback upgrade data in case a global definition is not provided.
+// Each upgrade defines a key (used for storing the level in state),
+// display info, cost parameters and an effect function that mutates the
+// provided state when purchased.
+const defaultUpgrades = [
+  {
+    key: 'kQiRegen',
+    name: 'Qi Flow',
+    desc: 'Increase Qi regeneration by 10%',
+    base: 10,
+    mult: 1.5,
+    eff: state => { state.karma.qiRegen = (state.karma.qiRegen || 0) + 0.1; },
+  },
+  {
+    key: 'kAtk',
+    name: 'Attack',
+    desc: 'Increase attack by 10%',
+    base: 10,
+    mult: 1.5,
+    eff: state => { state.karma.atk = (state.karma.atk || 0) + 0.1; },
+  },
+  {
+    key: 'kDef',
+    name: 'Defense',
+    desc: 'Increase defense by 10%',
+    base: 10,
+    mult: 1.5,
+    eff: state => { state.karma.def = (state.karma.def || 0) + 0.1; },
+  },
+];
+
+const KARMA_UPS = globalThis.KARMA_UPS || defaultUpgrades;
 
 function render(state){
   const bonuses = getKarmaBonuses(state);
@@ -8,9 +41,39 @@ function render(state){
   setText('karmaAtkBonus', `${(bonuses.atk * 100).toFixed(0)}%`);
   setText('karmaDefBonus', `${(bonuses.def * 100).toFixed(0)}%`);
   setText('karmaQiRegenBonus', `${(bonuses.qiRegen * 100).toFixed(0)}%`);
+
+  const body = document.getElementById('karmaUpgrades');
+  if (body) {
+    body.innerHTML = '';
+    KARMA_UPS.forEach(k => {
+      const level = state.karma?.[k.key.slice(2)] || 0;
+      const cost = k.base * Math.pow(k.mult, level);
+      const div = document.createElement('div');
+      div.innerHTML = `<button class="btn small" data-karma="${k.key}">${k.name}</button><div class="muted">${k.desc}</div><div class="muted">Cost: ${Math.floor(cost)} karma</div>`;
+      body.appendChild(div);
+    });
+  }
 }
 
 export function mountKarmaUI(state){
+  const body = document.getElementById('karmaUpgrades');
+  if (body) {
+    body.addEventListener('click', e => {
+      const key = e.target?.dataset?.karma;
+      if (!key) return;
+      const upgrade = KARMA_UPS.find(x => x.key === key);
+      if (!upgrade) return;
+      const level = state.karma?.[key.slice(2)] || 0;
+      const cost = upgrade.base * Math.pow(upgrade.mult, level);
+      if (getKarmaPoints(state) >= cost) {
+        state.karma.points -= cost;
+        upgrade.eff?.(state);
+        render(state);
+        emit('RENDER');
+      }
+    });
+  }
+
   on('RENDER', () => render(state));
   render(state);
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -56,6 +56,7 @@ import { setReduceMotion } from '../src/features/combat/ui/index.js';
 import { tickAbilityCooldowns } from '../src/features/ability/mutators.js';
 import { advanceMining } from '../src/features/mining/logic.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
+import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
 
 // Global variables
 const progressBars = {};
@@ -251,7 +252,6 @@ function updateAll(){
   // Laws
   if (typeof updateLawsDisplay === 'function') updateLawsDisplay();
   
-  renderKarma();
   updateQiOrbEffect();
   if (typeof updateYinYangVisual === 'function') updateYinYangVisual();
   if (typeof updateBreathingStats === 'function') updateBreathingStats();
@@ -259,19 +259,6 @@ function updateAll(){
   updateActivityCards();
 
   emit('RENDER');
-}
-function renderKarma(){
-  const body=document.getElementById('karmaUpgrades'); 
-  if (!body) return; 
-  
-  body.innerHTML='';
-  KARMA_UPS.forEach(k=>{
-    const cost = k.base * Math.pow(k.mult, S.karma[k.key.slice(2)] || 0);
-    const div=document.createElement('div');
-    div.innerHTML=`<button class="btn small" data-karma="${k.key}">${k.name}</button><div class="muted">${k.desc}</div><div class="muted">Cost: ${Math.floor(cost)} karma</div>`;
-    body.appendChild(div);
-  });
-  body.onclick=e=>{const key=e.target?.dataset?.karma; if(!key) return; const k=KARMA_UPS.find(x=>x.key===key); const cost=k.base*Math.pow(k.mult,S.karma[k.key.slice(2)]||0); if(S.karmaPts>=cost){ S.karmaPts-=cost; k.eff(S); updateAll(); }};
 }
 
 
@@ -1413,6 +1400,7 @@ window.addEventListener('load', ()=>{
   setupAdventureTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI
   mountAlchemyUI(S);
+  mountKarmaUI(S);
   selectActivity('cultivation'); // Start with cultivation selected
   updateAll();
   tick();


### PR DESCRIPTION
## Summary
- add upgrade list rendering and purchase handling to karma display
- hook karma UI into main UI initialization and remove inline version

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a68f08b7a4832684c60691ac68b492