### PR TITLE
feat: add app bootstrap and delegate start

### DIFF
--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -1,0 +1,46 @@
+// src/ui/app.js
+import { createGameController } from "../game/GameController.js";
+import { registerAllFeatures, FEATURES } from "../features/registry.js";
+import { mountSidebar } from "./sidebar.js";
+
+// If you already have a debug panel module, this import is safe;
+// if not, keep it and conditionally call only if it exists.
+let mountDebugUI;
+try {
+  ({ mountDebugUI } = await import("./debug.js"));
+} catch {}
+
+export function startApp() {
+  // 1) create controller & shared ctx
+  const game = createGameController();
+  const ctx = { emit: game.emit };
+
+  // 2) register features (fills FEATURES; some features may mount their own UI in init)
+  registerAllFeatures();
+
+  // 3) app-shell mounts
+  try { mountSidebar?.(game.state, ctx); } catch (e) { console.warn("Sidebar mount failed:", e); }
+
+  // TEMP bridge: call feature-provided mounts (until all features use init())
+  for (const f of FEATURES) {
+    try { f.mount?.(game.state, ctx); } catch (e) { console.warn(`Mount failed for feature ${f.key}:`, e); }
+  }
+
+  // 4) optional debug (dev only)
+  const dev = (typeof window !== "undefined" && window.DEBUG === true)
+           || (typeof import.meta !== "undefined" && import.meta?.env?.MODE === "development");
+  if (dev && typeof mountDebugUI === "function") {
+    try { mountDebugUI(game.state, ctx); } catch (e) { console.warn("Debug mount failed:", e); }
+  }
+
+  // 5) start loop
+  game.start();
+
+  return { game, ctx };
+}
+
+// Auto-boot in browser if this file is loaded directly
+if (typeof window !== "undefined" && !window.__APP_STARTED__) {
+  window.__APP_STARTED__ = true;
+  try { startApp(); } catch (e) { console.error("App boot failed:", e); }
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -62,6 +62,7 @@ import { updateResourceDisplay } from '../src/features/inventory/ui/resourceDisp
 import { updateKarmaDisplay } from '../src/features/karma/ui/karmaHUD.js';
 import { updateLawsUI } from '../src/features/progression/ui/lawsHUD.js';
 import { calcKarmaGain } from '../src/features/karma/selectors.js';
+import { startApp } from "../src/ui/app.js";
 
 // Global variables
 const progressBars = {};
@@ -1257,19 +1258,6 @@ function addPhysiqueMinigame() {
 
 
 // Init
-window.addEventListener('load', ()=>{
-  initUI();
-  initLawSystem();
-  initActivityListeners();
-  setupAdventureTabs();
-  setupEquipmentTab(); // EQUIP-CHAR-UI
-  mountAlchemyUI(S);
-  mountKarmaUI(S);
-  selectActivity('cultivation'); // Start with cultivation selected
-  updateAll();
-  tick();
-  log('Welcome, cultivator.');
-  setInterval(tick, 1000);
-});
+window.addEventListener('load', () => { startApp(); });
 
 // CHANGELOG: Added weapon HUD integration.


### PR DESCRIPTION
## Summary
- add src/ui/app.js bootstrap to create controller, register features, mount UI, and auto boot
- update ui/index.js to import startApp and use it on window load
- fix dev environment detection to avoid syntax error when checking for `import.meta`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UNDOCUMENTED FILE errors)


------
https://chatgpt.com/codex/tasks/task_e_68a7229b3138832692d4db7e8bfbf246