### PR TITLE
feat: add app bootstrap and delegate start

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -81,6 +81,7 @@ way-of-ascension/
 │   │   │   │   ├── zoneIds.js
 │   │   │   │   └── zones.js
 │   │   │   ├── ui/
+│   │   │   │   ├── adventureDisplay.js
 │   │   │   │   ├── progressBar.js
 │   │   │   │   └── zoneUI.js
 │   │   │   ├── logic.js
@@ -119,6 +120,7 @@ way-of-ascension/
 │   │   │   ├── state.js
 │   │   │   ├── statusEngine.js
 │   │   │   └── ui/
+│   │   │       ├── combatStats.js
 │   │   │       ├── fx.js
 │   │   │       └── index.js
 │   │   ├── cooking/
@@ -140,6 +142,7 @@ way-of-ascension/
 │   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       ├── CharacterPanel.js
+│   │   │       ├── resourceDisplay.js
 │   │   │       └── weaponChip.js
 │   │   ├── loot/
 │   │   │   ├── data/
@@ -175,6 +178,9 @@ way-of-ascension/
 │   │   │   ├── state.js
 │   │   │   ├── index.js
 │   │   │   └── ui/
+│   │   │       ├── lawDisplay.js
+│   │   │       ├── lawsHUD.js
+│   │   │       ├── qiDisplay.js
 │   │   │       ├── qiOrb.js
 │   │   │       └── realm.js
 │   │   ├── sect/
@@ -195,7 +201,8 @@ way-of-ascension/
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
 │   │   │   └── ui/
-│   │   │       └── karmaDisplay.js
+│   │   │       ├── karmaDisplay.js
+│   │   │       └── karmaHUD.js
 │   │   ├── alchemy/
 │   │   │   ├── data/
 │   │   │   │   └── recipes.js
@@ -249,6 +256,7 @@ way-of-ascension/
 │   │       ├── hp.js
 │   │       └── number.js
 │   └── ui/
+│       ├── app.js
 │       └── sidebar.js
 ├── ui/
 │   ├── components/
@@ -759,6 +767,16 @@ Paths added:
 - `src/features/sect/logic.js` – Core sect calculations and mechanics.
 - `src/features/sect/data/buildings.js` – Building definitions and costs.
 - `src/features/sect/ui/sectScreen.js` – UI for managing the sect.
+
+### Additional UI Components
+- `src/features/adventure/ui/adventureDisplay.js` – Updates adventure progress and location display.
+- `src/features/combat/ui/combatStats.js` – Renders combat statistics like attack, defense, and armor.
+- `src/features/inventory/ui/resourceDisplay.js` – Shows resource quantities and pill counts.
+- `src/features/karma/ui/karmaHUD.js` – Toggles ascend availability based on current karma gain.
+- `src/features/progression/ui/lawDisplay.js` – Presents law selection interface and skill trees.
+- `src/features/progression/ui/lawsHUD.js` – Refreshes law HUD and related visual effects.
+- `src/features/progression/ui/qiDisplay.js` – Updates Qi and foundation bars and values.
+- `src/ui/app.js` – App bootstrap that creates the controller, mounts UI, and starts the game.
 
 ### Feature Migration Files
 - `src/features/ability/migrations.js` – Save migrations for ability feature.

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -1,0 +1,47 @@
+// src/ui/app.js
+import { createGameController } from "../game/GameController.js";
+import { mountSidebar } from "./sidebar.js";
+import { mountAllFeatureUIs } from "../features/index.js";
+import { registeredFeatures } from "../features/registry.js";
+
+// If you already have a debug panel module, this import is safe;
+// if not, keep it and conditionally call only if it exists.
+let mountDebugUI;
+try {
+  ({ mountDebugUI } = await import("./debug.js"));
+} catch {}
+
+export function startApp() {
+  // 1) create controller & shared ctx
+  const game = createGameController();
+  const ctx = { emit: game.emit };
+
+  // 2) app-shell mounts
+  try { mountSidebar?.(game.state, ctx); } catch (e) { console.warn("Sidebar mount failed:", e); }
+
+  // TEMP bridge: mount feature UIs
+  try { mountAllFeatureUIs(game.state); } catch (e) { console.warn("Feature UI mount failed:", e); }
+
+  // TEMP bridge: call feature-provided mounts
+  for (const f of registeredFeatures) {
+    try { f.mount?.(game.state, ctx); } catch (e) { console.warn(`Mount failed for feature ${f.id}:`, e); }
+  }
+
+  // 3) optional debug (dev only)
+  const dev = (typeof window !== "undefined" && window.DEBUG === true)
+           || (typeof import.meta !== "undefined" && import.meta?.env?.MODE === "development");
+  if (dev && typeof mountDebugUI === "function") {
+    try { mountDebugUI(game.state, ctx); } catch (e) { console.warn("Debug mount failed:", e); }
+  }
+
+  // 4) start loop
+  game.start();
+
+  return { game, ctx };
+}
+
+// Auto-boot in browser if this file is loaded directly
+if (typeof window !== "undefined" && !window.__APP_STARTED__) {
+  window.__APP_STARTED__ = true;
+  try { startApp(); } catch (e) { console.error("App boot failed:", e); }
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -62,6 +62,7 @@ import { updateResourceDisplay } from '../src/features/inventory/ui/resourceDisp
 import { updateKarmaDisplay } from '../src/features/karma/ui/karmaHUD.js';
 import { updateLawsUI } from '../src/features/progression/ui/lawsHUD.js';
 import { calcKarmaGain } from '../src/features/karma/selectors.js';
+import { startApp } from "../src/ui/app.js";
 
 // Global variables
 const progressBars = {};
@@ -1257,19 +1258,6 @@ function addPhysiqueMinigame() {
 
 
 // Init
-window.addEventListener('load', ()=>{
-  initUI();
-  initLawSystem();
-  initActivityListeners();
-  setupAdventureTabs();
-  setupEquipmentTab(); // EQUIP-CHAR-UI
-  mountAlchemyUI(S);
-  mountKarmaUI(S);
-  selectActivity('cultivation'); // Start with cultivation selected
-  updateAll();
-  tick();
-  log('Welcome, cultivator.');
-  setInterval(tick, 1000);
-});
+window.addEventListener('load', () => { startApp(); });
 
 // CHANGELOG: Added weapon HUD integration.


### PR DESCRIPTION
## Summary
- add src/ui/app.js bootstrap to create controller, mount sidebar, and auto boot
- update ui/index.js to import startApp and use it on window load
- fix dev environment detection to avoid syntax error when checking for `import.meta`
- document UI modules in project structure
- replace nonexistent FEATURES import with registeredFeatures and call feature mounts

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68a7229b3138832692d4db7e8bfbf246