### PR TITLE
Harden static file serving

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -72,6 +72,8 @@ way-of-ascension/
 ├── node_modules/
 ├── scripts/
 │   └── validate-structure.js
+├── test/
+│   └── server.test.js
 ├── src/
 │   ├── index.js
 │   ├── features/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "game.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "validate": "node scripts/validate-structure.js",
     "validate-fix": "node scripts/validate-structure.js --auto-update",
     "start": "node server.js",

--- a/server.js
+++ b/server.js
@@ -3,11 +3,29 @@ import fs from 'fs';
 import path from 'path';
 
 const PORT = 8081;
+const PUBLIC_DIR = path.join(process.cwd(), 'public');
 
 const server = http.createServer((req, res) => {
-    let filePath = '.' + req.url;
-    if (filePath === './') {
-        filePath = './index.html';
+    const pathname = req.url.split('?')[0];
+    const normalizedPath = path.normalize(pathname);
+
+    if (pathname.includes('..') || normalizedPath.split(path.sep).includes('..')) {
+        res.writeHead(400);
+        res.end('Invalid path');
+        return;
+    }
+
+    let relativePath = normalizedPath.replace(/^\/+/u, '');
+    if (relativePath === '') {
+        relativePath = 'index.html';
+    }
+
+    const filePath = path.join(PUBLIC_DIR, relativePath);
+
+    if (!filePath.startsWith(PUBLIC_DIR)) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
     }
 
     const extname = String(path.extname(filePath)).toLowerCase();
@@ -35,11 +53,9 @@ const server = http.createServer((req, res) => {
 
     fs.readFile(filePath, (error, content) => {
         if (error) {
-            if (error.code == 'ENOENT') {
-                fs.readFile('./404.html', (error, content) => {
-                    res.writeHead(404, { 'Content-Type': 'text/html' });
-                    res.end(content, 'utf-8');
-                });
+            if (error.code === 'ENOENT') {
+                res.writeHead(404, { 'Content-Type': 'text/plain' });
+                res.end('Not Found');
             } else {
                 res.writeHead(500);
                 res.end('Sorry, check with the site admin for error: ' + error.code + '..\n');
@@ -51,6 +67,10 @@ const server = http.createServer((req, res) => {
     });
 });
 
-server.listen(PORT, () => {
-    console.log(`Server running at http://127.0.0.1:${PORT}/`);
-});
+if (process.env.NODE_ENV !== 'test') {
+    server.listen(PORT, () => {
+        console.log(`Server running at http://127.0.0.1:${PORT}/`);
+    });
+}
+
+export default server;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,25 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert';
+import net from 'net';
+
+process.env.NODE_ENV = 'test';
+const server = (await import('../server.js')).default;
+
+before(() => server.listen(8081));
+after(() => server.close());
+
+test('blocks path traversal attempts', async () => {
+  const data = await new Promise((resolve, reject) => {
+    const socket = net.connect(8081, '127.0.0.1', () => {
+      socket.write('GET /../server.js HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n');
+    });
+    let response = '';
+    socket.on('data', chunk => {
+      response += chunk.toString();
+    });
+    socket.on('end', () => resolve(response));
+    socket.on('error', reject);
+  });
+  const statusLine = data.split('\r\n')[0];
+  assert.match(statusLine, /^HTTP\/1.1 400/);
+});


### PR DESCRIPTION
## Summary
- Normalize request URLs and block `..` segments
- Serve only from a dedicated `public` directory
- Add regression test for path traversal

## Testing
- `npm test`
- `npm run validate` *(fails: MISSING CORE FILE, UI state violations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a24f9d548326b151448c25aaac45