### PR TITLE
Refactor adventure map UI handling

### DIFF
--- a/src/features/adventure/ui/mapUI.js
+++ b/src/features/adventure/ui/mapUI.js
@@ -1,0 +1,158 @@
+import { S } from '../../../shared/state.js';
+import { log } from '../../../shared/utils/dom.js';
+import { ZONES, isZoneUnlocked, isAreaUnlocked, getAreaById } from '../data/zones.js';
+import { selectAreaById, ensureAdventure, updateActivityAdventure } from '../logic.js';
+import { updateAdventureProgressBar } from './progressBar.js';
+
+function getElementIcon(element) {
+  const icons = {
+    nature: '🌿',
+    shadow: '🌙',
+    ice: '❄️',
+    fire: '🔥',
+    earth: '🗿',
+    wind: '💨'
+  };
+  return icons[element] || '⚡';
+}
+
+function selectAreaFromMap(zoneIndex, areaIndex, zoneId, areaId) {
+  if (selectAreaById(zoneId, areaId, areaIndex)) {
+    const area = getAreaById(zoneId, areaId);
+    updateActivityAdventure();
+    updateAdventureProgressBar(selectAreaById);
+    log(`Selected area from map: ${area?.name || 'Unknown Area'}`, 'good');
+  }
+  hideMapOverlay();
+}
+
+function updateMapContent() {
+  ensureAdventure();
+  const mapContent = document.getElementById('mapContent');
+  if (!mapContent) return;
+
+  mapContent.innerHTML = '';
+
+  ZONES.forEach((zone, zoneIndex) => {
+    const isZoneUnlockedValue = isZoneUnlocked(zone.id, S);
+
+    const accordion = document.createElement('div');
+    accordion.className = `zone-accordion ${!isZoneUnlockedValue ? 'locked' : ''}`;
+
+    // Zone header
+    const header = document.createElement('div');
+    header.className = 'zone-header';
+    header.setAttribute('aria-label', `${zone.name} zone`);
+
+    const zoneInfo = document.createElement('div');
+    zoneInfo.className = 'zone-info';
+
+    const elementIcon = document.createElement('div');
+    elementIcon.className = 'zone-element-icon';
+    elementIcon.style.background = zone.color;
+    elementIcon.textContent = getElementIcon(zone.element);
+
+    const zoneDetails = document.createElement('div');
+    zoneDetails.className = 'zone-details';
+    zoneDetails.innerHTML = `
+      <h4>${zone.name}</h4>
+      <p class="zone-description">${zone.description}</p>
+    `;
+
+    const expandIcon = document.createElement('div');
+    expandIcon.className = 'zone-expand-icon';
+    expandIcon.textContent = '▶';
+
+    zoneInfo.appendChild(elementIcon);
+    zoneInfo.appendChild(zoneDetails);
+    header.appendChild(zoneInfo);
+    header.appendChild(expandIcon);
+
+    // Zone areas
+    const areasContainer = document.createElement('div');
+    areasContainer.className = 'zone-areas';
+
+    if (isZoneUnlockedValue) {
+      zone.areas.forEach((area, areaIndex) => {
+        const areaKey = `${zone.id}-${area.id}`;
+        const legacyAreaKey = `${zoneIndex}-${areaIndex}`;
+        const isAreaUnlockedValue = isAreaUnlocked(zone.id, area.id, S) || S.adventure.unlockedAreas?.[legacyAreaKey] || false;
+        const progress = S.adventure.areaProgress?.[areaKey] || S.adventure.areaProgress?.[legacyAreaKey] || { kills: 0, bossDefeated: false };
+        const isCurrent = zoneIndex === S.adventure.currentZone && areaIndex === S.adventure.currentArea;
+
+        const areaItem = document.createElement('div');
+        areaItem.className = `area-item ${!isAreaUnlockedValue ? 'locked' : ''} ${isCurrent ? 'current' : ''}`;
+
+        const areaInfo = document.createElement('div');
+        areaInfo.className = 'area-info';
+        areaInfo.innerHTML = `
+          <h5>${area.name}</h5>
+          <div class="area-enemy">vs ${area.enemy}</div>
+        `;
+
+        const areaStatus = document.createElement('div');
+        areaStatus.className = 'area-status';
+
+        if (!isAreaUnlockedValue) {
+          areaStatus.innerHTML = '<span class="area-locked">🔒 Locked</span>';
+        } else if (progress.bossDefeated) {
+          areaStatus.innerHTML = '<span class="area-completed">✓ Completed</span>';
+        } else {
+          areaStatus.innerHTML = `<span class="area-progress">${progress.kills}/${area.killReq}</span>`;
+        }
+
+        areaItem.appendChild(areaInfo);
+        areaItem.appendChild(areaStatus);
+
+        if (isAreaUnlockedValue) {
+          areaItem.onclick = () => selectAreaFromMap(zoneIndex, areaIndex, zone.id, area.id);
+          areaItem.setAttribute('tabindex', '0');
+          areaItem.setAttribute('role', 'button');
+          areaItem.setAttribute('aria-label', `Select ${area.name}`);
+        }
+
+        areasContainer.appendChild(areaItem);
+      });
+
+      header.onclick = () => {
+        const isExpanded = header.classList.contains('expanded');
+        header.classList.toggle('expanded');
+        areasContainer.classList.toggle('expanded');
+        expandIcon.textContent = isExpanded ? '▶' : '▼';
+      };
+    }
+
+    accordion.appendChild(header);
+    accordion.appendChild(areasContainer);
+    mapContent.appendChild(accordion);
+  });
+}
+
+export function showMapOverlay() {
+  const overlay = document.getElementById('mapOverlay');
+  if (!overlay) return;
+
+  overlay.style.display = 'flex';
+  updateMapContent();
+
+  const backdrop = document.getElementById('mapOverlayBackdrop');
+  const closeButton = document.getElementById('closeMapButton');
+
+  backdrop?.addEventListener('click', hideMapOverlay);
+  closeButton?.addEventListener('click', hideMapOverlay);
+
+  const handleEscape = (e) => {
+    if (e.key === 'Escape') {
+      hideMapOverlay();
+      document.removeEventListener('keydown', handleEscape);
+    }
+  };
+  document.addEventListener('keydown', handleEscape);
+}
+
+export function hideMapOverlay() {
+  const overlay = document.getElementById('mapOverlay');
+  if (overlay) {
+    overlay.style.display = 'none';
+  }
+}

--- a/src/features/adventure/ui/zoneUI.js
+++ b/src/features/adventure/ui/zoneUI.js
@@ -1,33 +1,38 @@
-import { S } from '../../../shared/state.js';
 import { ZONES } from '../data/zones.js';
+import { getAdventure } from '../selectors.js';
+import { selectZone, selectArea, updateActivityAdventure } from '../logic.js';
 
-export function updateZoneButtons(selectZone) {
+export function updateZoneButtons() {
   const zoneContainer = document.getElementById('zoneButtons');
-  if (!zoneContainer || !S.adventure) return;
+  const adventure = getAdventure();
+  if (!zoneContainer || !adventure) return;
   zoneContainer.innerHTML = '';
   ZONES.forEach((zone, index) => {
-    if (index < (S.adventure.zonesUnlocked || 1)) {
+    if (index < (adventure.zonesUnlocked || 1)) {
       const button = document.createElement('button');
-      button.className = 'btn zone-btn' + (index === (S.adventure.selectedZone || 0) ? ' active' : '');
+      button.className = 'btn zone-btn' + (index === (adventure.selectedZone || 0) ? ' active' : '');
       button.textContent = zone.name;
-      button.onclick = () => selectZone(index);
+      button.onclick = () => {
+        if (selectZone(index)) updateActivityAdventure();
+      };
       zoneContainer.appendChild(button);
     }
   });
 }
 
-export function updateAreaGrid(selectArea) {
+export function updateAreaGrid() {
   const areaContainer = document.getElementById('areaGrid');
-  if (!areaContainer || !S.adventure) return;
-  const currentZone = ZONES[S.adventure.selectedZone || 0];
+  const adventure = getAdventure();
+  if (!areaContainer || !adventure) return;
+  const currentZone = ZONES[adventure.selectedZone || 0];
   if (currentZone && currentZone.areas) {
     areaContainer.innerHTML = '';
     currentZone.areas.forEach((area, index) => {
       const button = document.createElement('button');
-      const areaKey = `${S.adventure.selectedZone}-${index}`;
-      const isUnlocked = S.adventure.unlockedAreas[areaKey] || false;
-      const isActive = index === (S.adventure.selectedArea || 0);
-      const progress = S.adventure.areaProgress[areaKey] || { kills: 0, bossDefeated: false };
+      const areaKey = `${adventure.selectedZone}-${index}`;
+      const isUnlocked = adventure.unlockedAreas[areaKey] || false;
+      const isActive = index === (adventure.selectedArea || 0);
+      const progress = adventure.areaProgress[areaKey] || { kills: 0, bossDefeated: false };
 
       button.className = 'btn area-btn' + (isActive ? ' active' : '') + (!isUnlocked ? ' disabled' : '');
       button.textContent = area.name;
@@ -36,7 +41,9 @@ export function updateAreaGrid(selectArea) {
       if (isUnlocked) {
         const statusText = progress.bossDefeated ? ' ✓' : (progress.kills >= area.killReq ? ' 👹' : ` (${progress.kills}/${area.killReq})`);
         button.textContent += statusText;
-        button.onclick = () => selectArea(index);
+        button.onclick = () => {
+          if (selectArea(index)) updateActivityAdventure();
+        };
       } else {
         button.textContent += ' 🔒';
       }

--- a/ui/index.js
+++ b/ui/index.js
@@ -780,7 +780,7 @@ function initActivityListeners() {
   
   // Adventure Map button event listener - MAP-UI-UPDATE
   document.getElementById('mapButton')?.addEventListener('click', () => {
-    import('../src/features/adventure/logic.js').then(({ showMapOverlay }) => {
+    import('../src/features/adventure/ui/mapUI.js').then(({ showMapOverlay }) => {
       showMapOverlay();
     });
   });


### PR DESCRIPTION
## Summary
- Move map overlay and area status DOM logic to new `mapUI` module
- Make adventure `selectAreaById`, `selectZone`, and `selectArea` pure state updates
- Refresh zone UI to use selectors and logic helpers and update map button import

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: Missing script: "lint")


------
https://chatgpt.com/codex/tasks/task_e_68a7a25af8e48326996e5515b535937c