### PR TITLE
refactor cooking dom updates

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -131,6 +131,7 @@ way-of-ascension/
 │   │   │   ├── state.js
 │   │   │   ├── index.js
 │   │   │   └── ui/
+│   │   │       ├── cookControls.js
 │   │   │       └── cookingDisplay.js
 │   │   ├── inventory/
 │   │   │   ├── data/
@@ -769,7 +770,8 @@ Paths added:
 - `src/features/cooking/state.js` – Cooking level, experience, and success bonus.
 - `src/features/cooking/mutators.js` – Manage cooking actions and food slot equipment.
 - `src/features/cooking/selectors.js` – Access success bonus and other cooking state.
-- `src/features/cooking/logic.js` – Handle cooking, food slot usage, and UI updates.
+- `src/features/cooking/logic.js` – Handle cooking and food slot logic, returning data for the UI.
+- `src/features/cooking/ui/cookControls.js` – Update cook amount input and food slot counts.
 - `src/features/cooking/ui/cookingDisplay.js` – Sidebar display for cooking progress.
 
 ### Weapon Generation Feature (`src/features/weaponGeneration/`)

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -30,7 +30,7 @@ import {
 } from '../combat/ui/index.js';
 import { updateZoneButtons, updateAreaGrid } from './ui/zoneUI.js';
 import { updateAdventureProgressBar } from './ui/progressBar.js';
-import { updateFoodSlots } from '../cooking/logic.js';
+import { updateFoodSlots } from '../cooking/ui/cookControls.js';
 
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 

--- a/src/features/cooking/logic.js
+++ b/src/features/cooking/logic.js
@@ -1,6 +1,6 @@
-import { setText, log } from '../../shared/utils/dom.js';
+import { log } from '../../shared/utils/dom.js';
 
-export function updateFoodSlots(state) {
+export function getFoodSlotData(state) {
   if (!state.foodSlots) {
     state.foodSlots = {
       slot1: null,
@@ -10,18 +10,11 @@ export function updateFoodSlots(state) {
       cooldown: 5000,
     };
   }
-  setText('rawMeatCount', state.meat || 0);
-  setText('inventoryRawMeat', state.meat || 0);
-  setText('inventoryCookedMeat', state.cookedMeat || 0);
-  setText('inventoryRawMeatAdventure', state.meat || 0);
-  setText('inventoryCookedMeatAdventure', state.cookedMeat || 0);
-  const cookInput = document.getElementById('cookAmount');
-  if (cookInput) {
-    cookInput.max = state.meat || 0;
-    if (parseInt(cookInput.value) > (state.meat || 0)) {
-      cookInput.value = Math.max(1, state.meat || 0);
-    }
-  }
+  return {
+    meat: state.meat || 0,
+    cookedMeat: state.cookedMeat || 0,
+    cookAmountMax: state.meat || 0,
+  };
 }
 
 export function cookMeat(amount, state) {
@@ -47,7 +40,6 @@ export function cookMeat(amount, state) {
   }
   const bonusText = cookedAmount > amt ? ` (+${cookedAmount - amt} bonus)` : '';
   log(`Cooked ${amt} meat into ${cookedAmount} cooked meat${bonusText}!`, 'good');
-  updateFoodSlots(state);
 }
 
 export function equipFood(foodType, slotNumber, state) {
@@ -115,5 +107,4 @@ export function useFoodSlot(slotNumber, state) {
   if (state.adventure && state.adventure.inCombat) {
     state.adventure.playerHP = state.hp;
   }
-  updateFoodSlots(state);
 }

--- a/src/features/cooking/mutators.js
+++ b/src/features/cooking/mutators.js
@@ -1,8 +1,10 @@
 import { S } from '../../shared/state.js';
 import { cookMeat as logicCookMeat, equipFood as logicEquipFood, useFoodSlot as logicUseFoodSlot } from './logic.js';
+import { updateFoodSlots } from './ui/cookControls.js';
 
 export function cookMeat(amount, state = S) {
   logicCookMeat(amount, state);
+  updateFoodSlots(state);
 }
 
 export function equipFood(foodType, slot, state = S) {
@@ -11,4 +13,5 @@ export function equipFood(foodType, slot, state = S) {
 
 export function useFoodSlot(slot, state = S) {
   logicUseFoodSlot(slot, state);
+  updateFoodSlots(state);
 }

--- a/src/features/cooking/ui/cookControls.js
+++ b/src/features/cooking/ui/cookControls.js
@@ -1,0 +1,19 @@
+import { S } from '../../../shared/state.js';
+import { setText } from '../../../shared/utils/dom.js';
+import { getFoodSlotData } from '../logic.js';
+
+export function updateFoodSlots(state = S) {
+  const data = getFoodSlotData(state);
+  setText('rawMeatCount', data.meat);
+  setText('inventoryRawMeat', data.meat);
+  setText('inventoryCookedMeat', data.cookedMeat);
+  setText('inventoryRawMeatAdventure', data.meat);
+  setText('inventoryCookedMeatAdventure', data.cookedMeat);
+  const cookInput = document.getElementById('cookAmount');
+  if (cookInput) {
+    cookInput.max = data.cookAmountMax;
+    if (parseInt(cookInput.value) > data.cookAmountMax) {
+      cookInput.value = Math.max(1, data.cookAmountMax);
+    }
+  }
+}

--- a/src/features/cooking/ui/cookingDisplay.js
+++ b/src/features/cooking/ui/cookingDisplay.js
@@ -3,7 +3,7 @@ import { setText, setFill } from '../../../shared/utils/dom.js';
 import { on } from '../../../shared/events.js';
 import { getCookingYieldBonus } from '../selectors.js';
 import { cookMeat, equipFood, useFoodSlot } from '../mutators.js';
-import { updateFoodSlots } from '../logic.js';
+import { updateFoodSlots } from './cookControls.js';
 
 export function updateActivityCooking(state = S) {
   if (!state.cooking) {


### PR DESCRIPTION
## Summary
- decouple cooking logic from DOM by returning food slot data
- add cookControls UI to manage cook amount and meat counts
- route cooking and adventure modules through new UI helpers

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: UI state violations and DOM usage in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a28e88c88326b5b7721cb641f8ae