### PR TITLE
refactor: emit event for weapon HUD updates

### DIFF
--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -1,5 +1,6 @@
 import { S, save } from '../../shared/state.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
 
 export function addToInventory(item, state = S) {
@@ -32,15 +33,11 @@ export function equipItem(item, state = S) {
   state.equipment[slot] = equipData;
   removeFromInventory(id, state);
   console.log('[equip]', 'slot→', slot, 'item→', item.key);
-  if (slot === 'mainhand') {
-    const hud = document.getElementById('currentWeapon');
-    if (hud) hud.textContent = WEAPONS[item.key]?.displayName || item.key;
-    const chip = document.getElementById('weaponName');
-    if (chip) chip.textContent = WEAPONS[item.key]?.displayName || item.key;
-  }
   recomputePlayerTotals(state);
   save?.();
-  return true;
+  const payload = { key: item.key, name: WEAPONS[item.key]?.displayName || item.key, slot };
+  if (slot === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);
+  return payload;
 }
 
 export function unequip(slot, state = S) {
@@ -50,12 +47,9 @@ export function unequip(slot, state = S) {
   if (key !== 'fist') addToInventory(item, state);
   state.equipment[slot] = null;
   console.log('[equip]', 'slot→', slot, 'item→', 'none');
-  if (slot === 'mainhand') {
-    const hud = document.getElementById('currentWeapon');
-    if (hud) hud.textContent = 'Fists';
-    const chip = document.getElementById('weaponName');
-    if (chip) chip.textContent = 'fist';
-  }
   recomputePlayerTotals(state);
   save?.();
+  const payload = { key: 'fist', name: 'Fists', slot };
+  if (slot === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);
+  return payload;
 }

--- a/src/features/inventory/ui/weaponChip.js
+++ b/src/features/inventory/ui/weaponChip.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
-import { WEAPON_FLAGS } from '../../weaponGeneration/data/weapons.js';
+import { on } from '../../../shared/events.js';
+import { WEAPON_FLAGS, WEAPONS } from '../../weaponGeneration/data/weapons.js';
 
 const weaponFeatureEnabled = Object.keys(WEAPON_FLAGS).some(w => w !== 'fist' && WEAPON_FLAGS[w]);
 
@@ -15,14 +16,16 @@ export function initializeWeaponChip() {
   chip.innerHTML = `Weapon: <span id="weaponName">${key || 'fist'}</span>`;
   topChips.appendChild(chip);
   console.log('[weapon]', 'hud-init', key || 'fist');
+  on('INVENTORY:MAINHAND_CHANGED', updateWeaponChip);
 }
 
-export function updateWeaponChip() {
+export function updateWeaponChip(payload) {
   if (!weaponFeatureEnabled) return;
+  const key = payload?.key ?? (typeof S.equipment?.mainhand === 'string' ? S.equipment.mainhand : S.equipment?.mainhand?.key);
+  const name = payload?.name ?? WEAPONS[key]?.displayName || key || 'Fists';
   const el = document.getElementById('weaponName');
-  if (el) {
-    const key = typeof S.equipment?.mainhand === 'string' ? S.equipment.mainhand : S.equipment?.mainhand?.key;
-    el.textContent = key || 'fist';
-    console.log('[weapon]', 'hud-update', key || 'fist');
-  }
+  if (el) el.textContent = key || 'fist';
+  const hud = document.getElementById('currentWeapon');
+  if (hud) hud.textContent = name;
+  console.log('[weapon]', 'hud-update', key || 'fist');
 }


### PR DESCRIPTION
## Summary
- remove direct DOM updates from inventory equip/unequip mutators
- emit `INVENTORY:MAINHAND_CHANGED` event when mainhand changes
- weapon HUD chip listens for event and updates displayed weapon and HUD

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: MISSING CORE FILE: src/ui/app.js; UI state violation: src/features/inventory/ui/weaponChip.js imports S from shared/state.js; DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js; ...)


------
https://chatgpt.com/codex/tasks/task_e_68a7a29340848326935feb0242de690f