### PR TITLE
feat: add auto toggle mutators

### DIFF
--- a/src/features/automation/mutators.js
+++ b/src/features/automation/mutators.js
@@ -1,0 +1,19 @@
+import { S } from '../../shared/state.js';
+
+export function toggleAutoMeditate(value, state = S) {
+  state.auto = state.auto || {};
+  if (typeof value === 'boolean') {
+    state.auto.meditate = value;
+  } else {
+    state.auto.meditate = !state.auto.meditate;
+  }
+}
+
+export function toggleAutoAdventure(value, state = S) {
+  state.auto = state.auto || {};
+  if (typeof value === 'boolean') {
+    state.auto.adventure = value;
+  } else {
+    state.auto.adventure = !state.auto.adventure;
+  }
+}

--- a/src/features/automation/selectors.js
+++ b/src/features/automation/selectors.js
@@ -1,0 +1,9 @@
+import { S } from '../../shared/state.js';
+
+export function isAutoMeditate(state = S) {
+  return !!state.auto?.meditate;
+}
+
+export function isAutoAdventure(state = S) {
+  return !!state.auto?.adventure;
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -65,6 +65,8 @@ import { updateLawsUI } from '../src/features/progression/ui/lawsHUD.js';
 import { calcKarmaGain } from '../src/features/karma/selectors.js';
 import { tickPhysiqueTraining, endTrainingSession } from '../src/features/physique/mutators.js';
 import { mountTrainingGameUI } from '../src/features/physique/ui/trainingGame.js';
+import { toggleAutoMeditate, toggleAutoAdventure } from '../src/features/automation/mutators.js';
+import { isAutoMeditate, isAutoAdventure } from '../src/features/automation/selectors.js';
 
 // Global variables
 const progressBars = {};
@@ -110,15 +112,15 @@ function initUI(){
   // Autos (with safe null checks)
   const autoMeditate = qs('#autoMeditate');
   if (autoMeditate) {
-    autoMeditate.checked = S.auto.meditate;
-    autoMeditate.addEventListener('change', e => S.auto.meditate = e.target.checked);
+    autoMeditate.checked = isAutoMeditate();
+    autoMeditate.addEventListener('change', e => toggleAutoMeditate(e.target.checked));
   }
-  
-  
+
+
   const autoAdventure = qs('#autoAdventure');
   if (autoAdventure) {
-    autoAdventure.checked = S.auto.adventure;
-    autoAdventure.addEventListener('change', e => S.auto.adventure = e.target.checked);
+    autoAdventure.checked = isAutoAdventure();
+    autoAdventure.addEventListener('change', e => toggleAutoAdventure(e.target.checked));
   }
 
   const reduceMotionToggle = qs('#reduceMotionToggle');
@@ -347,9 +349,9 @@ function stopActivity(activityName) {
       log(`Training session complete! ${summary.hits} hits for ${summary.xp} XP`, 'good');
     }
   }
-  if (activityName === 'cultivation' && S.auto) {
+  if (activityName === 'cultivation' && isAutoMeditate()) {
     // Ensure passive meditation doesn't continue when cultivation is stopped
-    S.auto.meditate = false;
+    toggleAutoMeditate(false);
   }
   
   log(`Stopped ${activityName}`, 'neutral');
@@ -738,11 +740,11 @@ function tick(){
   }
   
   // Auto meditation fallback for old saves
-  if(S.auto.meditate && Object.values(S.activities).every(a => !a)) {
+  if(isAutoMeditate() && Object.values(S.activities).every(a => !a)) {
     const gain = foundationGainPerSec(S) * 0.5; // Reduced when not actively cultivating
     S.foundation = clamp(S.foundation + gain, 0, fCap(S));
   }
-  if(S.auto.adventure && !S.activities.adventure){ startActivity('adventure'); }
+  if(isAutoAdventure() && !S.activities.adventure){ startActivity('adventure'); }
 
   // Breakthrough progress
   updateBreakthrough();


### PR DESCRIPTION
## Summary
- add automation mutators and selectors for meditation and adventure
- use mutators and selectors in UI instead of direct state access

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a91c94788326b7b3f9efdf4f7200