### PR TITLE
feat: centralize retreat handling

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -779,7 +779,6 @@ export function retreatFromCombat() {
     S.adventure.combatLog.push('You retreated from combat.');
     claimSessionLoot(); // EQUIP-CHAR-UI
     updateLootTab(); // EQUIP-CHAR-UI
-    log('Retreated from combat safely.', 'neutral');
   }
 }
 

--- a/src/features/adventure/mutators.js
+++ b/src/features/adventure/mutators.js
@@ -1,3 +1,17 @@
+import {
+  selectZone,
+  selectArea,
+  selectAreaById,
+  startAdventureCombat,
+  startBossCombat,
+  progressToNextArea,
+  instakillCurrentEnemy,
+  retreatFromCombat as baseRetreatFromCombat
+} from './logic.js';
+import { qCap } from '../progression/selectors.js';
+import { S } from '../../shared/state.js';
+import { log } from '../../shared/utils/dom.js';
+
 export {
   selectZone,
   selectArea,
@@ -5,6 +19,17 @@ export {
   startAdventureCombat,
   startBossCombat,
   progressToNextArea,
-  retreatFromCombat,
   instakillCurrentEnemy
-} from './logic.js';
+};
+
+export function retreatFromCombat(state = S) {
+  baseRetreatFromCombat();
+  const loss = Math.floor(qCap(state) * 0.25);
+  state.qi = Math.max(0, state.qi - loss);
+  if (typeof globalThis.stopActivity === 'function') {
+    globalThis.stopActivity('adventure');
+  } else if (state.activities) {
+    state.activities.adventure = false;
+  }
+  log(`Retreated from combat. Lost ${loss} Qi.`, 'neutral');
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -816,14 +816,6 @@ function initActivityListeners() {
       } else {
         clearInterval(interval);
         retreatFromCombat();
-        if (typeof globalThis.stopActivity === 'function') {
-          globalThis.stopActivity('adventure');
-        } else {
-          S.activities.adventure = false;
-        }
-        const loss = Math.floor(qCap(S) * 0.25);
-        S.qi = Math.max(0, S.qi - loss);
-        log(`Retreated from combat. Lost ${loss} Qi.`, 'neutral');
         btn.disabled = false;
         btn.classList.remove('warn');
         btn.classList.add('primary');


### PR DESCRIPTION
## Summary
- add adventure retreat mutator that handles qi loss, activity cleanup, and logging
- replace inline retreat logic in UI with mutator call
- drop duplicate combat retreat log in adventure logic

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation and DOM usage warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a925715c83268aba12037bec3fb4