### PR TITLE
feat(adventure): add startAdventure mutator

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -388,6 +388,11 @@ Formats large numbers with shorthand suffixes (k, m, b, t).
 **Dependencies**: `src/features/adventure/data/zones.js` for zone/area data structure
 **When to modify**: Add new zones/areas, modify combat mechanics, adjust boss system, enhance map UI
 
+#### `src/features/adventure/mutators.js` - Adventure Mutators
+Stateful helpers for manipulating adventure progression.
+- `startAdventure()` - Create and initialize the `S.adventure` state container.
+- `retreatFromCombat()` - Retreat from combat and apply Qi penalty.
+
 #### `src/features/adventure/ui/adventureDisplay.js` - Adventure Sidebar Display
 **Purpose**: Renders adventure progress and current area in the sidebar.
 **When to modify**: Adjust adventure sidebar presentation or add new metrics.

--- a/src/features/adventure/mutators.js
+++ b/src/features/adventure/mutators.js
@@ -10,6 +10,8 @@ import {
 } from './logic.js';
 import { qCap } from '../progression/selectors.js';
 import { S } from '../../shared/state.js';
+import { initializeFight } from '../combat/mutators.js';
+import { adventureState } from './state.js';
 import { log } from '../../shared/utils/dom.js';
 
 export {
@@ -21,6 +23,23 @@ export {
   progressToNextArea,
   instakillCurrentEnemy
 };
+
+export function startAdventure(state = S) {
+  if (!state.adventure) {
+    const { enemyHP, enemyMax } = initializeFight({ hp: 0 }, state);
+    state.adventure = {
+      ...structuredClone(adventureState),
+      playerHP: state.hp,
+      enemyHP,
+      enemyMaxHP: enemyMax,
+      lastPlayerAttack: 0,
+      lastEnemyAttack: 0,
+      playerStunBar: 0,
+      enemyStunBar: 0,
+    };
+  }
+  return state.adventure;
+}
 
 export function retreatFromCombat(state = S) {
   baseRetreatFromCombat();

--- a/ui/index.js
+++ b/ui/index.js
@@ -16,7 +16,6 @@ import {
   calculatePlayerCombatAttack,
   calculatePlayerAttackRate
 } from '../src/features/progression/selectors.js';
-import { initializeFight } from '../src/features/combat/mutators.js';
 import { refillShieldFromQi } from '../src/features/combat/logic.js';
 import {
   updateRealmUI,
@@ -41,6 +40,7 @@ import {
 } from '../src/features/adventure/logic.js';
 import { updateActivityCooking, updateCookingSidebar } from '../src/features/cooking/ui/cookingDisplay.js';
 import {
+  startAdventure,
   startAdventureCombat,
   startBossCombat,
   progressToNextArea,
@@ -287,26 +287,7 @@ function startActivity(activityName) {
     }
   } else if (activityName === 'adventure') {
     // Initialize adventure and start first combat
-    if (!S.adventure) {
-      const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
-      S.adventure = {
-        currentZone: 0,
-        currentArea: 0,
-        totalKills: 0,
-        areasCompleted: 0,
-        zonesUnlocked: 1,
-        killsInCurrentArea: 0,
-        inCombat: false,
-        playerHP: S.hp,
-        enemyHP,
-        enemyMaxHP: enemyMax,
-        currentEnemy: null,
-        lastPlayerAttack: 0,
-        lastEnemyAttack: 0,
-        combatLog: []
-      };
-    }
-    
+    startAdventure();
     // Start first combat encounter
     setTimeout(() => startAdventureCombat(), 1000);
   }
@@ -836,27 +817,7 @@ function initActivityListeners() {
     }
 
     // Ensure adventure data is initialized
-    if (!S.adventure) {
-      const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
-      S.adventure = {
-        currentZone: 0,
-        currentArea: 0,
-        selectedZone: 0,
-        selectedArea: 0,
-        totalKills: 0,
-        areasCompleted: 0,
-        zonesUnlocked: 1,
-        killsInCurrentArea: 0,
-        inCombat: false,
-        playerHP: S.hp,
-        enemyHP,
-        enemyMaxHP: enemyMax,
-        currentEnemy: null,
-        lastPlayerAttack: 0,
-        lastEnemyAttack: 0,
-        combatLog: []
-      };
-    }
+    startAdventure();
 
     // Start the adventure activity if not already active
     if (!S.activities.adventure) {
@@ -879,28 +840,8 @@ function initActivityListeners() {
   // Adventure boss challenge button event listener
   document.getElementById('challengeBossButton')?.addEventListener('click', () => {
     // Ensure adventure data is initialized
-    if (!S.adventure) {
-      const { enemyHP, enemyMax } = initializeFight({ hp: 0 });
-      S.adventure = {
-        currentZone: 0,
-        currentArea: 0,
-        selectedZone: 0,
-        selectedArea: 0,
-        totalKills: 0,
-        areasCompleted: 0,
-        zonesUnlocked: 1,
-        killsInCurrentArea: 0,
-        inCombat: false,
-        playerHP: S.hp,
-        enemyHP,
-        enemyMaxHP: enemyMax,
-        currentEnemy: null,
-        lastPlayerAttack: 0,
-        lastEnemyAttack: 0,
-        combatLog: []
-      };
-    }
-    
+    startAdventure();
+
     // Start the adventure activity if not already active
     if (!S.activities.adventure) {
       startActivity('adventure');


### PR DESCRIPTION
## Summary
- centralize adventure state setup with new `startAdventure` mutator
- use `startAdventure` in UI instead of inline object literals
- document adventure mutators, including `startAdventure`
- fix duplicate export in adventure mutators module

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68a7b21e18308326b9e83323fb84a472