### PR TITLE
Add mini dev quick menu and consolidate debug controls

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,12 @@ Selectors read from state and mutators write to state. User interfaces never mut
 
 `src/shared/selectors.js` and `src/shared/mutators.js` re-export each feature's API. Features that need data or behaviour from another slice import through this shared layer, keeping dependencies explicit and avoiding deep relative paths.
 
+### Dev Tools
+- Mini dev menu at `src/ui/dev/devQuickMenu.js` (always available; top-right).
+- Uses `window.__PAUSE/__RESUME/__STEP/__GET_SPEED/__SET_SPEED` if present.
+- Emits `DEV:SET_SEED` for RNG; features/controller may listen to it.
+- If `#debugPanel` exists, it is displayed inside the menu.
+
 #### Migration Process (Incremental)
 
 Keep `progression/logic.js` intact for now; migrate features one at a time (loot → inventory → affixes → ability → combat → adventure → engine). After a feature is migrated, remove its responsibilities from `progression/logic.js` and replace them with registered `tick` hooks or `TICK` listeners.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -271,6 +271,8 @@ way-of-ascension/
 │   │       └── number.js
 │   └── ui/
 │       ├── app.js
+│       ├── dev/
+│       │   └── devQuickMenu.js
 │       └── sidebar.js
 ├── ui/
 │   ├── components/
@@ -604,6 +606,9 @@ function updateAll() {
 #### `src/ui/sidebar.js` - Sidebar Activity Renderer
 **Purpose**: Builds the sidebar activity list and progress displays.
 **When to modify**: Adjust sidebar activities or their presentation.
+
+#### `src/ui/dev/devQuickMenu.js`
+**Purpose:** Tiny top-right Dev button and menu. Uses existing `window.__*` hooks if present; emits `DEV:SET_SEED` for RNG.
 
 #### `src/features/inventory/ui/weaponChip.js` - Weapon Chip HUD
 **Purpose**: Initializes and updates the weapon display chip in the top HUD.

--- a/index.html
+++ b/index.html
@@ -63,7 +63,6 @@
       <div class="chip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
     </div>
     <div class="right-actions">
-      <button class="btn small ghost" id="debugBtn">🐛 Debug</button>
       <button class="btn small ghost" id="saveBtn">💾 Save</button>
       <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
       <button class="btn small ghost" id="importBtn">⬆️ Import</button>
@@ -874,23 +873,15 @@
     </div>
   </div>
 
-  <button id="debugToggle"
-    style="position:fixed;right:.75rem;bottom:.75rem;z-index:99999;padding:.5rem .7rem;border-radius:.6rem;border:1px solid #ccc;background:#fff;opacity:.75">
-    Debug
-  </button>
-  <script>
-  document.getElementById('debugToggle')?.addEventListener('click', async () => {
-    if (!window.eruda) {
-      const s = document.createElement('script');
-      s.src = 'https://cdn.jsdelivr.net/npm/eruda';
-      s.onload = () => eruda.init();
-      document.head.appendChild(s);
-    } else {
-      eruda.destroy(); // hides/removes
-    }
-  });
-  </script>
 
   <script type="module" src="ui/index.js"></script>
+  <script type="module">
+    import { mountDevQuickMenu } from "./src/ui/dev/devQuickMenu.js";
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", () => mountDevQuickMenu());
+    } else {
+      mountDevQuickMenu();
+    }
+  </script>
 </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,15 @@
 import { createGameController } from "./game/GameController.js";
 import { mountAllFeatureUIs } from "./features/index.js";
+import { mountDevQuickMenu } from "./ui/dev/devQuickMenu.js";
 
 const game = createGameController();
 mountAllFeatureUIs(game.state);
 game.start();
 
 // window.game = game; // optional for debugging
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => mountDevQuickMenu());
+} else {
+  mountDevQuickMenu();
+}

--- a/src/ui/dev/devQuickMenu.js
+++ b/src/ui/dev/devQuickMenu.js
@@ -1,0 +1,136 @@
+// src/ui/dev/devQuickMenu.js
+// UI-only mini dev menu: no gameplay imports. Uses window.__* hooks if present,
+// and emits DEV:SET_SEED if the event bus is available.
+
+let mounted = false;
+
+function el(tag, props = {}, children = []) {
+  const n = document.createElement(tag);
+  Object.assign(n, props);
+  for (const c of children) n.append(typeof c === "string" ? document.createTextNode(c) : c);
+  return n;
+}
+
+function callIf(fnName, ...args) {
+  const fn = window[fnName];
+  if (typeof fn === "function") return fn(...args);
+}
+
+function emitDev(type, payload) {
+  try {
+    // optional event bus: src/shared/events.js exports global 'emit' on window?
+    if (typeof window.emit === "function") return window.emit(type, payload);
+    // fallback: dispatch a DOM event others can listen for
+    window.dispatchEvent(new CustomEvent(type, { detail: payload }));
+  } catch {}
+}
+
+export function mountDevQuickMenu() {
+  if (mounted) return; mounted = true;
+
+  // Top-right toggle button
+  const btn = el("button", { id: "devQuickBtn", textContent: "Dev" });
+  Object.assign(btn.style, {
+    position: "fixed", top: "8px", right: "8px", zIndex: 9999,
+    padding: "6px 10px", borderRadius: "8px",
+    border: "1px solid #2b3a55", background: "#0b0f14", color: "#e8f0ff",
+    cursor: "pointer"
+  });
+
+  // Panel
+  const panel = el("div", { id: "devQuickPanel" });
+  Object.assign(panel.style, {
+    position: "fixed", top: "42px", right: "8px", zIndex: 9999,
+    minWidth: "280px", padding: "10px 12px",
+    borderRadius: "12px", border: "1px solid #2b3a55",
+    background: "#0b0f14cc", color: "#e8f0ff", backdropFilter: "blur(2px)",
+    display: "none"
+  });
+
+  const title = el("div", { textContent: "DEV MENU" });
+  title.style.cssText = "font:600 12px ui-monospace,monospace; margin-bottom:8px; opacity:.9;";
+  panel.appendChild(title);
+
+  const row = (label, controlEl) => {
+    const r = el("div"); r.style.cssText = "display:flex; align-items:center; gap:8px; margin:6px 0;";
+    const l = el("div", { textContent: label }); l.style.cssText = "flex:0 0 96px; opacity:.8;";
+    r.append(l, controlEl); return r;
+  };
+  const smallBtn = (txt, on) => {
+    const b = el("button", { textContent: txt });
+    Object.assign(b.style, { padding: "4px 8px", borderRadius: "6px",
+      border: "1px solid #3a4c77", background: "#142034", color: "#cfe", cursor: "pointer" });
+    b.onclick = on; return b;
+  };
+
+  // Loop controls (use window.__ if available; disable if missing)
+  const loopWrap = el("div");
+  loopWrap.style.display = "flex"; loopWrap.style.gap = "6px";
+  const pauseB  = smallBtn("Pause",  () => callIf("__PAUSE"));
+  const resumeB = smallBtn("Resume", () => callIf("__RESUME"));
+  const stepB   = smallBtn("Step",   () => callIf("__STEP"));
+  loopWrap.append(pauseB, resumeB, stepB);
+  panel.appendChild(row("Loop", loopWrap));
+
+  // Speed (only if getters/setters present)
+  const speedWrap = el("div"); speedWrap.style.display = "flex"; speedWrap.style.gap = "8px"; speedWrap.style.alignItems = "center";
+  const speedInput = el("input"); speedInput.type = "range"; speedInput.min = "0.1"; speedInput.max = "4"; speedInput.step = "0.1";
+  const getSpeed = () => Number(callIf("__GET_SPEED") ?? 1);
+  const setSpeed = (v) => callIf("__SET_SPEED", v);
+  speedInput.value = String(getSpeed());
+  const speedVal = el("span", { textContent: getSpeed().toFixed(1) + "x" });
+  speedInput.oninput = () => { const v = Number(speedInput.value) || 1; setSpeed(v); speedVal.textContent = v.toFixed(1) + "x"; };
+  if (typeof window.__GET_SPEED === "function" && typeof window.__SET_SPEED === "function") {
+    speedWrap.append(speedInput, speedVal);
+    panel.appendChild(row("Speed", speedWrap));
+  }
+
+  // RNG seed (emit event first; if no bus, try __SET_SEED)
+  const seedWrap = el("div"); seedWrap.style.display = "flex"; seedWrap.style.gap = "6px";
+  const seedIn = el("input"); seedIn.placeholder = "seed (e.g. 42)";
+  Object.assign(seedIn.style, { width: "120px", padding: "4px 6px",
+    borderRadius: "6px", border: "1px solid #2b3a55", background: "#0b1422", color: "#e8f0ff" });
+  const seedBtn = smallBtn("Set", () => {
+    const seed = seedIn.value || "1234";
+    emitDev("DEV:SET_SEED", { seed });
+    callIf("__SET_SEED", seed);
+  });
+  seedWrap.append(seedIn, seedBtn);
+  panel.appendChild(row("RNG", seedWrap));
+
+  // Misc tools
+  const erudaBtn = smallBtn("Console", () => {
+    if (!window.eruda) {
+      const s = document.createElement("script");
+      s.src = "https://cdn.jsdelivr.net/npm/eruda";
+      s.onload = () => window.eruda && window.eruda.init();
+      document.head.appendChild(s);
+    } else {
+      try { window.eruda.destroy(); } catch {}
+    }
+  });
+  panel.appendChild(row("Tools", erudaBtn));
+
+  // Consolidate existing dev panels if present (non-breaking)
+  // Move any #debugPanel/#debugConsole into our panel
+  setTimeout(() => {
+    const existing = document.getElementById("debugPanel") || document.getElementById("debugConsole");
+    if (existing && !panel.contains(existing)) {
+      existing.style.display = "block";
+      existing.style.position = "static";
+      existing.style.bottom = existing.style.left = "";
+      const hdr = el("div", { textContent: "Existing Debug" });
+      hdr.style.cssText = "margin-top:8px; font:600 12px ui-monospace,monospace; opacity:.9;";
+      const wrap = el("div");
+      wrap.style.cssText = "max-height:180px; overflow:auto; border-top:1px solid #2b3a55; margin-top:6px; padding-top:6px;";
+      wrap.appendChild(existing);
+      panel.append(hdr, wrap);
+    }
+  }, 0);
+
+  // Toggle
+  btn.onclick = () => { panel.style.display = panel.style.display === "none" ? "block" : "none"; };
+
+  document.body.append(btn, panel);
+}
+

--- a/ui/index.js
+++ b/ui/index.js
@@ -157,14 +157,6 @@ function initUI(){
       inp.click();
     });
   }
-  const debugBtn = qs('#debugBtn');
-  const debugConsole = qs('#debugConsole');
-  if (debugBtn && debugConsole) {
-    debugBtn.addEventListener('click', () => {
-      debugConsole.style.display = debugConsole.style.display === 'none' ? 'block' : 'none';
-    });
-  }
-
   const debugRunBtn = qs('#debugRunBtn');
   if (debugRunBtn) {
     debugRunBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Add `src/ui/dev/devQuickMenu.js` providing a small Dev button and panel that hooks into existing window control functions, emits `DEV:SET_SEED`, includes a console toggle, and absorbs any existing debug console
- Mount dev quick menu on document ready via `src/index.js` and a startup script in `index.html`
- Remove legacy debug buttons and move any existing debug console into the dev menu
- Document dev menu in project structure and architecture notes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: undocumented files and UI state violations reported)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aff22c60832690ecdaf5bc74790c