### PR TITLE
refactor law system handlers into progression feature

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -177,3 +177,22 @@ export function breakthroughChance(state = progressionState){
   return clamp(totalChance, 0.01, 0.95);
 }
 
+export function canLearnSkill(lawKey, skillKey, state = progressionState) {
+  const skill = LAWS[lawKey]?.tree?.[skillKey];
+  if (!skill) return false;
+
+  const learned = state.laws.trees[lawKey] || {};
+  if (learned[skillKey]) return false;
+
+  if (state.laws.points < skill.cost) return false;
+
+  if (skill.prereq) {
+    if (Array.isArray(skill.prereq)) {
+      return skill.prereq.every(p => learned[p]);
+    }
+    return !!learned[skill.prereq];
+  }
+
+  return true;
+}
+

--- a/src/features/progression/ui/lawDisplay.js
+++ b/src/features/progression/ui/lawDisplay.js
@@ -1,7 +1,9 @@
 import { LAWS } from '../data/laws.js';
 import { S } from '../../../shared/state.js';
 import { setText } from '../../../shared/utils/dom.js';
-import { on } from '../../../shared/events.js';
+import { on, emit } from '../../../shared/events.js';
+import { selectLaw, learnSkill } from '../mutators.js';
+import { canLearnSkill } from '../logic.js';
 
 
 export function updateLawsDisplay(){
@@ -58,9 +60,20 @@ export function renderLawSelection(){
           return bonus ? `<span class="bonus">${bonus}</span>` : '';
         }).join('')}
       </div>
-      ${!isSelected ? `<button class="btn primary" onclick="selectLaw('${lawKey}')">Select Law</button>` : ''}
     `;
-    
+
+    if (!isSelected) {
+      const btn = document.createElement('button');
+      btn.className = 'btn primary';
+      btn.textContent = 'Select Law';
+      btn.addEventListener('click', () => {
+        selectLaw(lawKey);
+        emit('RENDER');
+        updateLawsDisplay();
+      });
+      div.appendChild(btn);
+    }
+
     container.appendChild(div);
   });
 }
@@ -88,10 +101,21 @@ export function renderSkillTrees(){
       <div class="skill-name">${skill.name}</div>
       <div class="skill-desc">${skill.desc}</div>
       <div class="skill-cost">Cost: ${skill.cost} points</div>
-      ${!isLearned && canLearn ? `<button class="btn small" onclick="learnSkill('${S.laws.selected}', '${skillKey}')">Learn</button>` : ''}
       ${isLearned ? '<div class="learned-badge">✓</div>' : ''}
     `;
-    
+
+    if (!isLearned && canLearn) {
+      const btn = document.createElement('button');
+      btn.className = 'btn small';
+      btn.textContent = 'Learn';
+      btn.addEventListener('click', () => {
+        learnSkill(S.laws.selected, skillKey);
+        emit('RENDER');
+        updateLawsDisplay();
+      });
+      skillDiv.appendChild(btn);
+    }
+
     skillsDiv.appendChild(skillDiv);
   });
   

--- a/ui/index.js
+++ b/ui/index.js
@@ -3,7 +3,6 @@
 
 // Way of Ascension — Modular JS
 
-import { LAWS } from '../src/features/progression/data/laws.js';
 import { S, defaultState, save, setState } from '../src/shared/state.js';
 import {
   clamp,
@@ -575,90 +574,6 @@ function meditate(){
   S.foundation = clamp(S.foundation + gain, 0, fCap(S));
   log(`Meditated: +${gain.toFixed(1)} Foundation`);
   updateAll();
-}
-
-// Law System Functions
-function selectLaw(lawKey){
-  if(!S.laws.unlocked.includes(lawKey)){
-    log('Law not unlocked yet!', 'bad');
-    return;
-  }
-  
-  if(S.laws.selected === lawKey){
-    log('Already following this law!', 'bad');
-    return;
-  }
-  
-  S.laws.selected = lawKey;
-  const law = LAWS[lawKey];
-  log(`You have chosen to follow the ${law.name}!`, 'good');
-  updateAll();
-}
-
-function canLearnSkill(lawKey, skillKey){
-  const skill = LAWS[lawKey].tree[skillKey];
-  if(!skill) return false;
-  
-  // Check if already learned
-  if(S.laws.trees[lawKey][skillKey]) return false;
-  
-  // Check law points
-  if(S.laws.points < skill.cost) return false;
-  
-  // Check prerequisites
-  if(skill.prereq){
-    if(Array.isArray(skill.prereq)){
-      // Multiple prerequisites - all must be met
-      for(const prereq of skill.prereq){
-        if(!S.laws.trees[lawKey][prereq]) return false;
-      }
-    } else {
-      // Single prerequisite
-      if(!S.laws.trees[lawKey][skill.prereq]) return false;
-    }
-  }
-  
-  return true;
-}
-
-function learnSkill(lawKey, skillKey){
-  if(!canLearnSkill(lawKey, skillKey)){
-    log('Cannot learn this skill yet!', 'bad');
-    return;
-  }
-  
-  const skill = LAWS[lawKey].tree[skillKey];
-  S.laws.points -= skill.cost;
-  S.laws.trees[lawKey][skillKey] = true;
-  
-  // Apply skill bonuses
-  applySkillBonuses(lawKey, skillKey);
-  
-  log(`Learned ${skill.name}!`, 'good');
-  updateAll();
-}
-
-function applySkillBonuses(lawKey, skillKey){
-  const skill = LAWS[lawKey].tree[skillKey];
-  const bonus = skill.bonus;
-  
-  // Apply various bonuses
-  // Apply cultivation bonuses
-  if(bonus.cultivationTalent){
-    S.cultivation.talent += bonus.cultivationTalent;
-  }
-  
-  if(bonus.comprehension){
-    S.cultivation.comprehension += bonus.comprehension;
-  }
-  
-  if(bonus.foundationMult){
-    S.cultivation.foundationMult += bonus.foundationMult;
-  }
-  
-  if(bonus.pillMult){
-    S.cultivation.pillMult += bonus.pillMult;
-  }
 }
 
 


### PR DESCRIPTION
## Summary
- move law skill checks and learning into progression feature logic/mutators
- update law UI to import these helpers and attach event listeners instead of globals
- trim legacy law functions from main UI script

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c1c1c7108326a2583b1cb3d28ccb