### PR TITLE
refactor: centralize law system init

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -549,25 +549,6 @@ function updateActivityUI() {
   });
 }
 
-// Initialize law system on game start
-function initLawSystem(){
-  // Ensure laws object exists
-  if(!S.laws) {
-    S.laws = {
-      selected: null,
-      unlocked: [],
-      points: 0,
-      trees: {
-        sword: {},
-        formation: {},
-        alchemy: {}
-      }
-    };
-  }
-  
-  // Check for any laws that should already be unlocked
-  checkLawUnlocks();
-}
 
 function meditate(){
   const gain = foundationGainPerMeditate(S);
@@ -779,7 +760,7 @@ function initActivityListeners() {
 // Init
 window.addEventListener('load', ()=>{
   initUI();
-  initLawSystem();
+  checkLawUnlocks();
   initActivityListeners();
   setupAdventureTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI


### PR DESCRIPTION
## Summary
- remove redundant `initLawSystem` helper from UI bootstrap
- invoke progression `checkLawUnlocks` when app loads to populate law unlocks

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: existing violations)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68a7c3fdaf7c8326b980fcb4a5054612