### PR TITLE
Refactor activity UI into modules

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -723,6 +723,13 @@ Paths added:
 - `docs/ARCHITECTURE.md`
 - `docs/To-dos/stats-to-implement.md`
 - `src/shared/utils/number.js` - number formatting helper
+- `src/features/activity/state.js` – activity state slice
+- `src/features/activity/selectors.js` – activity selectors
+- `src/features/activity/mutators.js` – activity mutators
+- `src/features/activity/ui/activityUI.js` – activity UI helpers
+- `src/features/adventure/ui/mapUI.js` – adventure map UI
+- `src/features/automation/mutators.js` – automation mutators
+- `src/features/automation/selectors.js` – automation selectors
 
 #### `src/game/GameController.js` - Game Orchestrator
 **Purpose**: Boots the game, runs the fixed-step loop, emits events and handles simple routing.
@@ -747,6 +754,34 @@ Paths added:
 
 #### `docs/To-dos/stats-to-implement.md` - Stats Roadmap
 **Purpose**: Lists game stats that still need implementation.
+
+#### `src/features/activity/state.js` - Activity State
+**Purpose**: Ensures activity flags exist on the root state object.
+**Key Functions**: `ensureActivities(state)`.
+
+#### `src/features/activity/selectors.js` - Activity Selectors
+**Purpose**: Helpers for reading activity state.
+**Key Functions**: `getActiveActivity(state)`, `getSelectedActivity(state)`.
+
+#### `src/features/activity/mutators.js` - Activity Mutators
+**Purpose**: Select, start, and stop activities while emitting events.
+**Key Functions**: `selectActivity(state, name)`, `startActivity(state, name)`, `stopActivity(state, name)`.
+
+#### `src/features/activity/ui/activityUI.js` - Activity UI
+**Purpose**: Mounts sidebar listeners and refreshes visible activity panels.
+**Key Functions**: `mountActivityUI(state)`, `updateActivitySelectors(state)`, `updateCurrentTaskDisplay(state)`.
+
+#### `src/features/adventure/ui/mapUI.js` - Adventure Map UI
+**Purpose**: Renders the zone/area selection map overlay.
+**Key Functions**: `showMapOverlay()`, `hideMapOverlay()`.
+
+#### `src/features/automation/mutators.js` - Automation Mutators
+**Purpose**: Toggles options such as auto-meditate and auto-adventure.
+**Key Functions**: `toggleAutoMeditate(value, state)`, `toggleAutoAdventure(value, state)`.
+
+#### `src/features/automation/selectors.js` - Automation Selectors
+**Purpose**: Reads automation settings from state.
+**Key Functions**: `isAutoMeditate(state)`, `isAutoAdventure(state)`.
 
 ### Combat Feature (`src/features/combat/`)
 - `src/features/combat/logic.js` – Core combat calculations such as armor mitigation and shield handling.
@@ -816,6 +851,19 @@ Paths added:
 - `src/features/sect/logic.js` – Core sect calculations and mechanics.
 - `src/features/sect/data/buildings.js` – Building definitions and costs.
 - `src/features/sect/ui/sectScreen.js` – UI for managing the sect.
+
+### Activity Feature (`src/features/activity/`)
+- `src/features/activity/state.js` – Ensures the activity flags exist on the root state.
+- `src/features/activity/selectors.js` – Helpers to read the active and selected activities.
+- `src/features/activity/mutators.js` – Start, stop, or select activities and emit related events.
+- `src/features/activity/ui/activityUI.js` – Mounts sidebar listeners and updates visible activity panels.
+
+### Adventure Feature (`src/features/adventure/`)
+- `src/features/adventure/ui/mapUI.js` – Displays the area selection map overlay.
+
+### Automation Feature (`src/features/automation/`)
+- `src/features/automation/mutators.js` – Toggles automation options like auto-meditate and auto-adventure.
+- `src/features/automation/selectors.js` – Reads automation settings from state.
 
 ### Feature Migration Files
 - `src/features/ability/migrations.js` – Save migrations for ability feature.

--- a/src/features/activity/mutators.js
+++ b/src/features/activity/mutators.js
@@ -1,0 +1,26 @@
+// src/features/activity/mutators.js
+import { ensureActivities } from "./state.js";
+import { emit } from "../../shared/events.js";
+
+export function selectActivity(root, name) {
+  root.ui ??= {};
+  root.ui.selectedActivity = name;
+  emit("UI:ACTIVITY_SELECTED", { name });
+}
+
+export function startActivity(root, name) {
+  ensureActivities(root);
+  for (const k of Object.keys(root.activities)) root.activities[k] = (k === name);
+
+  // Let features react without coupling:
+  emit("ACTIVITY:START", { name });
+
+  // Convenience side-effects that used to live in ui/index.js:
+  if (name === "mining") root.mining ??= { level: 1, exp: 0, expMax: 100, selectedResource: root.mining?.selectedResource || "stones" };
+}
+
+export function stopActivity(root, name) {
+  ensureActivities(root);
+  if (name in root.activities) root.activities[name] = false;
+  emit("ACTIVITY:STOP", { name });
+}

--- a/src/features/activity/selectors.js
+++ b/src/features/activity/selectors.js
@@ -1,0 +1,8 @@
+// src/features/activity/selectors.js
+export function getActiveActivity(root) {
+  if (!root.activities) return null;
+  return Object.keys(root.activities).find(k => root.activities[k]) ?? null;
+}
+export function getSelectedActivity(root) {
+  return root.ui?.selectedActivity || 'cultivation';
+}

--- a/src/features/activity/state.js
+++ b/src/features/activity/state.js
@@ -1,0 +1,13 @@
+// src/features/activity/state.js
+export function ensureActivities(root) {
+  if (!root.activities) {
+    root.activities = {
+      cultivation: false,
+      physique: false,
+      mining: false,
+      adventure: false,
+      cooking: false,
+      sect: false,
+    };
+  }
+}

--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -1,0 +1,101 @@
+// src/features/activity/ui/activityUI.js
+import { selectActivity } from "../mutators.js";
+import { getActiveActivity } from "../selectors.js";
+import { fCap } from "../../progression/selectors.js";
+
+export function mountActivityUI(root) {
+  const handle = name => {
+    selectActivity(root, name);
+    updateActivitySelectors(root);
+    if (typeof globalThis.updateActivityContent === 'function') {
+      globalThis.updateActivityContent();
+    }
+  };
+
+  // Click handlers (new compact sidebar + legacy)
+  document.querySelectorAll('.activity-item[data-activity]')
+    .forEach(el => el.addEventListener('click', () => handle(el.dataset.activity)));
+
+  document.getElementById('cultivationSelector')?.addEventListener('click', () => handle('cultivation'));
+  document.getElementById('physiqueSelector')?.addEventListener('click', () => handle('physique'));
+  document.getElementById('miningSelector')?.addEventListener('click', () => handle('mining'));
+  document.getElementById('adventureSelector')?.addEventListener('click', () => handle('adventure'));
+  document.getElementById('sectSelector')?.addEventListener('click', () => handle('sect'));
+
+  // Initial paint
+  updateActivitySelectors(root);
+  updateCurrentTaskDisplay(root);
+}
+
+export function updateActivitySelectors(root) {
+  // Ensure minimal slices exist for UI reads
+  root.physique ??= { level: 1, exp: 0, expMax: 100 };
+  root.mining   ??= { level: 1, exp: 0, expMax: 100 };
+
+  const selected = root.ui?.selectedActivity || 'cultivation';
+
+  document.querySelectorAll('.activity-content')
+    .forEach(panel => {
+      panel.style.display = panel.id === `activity-${selected}` ? 'block' : 'none';
+    });
+
+  // Cultivation
+  const cultivationSelector = document.getElementById('cultivationSelector');
+  const cultivationFill = document.getElementById('cultivationFill');
+  const cultivationInfo = document.getElementById('cultivationInfo');
+  cultivationSelector?.classList.toggle('active', selected === 'cultivation');
+  cultivationSelector?.classList.toggle('running', root.activities?.cultivation);
+  if (cultivationFill && cultivationInfo) {
+    const foundationPct = (root.foundation / fCap(root)) * 100;
+    cultivationFill.style.width = `${foundationPct}%`;
+    cultivationInfo.textContent = root.activities?.cultivation ? 'Cultivating...' : 'Foundation Progress';
+  }
+
+  // Physique
+  const physSel = document.getElementById('physiqueSelector');
+  const physFill = document.getElementById('physiqueSelectorFill');
+  const physInfo = document.getElementById('physiqueInfo');
+  physSel?.classList.toggle('active', selected === 'physique');
+  physSel?.classList.toggle('running', root.activities?.physique);
+  if (physFill && physInfo) {
+    const expPct = (root.physique.exp / root.physique.expMax) * 100;
+    physFill.style.width = `${expPct}%`;
+    physInfo.textContent = root.activities?.physique ? 'Training...' : `Level ${root.physique.level}`;
+  }
+
+  // Mining
+  const miningSel = document.getElementById('miningSelector');
+  const miningFill = document.getElementById('miningSelectorFill');
+  const miningInfo = document.getElementById('miningInfo');
+  miningSel?.classList.toggle('active', selected === 'mining');
+  miningSel?.classList.toggle('running', root.activities?.mining);
+  if (miningFill && miningInfo) {
+    const expPct = (root.mining.exp / root.mining.expMax) * 100;
+    miningFill.style.width = `${expPct}%`;
+    miningInfo.textContent = root.activities?.mining ? 'Mining...' : `Level ${root.mining.level}`;
+  }
+
+  // Adventure
+  const advSel = document.getElementById('adventureSelector');
+  const advInfo = document.getElementById('adventureInfo');
+  advSel?.classList.toggle('active', selected === 'adventure');
+  advSel?.classList.toggle('running', root.activities?.adventure);
+  if (advInfo) {
+    const loc = root.adventure?.location || 'Village Outskirts';
+    advInfo.textContent = root.activities?.adventure ? 'Exploring...' : loc;
+  }
+
+  // Sect tab indicator (simple)
+  const sectSelector = document.getElementById('sectSelector');
+  sectSelector?.classList.toggle('active', selected === 'sect');
+
+  updateCurrentTaskDisplay(root);
+}
+
+export function updateCurrentTaskDisplay(root) {
+  const el = document.getElementById('currentTask');
+  if (!el) return;
+  const map = { cultivation:'Cultivating', physique:'Physique Training', mining:'Mining', adventure:'Adventuring', cooking:'Cooking' };
+  const active = getActiveActivity(root);
+  el.textContent = active ? (map[active] || 'Idle') : 'Idle';
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -66,10 +66,23 @@ import { tickPhysiqueTraining, endTrainingSession } from '../src/features/physiq
 import { mountTrainingGameUI } from '../src/features/physique/ui/trainingGame.js';
 import { toggleAutoMeditate, toggleAutoAdventure } from '../src/features/automation/mutators.js';
 import { isAutoMeditate, isAutoAdventure } from '../src/features/automation/selectors.js';
+import { selectActivity, startActivity, stopActivity } from '../src/features/activity/mutators.js';
+import { getSelectedActivity } from '../src/features/activity/selectors.js';
+import { mountActivityUI, updateActivitySelectors } from '../src/features/activity/ui/activityUI.js';
 
 // Global variables
 const progressBars = {};
-let selectedActivity = 'cultivation'; // Current selected activity for the sidebar
+
+// Expose activity controls globally for compatibility
+globalThis.startActivity = name => startActivity(S, name);
+globalThis.stopActivity = name => stopActivity(S, name);
+globalThis.selectActivity = name => {
+  selectActivity(S, name);
+  updateActivitySelectors(S);
+  if (typeof globalThis.updateActivityContent === 'function') {
+    globalThis.updateActivityContent();
+  }
+};
 
 
 
@@ -188,12 +201,7 @@ function updateAll(){
   setFill('hpFill', S.hp / S.hpMax);
   setFill('shieldFill', S.shield?.max ? S.shield.current / S.shield.max : 0);
   updateCombatStats();
-  
-  // Activity system display
-  if (!S.activities) {
-    S.activities = { cultivation: false, physique: false, mining: false, adventure: false, cooking: false };
-  }
-  updateCurrentTaskDisplay();
+  updateActivitySelectors(S);
 
 
   // Update progression displays
@@ -221,219 +229,11 @@ function updateAll(){
 
 
 
-// Activity Management System
-
-function selectActivity(activityType) {
-  selectedActivity = activityType;
-  
-  // Update activity item styling for new compact sidebar
-  const activityItems = document.querySelectorAll('.activity-item');
-  activityItems.forEach(item => {
-    item.classList.remove('active');
-    if (item.dataset.activity === activityType) {
-      item.classList.add('active');
-    }
-  });
-  
-  // Hide all activity content panels
-  const activityPanels = document.querySelectorAll('.activity-content');
-  activityPanels.forEach(panel => panel.style.display = 'none');
-  
-  // Hide all tabs
-  const tabs = document.querySelectorAll('section[id^="tab-"]');
-  tabs.forEach(tab => tab.style.display = 'none');
-  
-  // Show selected activity panel
-  const selectedPanel = document.getElementById(`activity-${activityType}`);
-  if (selectedPanel) {
-    selectedPanel.style.display = 'block';
-  }
-  
-  // Update sidebar selectors
-  updateActivitySelectors();
-  updateActivityContent();
-  
-  log(`Switched to ${activityType} view`, 'neutral');
-}
-
-// Combat calculation functions
-
-
-
-
-
-
-function startActivity(activityName) {
-  // Stop all other activities first (strict exclusivity)
-  Object.keys(S.activities).forEach(key => {
-    if (key !== activityName) {
-      S.activities[key] = false;
-    }
-  });
-  
-  if (activityName === 'mining') {
-    // Initialize mining data
-    if (!S.mining.selectedResource) {
-      S.mining.selectedResource = 'stones';
-    }
-  } else if (activityName === 'adventure') {
-    // Initialize adventure and start first combat
-    startAdventure();
-    // Start first combat encounter
-    setTimeout(() => startAdventureCombat(), 1000);
-  }
-  
-  // Start the requested activity
-  S.activities[activityName] = true;
-  
-  // Log appropriate message
-  switch(activityName) {
-    case 'cultivation':
-      log('Started cultivating. Foundation will increase over time.', 'good');
-      break;
-    case 'physique':
-      log('Started physique training. Use the training interface to gain experience!', 'good');
-      break;
-    case 'mining':
-      log('Started mining operations. Select a resource to mine passively.', 'good');
-      break;
-    case 'adventure':
-      log('Started exploring. Adventure awaits!', 'good');
-      break;
-    case 'cooking':
-      log('Started cooking. Prepare your meals carefully.', 'good');
-      break;
-    default:
-      log(`Started ${activityName}`, 'good');
-  }
-  
-  updateActivitySelectors();
-  updateActivityContent();
-}
-
-function stopActivity(activityName) {
-  S.activities[activityName] = false;
-  
-  // Stop any active physique training session
-  if (activityName === 'physique') {
-    const summary = endTrainingSession(S);
-    if (summary) {
-      log(`Training session complete! ${summary.hits} hits for ${summary.xp} XP`, 'good');
-    }
-  }
-  if (activityName === 'cultivation' && isAutoMeditate()) {
-    // Ensure passive meditation doesn't continue when cultivation is stopped
-    toggleAutoMeditate(false);
-  }
-  
-  log(`Stopped ${activityName}`, 'neutral');
-  updateActivitySelectors();
-  updateActivityContent();
-}
-
-// Expose activity controls globally so other modules like the progression realm UI can access
-// them when binding UI event handlers. Without this, the cultivation start/stop
-// button fails to toggle the activity state.
-window.startActivity = startActivity;
-window.stopActivity = stopActivity;
-
-function updateCurrentTaskDisplay() {
-  const el = document.getElementById('currentTask');
-  if (!el) return;
-  const names = {
-    cultivation: 'Cultivating',
-    physique: 'Physique Training',
-    mining: 'Mining',
-    adventure: 'Adventuring',
-    cooking: 'Cooking'
-  };
-  const active = S.activities ? Object.keys(S.activities).find(key => S.activities[key]) : null;
-  el.textContent = active ? (names[active] || 'Idle') : 'Idle';
-}
-
-function updateActivitySelectors() {
-  // Ensure physique and mining data structures exist
-  if (!S.physique) {
-    S.physique = { level: 1, exp: 0, expMax: 100 };
-  }
-  if (!S.mining) {
-    S.mining = { level: 1, exp: 0, expMax: 100 };
-  }
-  
-  // Update cultivation selector
-  const cultivationSelector = document.getElementById('cultivationSelector');
-  const cultivationFill = document.getElementById('cultivationFill');
-  const cultivationInfo = document.getElementById('cultivationInfo');
-  
-  if (cultivationSelector) {
-    cultivationSelector.classList.toggle('active', selectedActivity === 'cultivation');
-    cultivationSelector.classList.toggle('running', S.activities.cultivation);
-  }
-  
-  if (cultivationFill && cultivationInfo) {
-    const foundationPct = S.foundation / fCap(S) * 100;
-    cultivationFill.style.width = `${foundationPct}%`;
-    cultivationInfo.textContent = S.activities.cultivation ? 'Cultivating...' : 'Foundation Progress';
-  }
-  
-  // Update physique selector
-  const physiqueSelector = document.getElementById('physiqueSelector');
-  const physiqueFill = document.getElementById('physiqueSelectorFill');
-  const physiqueInfo = document.getElementById('physiqueInfo');
-  
-  if (physiqueSelector) {
-    physiqueSelector.classList.toggle('active', selectedActivity === 'physique');
-    physiqueSelector.classList.toggle('running', S.activities.physique);
-  }
-  
-  if (physiqueFill && physiqueInfo) {
-    const expPct = S.physique.exp / S.physique.expMax * 100;
-    physiqueFill.style.width = `${expPct}%`;
-    physiqueInfo.textContent = S.activities.physique ? 'Training...' : `Level ${S.physique.level}`;
-  }
-  
-  // Update mining selector
-  const miningSelector = document.getElementById('miningSelector');
-  const miningFill = document.getElementById('miningSelectorFill');
-  const miningInfo = document.getElementById('miningInfo');
-  
-  if (miningSelector) {
-    miningSelector.classList.toggle('active', selectedActivity === 'mining');
-    miningSelector.classList.toggle('running', S.activities.mining);
-  }
-  
-  if (miningFill && miningInfo) {
-    const expPct = S.mining.exp / S.mining.expMax * 100;
-    miningFill.style.width = `${expPct}%`;
-    miningInfo.textContent = S.activities.mining ? 'Mining...' : `Level ${S.mining.level}`;
-  }
-  
-  // Update adventure selector
-  const adventureSelector = document.getElementById('adventureSelector');
-  const adventureInfo = document.getElementById('adventureInfo');
-  
-  if (adventureSelector) {
-    adventureSelector.classList.toggle('active', selectedActivity === 'adventure');
-    adventureSelector.classList.toggle('running', S.activities.adventure);
-  }
-  
-  if (adventureInfo) {
-    const location = S.adventure && S.adventure.location ? S.adventure.location : 'Village Outskirts';
-    adventureInfo.textContent = S.activities.adventure ? 'Exploring...' : location;
-  }
-  
-  // Update sect selector
-  const sectSelector = document.getElementById('sectSelector');
-  if (sectSelector) {
-    sectSelector.classList.toggle('active', selectedActivity === 'sect');
-  }
-  updateCurrentTaskDisplay();
-}
-
 function updateActivityContent() {
   // Update cultivation activity content
   updateActivityCultivation();
-  switch(selectedActivity) {
+  const selected = getSelectedActivity(S);
+  switch(selected) {
     case 'adventure':
       updateActivityAdventure();
       break;
@@ -445,6 +245,7 @@ function updateActivityContent() {
       break;
   }
 }
+globalThis.updateActivityContent = updateActivityContent;
 
 
 // Update sidebar activity displays
@@ -491,7 +292,7 @@ function updateSidebarActivities() {
   // Update sect status indicator
   const sectStatus = document.getElementById('sectStatus');
   if (sectStatus) {
-    if (selectedActivity === 'sect') {
+    if (getSelectedActivity(S) === 'sect') {
       sectStatus.textContent = 'Active';
       sectStatus.classList.add('active');
     } else {
@@ -503,7 +304,7 @@ function updateSidebarActivities() {
 
 // Legacy function for compatibility
 function updateActivityCards() {
-  updateActivitySelectors();
+  updateActivitySelectors(S);
   updateActivityContent();
 }
 
@@ -632,7 +433,7 @@ function tick(){
     const gain = foundationGainPerSec(S) * 0.5; // Reduced when not actively cultivating
     S.foundation = clamp(S.foundation + gain, 0, fCap(S));
   }
-  if(isAutoAdventure() && !S.activities.adventure){ startActivity('adventure'); }
+  if(isAutoAdventure() && !S.activities.adventure){ startActivity(S, 'adventure'); }
 
   // Breakthrough progress
   updateBreakthrough();
@@ -651,22 +452,6 @@ function tick(){
 
 // Activity selector event listeners
 function initActivityListeners() {
-  // New compact sidebar activity listeners
-  const activityItems = document.querySelectorAll('.activity-item[data-activity]');
-  activityItems.forEach(item => {
-    item.addEventListener('click', () => {
-      const activityType = item.dataset.activity;
-      selectActivity(activityType);
-    });
-  });
-  
-  // Legacy selectors (if they exist)
-  document.getElementById('cultivationSelector')?.addEventListener('click', () => selectActivity('cultivation'));
-  document.getElementById('physiqueSelector')?.addEventListener('click', () => selectActivity('physique'));
-  document.getElementById('miningSelector')?.addEventListener('click', () => selectActivity('mining'));
-  document.getElementById('adventureSelector')?.addEventListener('click', () => selectActivity('adventure'));
-  document.getElementById('sectSelector')?.addEventListener('click', () => selectActivity('sect'));
-  
   // Activity content event listeners
   document.getElementById('useQiPillActivity')?.addEventListener('click', () => usePill('qi'));
   document.getElementById('useWardPillActivity')?.addEventListener('click', () => usePill('ward'));
@@ -728,7 +513,7 @@ function initActivityListeners() {
 
     // Start the adventure activity if not already active
     if (!S.activities.adventure) {
-      startActivity('adventure');
+      startActivity(S, 'adventure');
     }
 
     // Start combat immediately
@@ -751,7 +536,7 @@ function initActivityListeners() {
 
     // Start the adventure activity if not already active
     if (!S.activities.adventure) {
-      startActivity('adventure');
+      startActivity(S, 'adventure');
     }
     
     // Start boss combat
@@ -772,12 +557,13 @@ function initActivityListeners() {
 window.addEventListener('load', ()=>{
   initUI();
   initLawSystem();
+  mountActivityUI(S);
   initActivityListeners();
   setupAdventureTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI
   mountAlchemyUI(S);
   mountKarmaUI(S);
-  selectActivity('cultivation'); // Start with cultivation selected
+  selectActivity(S, 'cultivation'); // Start with cultivation selected
   updateAll();
   tick();
   log('Welcome, cultivator.');


### PR DESCRIPTION
## Summary
- Extract activity state initialization to `ensureActivities`
- Add selectors for active and selected activities
- Introduce mutators for selecting, starting, and stopping activities with event hooks
- Build dedicated activity UI module and integrate it into main UI
- Ensure activity tabs display the correct content when selected
- Refresh activity panels immediately on tab selection
- Document activity, adventure map, and automation modules in project structure

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: requires documentation update for new files despite edits)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cf3b535c8326b1a2c8aea2d1495b