### PR TITLE
Add meditation, pill usage, and adventure controls

### DIFF
--- a/src/features/adventure/ui/adventureDisplay.js
+++ b/src/features/adventure/ui/adventureDisplay.js
@@ -1,6 +1,8 @@
 import { S } from '../../../shared/state.js';
 import { setFill, setText } from '../../../shared/utils/dom.js';
 import { ZONES } from '../data/zones.js';
+import { startAdventure, startAdventureCombat, startBossCombat, progressToNextArea, retreatFromCombat } from '../mutators.js';
+import { updateActivityAdventure } from '../logic.js';
 
 export function updateAdventureProgress(state = S) {
   if (!state.adventure) return;
@@ -13,4 +15,65 @@ export function updateAdventureProgress(state = S) {
     setText('adventureProgressText', `${Math.floor(progress * 100)}%`);
   }
   setText('adventureLevel', location);
+}
+
+export function mountAdventureControls(root) {
+  // Map overlay
+  document.getElementById('mapButton')?.addEventListener('click', () => {
+    import('./mapUI.js').then(({ showMapOverlay }) => showMapOverlay());
+  });
+
+  function startRetreatCountdown() {
+    const btn = document.getElementById('startBattleButton');
+    if (!root.adventure || !root.adventure.inCombat || !btn) return;
+    let remaining = 5;
+    btn.disabled = true;
+    btn.textContent = `Retreating (${remaining})`;
+    const it = setInterval(() => {
+      if (root.adventure.playerHP <= 0) {
+        clearInterval(it);
+        btn.disabled = false;
+        btn.classList.remove('warn'); btn.classList.add('primary');
+        btn.textContent = '⚔️ Start Battle';
+        (globalThis.stopActivity?.('adventure'));
+        root.qi = 0;
+        updateActivityAdventure();
+        return;
+      }
+      remaining--;
+      if (remaining > 0) {
+        btn.textContent = `Retreating (${remaining})`;
+      } else {
+        clearInterval(it);
+        retreatFromCombat();
+        btn.disabled = false;
+        btn.classList.remove('warn'); btn.classList.add('primary');
+        btn.textContent = '⚔️ Start Battle';
+        updateActivityAdventure();
+      }
+    }, 1000);
+  }
+
+  const startBtn = document.getElementById('startBattleButton');
+  startBtn?.addEventListener('click', () => {
+    if (root.adventure && root.adventure.inCombat) { startRetreatCountdown(); return; }
+    startAdventure();
+    if (!root.activities?.adventure && typeof globalThis.startActivity === 'function') {
+      globalThis.startActivity('adventure');
+    }
+    startAdventureCombat();
+    updateActivityAdventure();
+    startBtn.textContent = '🏃 Retreat';
+    startBtn.classList.remove('primary'); startBtn.classList.add('warn');
+  });
+
+  document.getElementById('progressButton')?.addEventListener('click', () => progressToNextArea());
+  document.getElementById('challengeBossButton')?.addEventListener('click', () => {
+    startAdventure();
+    if (!root.activities?.adventure && typeof globalThis.startActivity === 'function') {
+      globalThis.startActivity('adventure');
+    }
+    startBossCombat();
+    updateActivityAdventure();
+  });
 }

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -2,6 +2,7 @@ import { S, save } from '../../shared/state.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
+import { qCap, clamp } from '../progression/selectors.js';
 
 export function addToInventory(item, state = S) {
   state.inventory = state.inventory || [];
@@ -52,4 +53,25 @@ export function unequip(slot, state = S) {
   const payload = { key: 'fist', name: 'Fists', slot };
   if (slot === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);
   return payload;
+}
+
+export function usePill(root, type) {
+  root.pills ??= { qi: 0, body: 0, ward: 0 };
+  if ((root.pills[type] ?? 0) <= 0) return { ok: false, reason: 'none' };
+
+  if (type === 'qi') {
+    const add = Math.floor(qCap(root) * 0.25);
+    root.qi = clamp(root.qi + add, 0, qCap(root));
+  }
+  if (type === 'body') {
+    root.tempAtk = (root.tempAtk || 0) + 4;
+    root.tempDef = (root.tempDef || 0) + 3;
+    // NOTE: timer remains in UI for now; long-term move to a timed effect system
+  }
+  if (type === 'ward') {
+    // consumed during breakthrough
+  }
+
+  root.pills[type]--;
+  return { ok: true, type };
 }

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -3,6 +3,7 @@ import { REALMS } from './data/realms.js';
 import { LAWS } from './data/laws.js';
 import { log } from '../../shared/utils/dom.js';
 import { canLearnSkill } from './logic.js';
+import { clamp, fCap, foundationGainPerMeditate } from './selectors.js';
 
 export function advanceRealm(state = progressionState) {
   const wasRealmAdvancement = state.realm.stage > REALMS[state.realm.tier].stages;
@@ -138,4 +139,10 @@ function applySkillBonuses(lawKey, skillKey, state = progressionState) {
   if (bonus.comprehension) state.cultivation.comprehension = (state.cultivation.comprehension || 0) + bonus.comprehension;
   if (bonus.foundationMult) state.cultivation.foundationMult += bonus.foundationMult;
   if (bonus.pillMult) state.cultivation.pillMult += bonus.pillMult;
+}
+
+export function meditate(root) {
+  const gain = foundationGainPerMeditate(root);
+  root.foundation = clamp(root.foundation + gain, 0, fCap(root));
+  return gain;
 }


### PR DESCRIPTION
## Summary
- Add meditate mutator to grow foundation within bounds
- Implement usePill for qi, body, and ward pills with clamped qi gain
- Mount adventure controls for map overlay, battles, retreats, and boss challenges
- Delegate meditation, pill handling, and adventure controls from `ui/index.js` to dedicated modules

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: verification protocol violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f664bfd08326abf7632545fffb38