### PR TITLE
Refactor activity state into slice with helpers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,6 +88,10 @@ The `mutators.js` file writes a generated weapon into the state slice and expose
 
 Weapon generation data includes `weaponTypes.js`, `weapons.js`, `weaponIcons.js` and `materials.stub.js`.  The `weaponTypes.js` file defines the base DPS, scaling and tags for each weapon type and references signature abilities that are still stubs for later implementation:contentReference[oaicite:14]{index=14}.  The `weapons.js` file builds a list of default weapon items using `generateWeapon()` and exports convenience objects like `WEAPON_FLAGS` and `WEAPON_CONFIG` for quick lookups:contentReference[oaicite:15]{index=15}.
 
+### Activity feature
+
+The Activity module tracks which major task the player is performing. Its `state.js` exports an `activityState` object and an `initialState()` helper that adds the `_v` version tag. Pure helpers such as `isValidActivity(name)` live in `logic.js`, and `migrations.js` exposes an array reserved for future save migrations.
+
 ## Legacy `src/game` modules
 
 The original `src/game` folder has largely been superseded.  With the root state and helpers moved into `src/shared/`, this directory now primarily houses `GameController.js` as a bridge for the legacy world.  Any remaining legacy systems will continue to be migrated into `src/features` until the folder can be retired entirely.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -287,6 +287,8 @@ way-of-ascension/
 ├── server.js
 ├── src/features/ability/index.js
 ├── src/features/activity/index.js
+├── src/features/activity/logic.js
+├── src/features/activity/migrations.js
 ├── src/features/activity/mutators.js
 ├── src/features/activity/selectors.js
 ├── src/features/activity/state.js
@@ -739,7 +741,9 @@ Paths added:
 - `docs/ARCHITECTURE.md`
 - `docs/To-dos/stats-to-implement.md`
 - `src/shared/utils/number.js` - number formatting helper
-- `src/features/activity/state.js` – activity state slice
+- `src/features/activity/state.js` – activity state slice and `initialState()`
+- `src/features/activity/logic.js` – activity helpers
+- `src/features/activity/migrations.js` – activity save migrations
 - `src/features/activity/selectors.js` – activity selectors
 - `src/features/activity/mutators.js` – activity mutators
 - `src/features/activity/ui/activityUI.js` – activity UI helpers
@@ -772,8 +776,12 @@ Paths added:
 **Purpose**: Lists game stats that still need implementation.
 
 #### `src/features/activity/state.js` - Activity State
-**Purpose**: Ensures activity flags exist on the root state object.
-**Key Functions**: `ensureActivities(state)`.
+**Purpose**: Defines default activity flags and exposes `initialState()`.
+**Exports**: `activityState`, `initialState()`.
+
+#### `src/features/activity/logic.js` - Activity Logic
+**Purpose**: Pure helpers for activity rules.
+**Key Functions**: `isValidActivity(name)`.
 
 #### `src/features/activity/selectors.js` - Activity Selectors
 **Purpose**: Helpers for reading activity state.
@@ -782,6 +790,9 @@ Paths added:
 #### `src/features/activity/mutators.js` - Activity Mutators
 **Purpose**: Select, start, and stop activities while emitting events.
 **Key Functions**: `selectActivity(state, name)`, `startActivity(state, name)`, `stopActivity(state, name)`.
+
+#### `src/features/activity/migrations.js` - Activity Migrations
+**Purpose**: Holds save migrations for the activity slice.
 
 #### `src/features/activity/ui/activityUI.js` - Activity UI
 **Purpose**: Mounts sidebar listeners and refreshes visible activity panels.
@@ -869,9 +880,11 @@ Paths added:
 - `src/features/sect/ui/sectScreen.js` – UI for managing the sect.
 
 ### Activity Feature (`src/features/activity/`)
-- `src/features/activity/state.js` – Ensures the activity flags exist on the root state.
+- `src/features/activity/state.js` – Defines activity flags and provides `initialState()`.
+- `src/features/activity/logic.js` – Validation helpers for activity names.
 - `src/features/activity/selectors.js` – Helpers to read the active and selected activities.
 - `src/features/activity/mutators.js` – Start, stop, or select activities and emit related events.
+- `src/features/activity/migrations.js` – Save migrations for the activity feature.
 - `src/features/activity/ui/activityUI.js` – Mounts sidebar listeners and updates visible activity panels.
 
 ### Adventure Feature (`src/features/adventure/`)
@@ -883,6 +896,7 @@ Paths added:
 
 ### Feature Migration Files
 - `src/features/ability/migrations.js` – Save migrations for ability feature.
+- `src/features/activity/migrations.js` – Save migrations for activity feature.
 - `src/features/adventure/migrations.js` – Save migrations for adventure feature.
 - `src/features/alchemy/migrations.js` – Save migrations for alchemy feature.
 - `src/features/affixes/migrations.js` – Save migrations for affixes feature.

--- a/src/features/activity/index.js
+++ b/src/features/activity/index.js
@@ -1,12 +1,6 @@
+import { initialState } from "./state.js";
+
 export const ActivityFeature = {
   key: "activities",
-  initialState: () => ({
-    cultivation: false,
-    physique: false,
-    mining: false,
-    adventure: false,
-    cooking: false,
-    sect: false,
-    _v: 0,
-  }),
+  initialState,
 };

--- a/src/features/activity/logic.js
+++ b/src/features/activity/logic.js
@@ -1,0 +1,5 @@
+import { activityState } from './state.js';
+
+export function isValidActivity(name) {
+  return Object.prototype.hasOwnProperty.call(activityState, name);
+}

--- a/src/features/activity/migrations.js
+++ b/src/features/activity/migrations.js
@@ -1,0 +1,1 @@
+export const migrations = [];

--- a/src/features/activity/state.js
+++ b/src/features/activity/state.js
@@ -1,13 +1,12 @@
-// src/features/activity/state.js
-export function ensureActivities(root) {
-  if (!root.activities) {
-    root.activities = {
-      cultivation: false,
-      physique: false,
-      mining: false,
-      adventure: false,
-      cooking: false,
-      sect: false,
-    };
-  }
+export const activityState = {
+  cultivation: false,
+  physique: false,
+  mining: false,
+  adventure: false,
+  cooking: false,
+  sect: false,
+};
+
+export function initialState() {
+  return { ...activityState, _v: 0 };
 }


### PR DESCRIPTION
## Summary
- refactor activity state to export `activityState` and `initialState`
- add `logic.js` helper and empty `migrations.js`
- document new activity files and reference `initialState` in feature descriptor

## Testing
- `node scripts/validate-structure.js` *(fails: UI state violations in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a8721657088326b6d00de92b2f5eb6