### PR TITLE
feat: add automation state and docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,6 +88,13 @@ The `mutators.js` file writes a generated weapon into the state slice and expose
 
 Weapon generation data includes `weaponTypes.js`, `weapons.js`, `weaponIcons.js` and `materials.stub.js`.  The `weaponTypes.js` file defines the base DPS, scaling and tags for each weapon type and references signature abilities that are still stubs for later implementation:contentReference[oaicite:14]{index=14}.  The `weapons.js` file builds a list of default weapon items using `generateWeapon()` and exports convenience objects like `WEAPON_FLAGS` and `WEAPON_CONFIG` for quick lookups:contentReference[oaicite:15]{index=15}.
 
+### Automation feature
+
+The **Automation** module stores flags for enabling background actions such as meditation and adventuring.
+Its `state.js` defines `automationState` and an `initialState()` helper that adds version metadata.
+`logic.js` contains pure calculations like `isAnyAutomationEnabled()` for derived checks.
+Mutators flip automation flags while selectors read them, and `migrations.js` exports an array for save upgrades.
+
 ## Legacy `src/game` modules
 
 The original `src/game` folder has largely been superseded.  With the root state and helpers moved into `src/shared/`, this directory now primarily houses `GameController.js` as a bridge for the legacy world.  Any remaining legacy systems will continue to be migrated into `src/features` until the folder can be retired entirely.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -295,8 +295,11 @@ way-of-ascension/
 ├── src/features/adventure/ui/mapUI.js
 ├── src/features/affixes/index.js
 ├── src/features/automation/index.js
+├── src/features/automation/logic.js
+├── src/features/automation/migrations.js
 ├── src/features/automation/mutators.js
 ├── src/features/automation/selectors.js
+├── src/features/automation/state.js
 ├── src/features/combat/index.js
 ├── src/features/karma/index.js
 ├── src/features/mining/index.js
@@ -744,8 +747,11 @@ Paths added:
 - `src/features/activity/mutators.js` – activity mutators
 - `src/features/activity/ui/activityUI.js` – activity UI helpers
 - `src/features/adventure/ui/mapUI.js` – adventure map UI
+- `src/features/automation/logic.js` – automation logic helpers
+- `src/features/automation/migrations.js` – automation save migrations
 - `src/features/automation/mutators.js` – automation mutators
 - `src/features/automation/selectors.js` – automation selectors
+- `src/features/automation/state.js` – automation state slice
 
 #### `src/game/GameController.js` - Game Orchestrator
 **Purpose**: Boots the game, runs the fixed-step loop, emits events and handles simple routing.
@@ -790,6 +796,18 @@ Paths added:
 #### `src/features/adventure/ui/mapUI.js` - Adventure Map UI
 **Purpose**: Renders the zone/area selection map overlay.
 **Key Functions**: `showMapOverlay()`, `hideMapOverlay()`.
+
+#### `src/features/automation/state.js` - Automation State
+**Purpose**: Defines default automation flags and provides `initialState()`.
+**Key Exports**: `automationState`, `initialState()`.
+
+#### `src/features/automation/logic.js` - Automation Logic
+**Purpose**: Pure helpers for automation calculations.
+**Key Functions**: `slice(root)`, `isAnyAutomationEnabled(root)`.
+
+#### `src/features/automation/migrations.js` - Automation Migrations
+**Purpose**: Save migrations for automation slice.
+**Key Exports**: `migrations` array.
 
 #### `src/features/automation/mutators.js` - Automation Mutators
 **Purpose**: Toggles options such as auto-meditate and auto-adventure.
@@ -878,6 +896,9 @@ Paths added:
 - `src/features/adventure/ui/mapUI.js` – Displays the area selection map overlay.
 
 ### Automation Feature (`src/features/automation/`)
+- `src/features/automation/state.js` – Default automation flags and `initialState()` helper.
+- `src/features/automation/logic.js` – Pure helpers for automation calculations.
+- `src/features/automation/migrations.js` – Save migrations for automation feature.
 - `src/features/automation/mutators.js` – Toggles automation options like auto-meditate and auto-adventure.
 - `src/features/automation/selectors.js` – Reads automation settings from state.
 
@@ -886,6 +907,7 @@ Paths added:
 - `src/features/adventure/migrations.js` – Save migrations for adventure feature.
 - `src/features/alchemy/migrations.js` – Save migrations for alchemy feature.
 - `src/features/affixes/migrations.js` – Save migrations for affixes feature.
+- `src/features/automation/migrations.js` – Save migrations for automation feature.
 - `src/features/combat/migrations.js` – Save migrations for combat feature.
 - `src/features/cooking/migrations.js` – Save migrations for cooking feature.
 - `src/features/inventory/migrations.js` – Save migrations for inventory and equipment.

--- a/src/features/automation/index.js
+++ b/src/features/automation/index.js
@@ -1,8 +1,6 @@
+import { initialState } from "./state.js";
+
 export const AutomationFeature = {
   key: "auto",
-  initialState: () => ({
-    meditate: false,
-    adventure: false,
-    _v: 0,
-  }),
+  initialState,
 };

--- a/src/features/automation/logic.js
+++ b/src/features/automation/logic.js
@@ -1,0 +1,10 @@
+import { automationState } from "./state.js";
+
+export function slice(root) {
+  return root.auto || automationState;
+}
+
+export function isAnyAutomationEnabled(root) {
+  const a = slice(root);
+  return !!(a.meditate || a.adventure);
+}

--- a/src/features/automation/migrations.js
+++ b/src/features/automation/migrations.js
@@ -1,0 +1,1 @@
+export const migrations = [];

--- a/src/features/automation/state.js
+++ b/src/features/automation/state.js
@@ -1,0 +1,8 @@
+export const automationState = {
+  meditate: false,
+  adventure: false,
+};
+
+export function initialState() {
+  return { ...automationState, _v: 0 };
+}


### PR DESCRIPTION
## Summary
- extract automation default state and initialState helper
- add pure logic helpers and migrations scaffold for automation feature
- document automation files in architecture and project structure docs

## Testing
- `node scripts/validate-structure.js` *(fails: UI state violations in existing files)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a872203c6c8326aec89bb0a4863f38