### PR TITLE
Decouple mining initialization from activity start

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ Other folders such as `scripts/` (build or deployment scripts), `browser-tools-m
 
 #### Events Bus
 
-A tiny pub/sub lives in `src/shared/events.js` exposing `on`, `off` and `emit`. The controller emits `TICK` (fixed step) and `RENDER` (per frame). Feature UIs subscribe to `RENDER` to redraw, and systems can listen to `TICK` for simulation updates.
+A tiny pub/sub lives in `src/shared/events.js` exposing `on`, `off` and `emit`. The controller emits `TICK` (fixed step) and `RENDER` (per frame). Feature UIs subscribe to `RENDER` to redraw, and systems can listen to `TICK` for simulation updates. Mutators can also broadcast domain events; for example `startActivity` emits `ACTIVITY:START` with the root state and activity name so features like mining can initialise themselves without direct dependencies.
 
 #### Entrypoint & Bootstrap
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -786,7 +786,7 @@ Paths added:
 **Key Functions**: `getActiveActivity(state)`, `getSelectedActivity(state)`.
 
 #### `src/features/activity/mutators.js` - Activity Mutators
-**Purpose**: Select, start, and stop activities while emitting events.
+**Purpose**: Select, start, and stop activities while emitting events. `startActivity` broadcasts `ACTIVITY:START` with the root state and activity name.
 **Key Functions**: `selectActivity(state, name)`, `startActivity(state, name)`, `stopActivity(state, name)`.
 
 #### `src/features/activity/ui/activityUI.js` - Activity UI
@@ -840,7 +840,7 @@ Paths added:
 ### Mining Feature (`src/features/mining/`)
 - `src/features/mining/state.js` – Tracks mining level, experience, unlocked resources and yields.
 - `src/features/mining/logic.js` – Handles mining rates, resource gains and experience progression.
-- `src/features/mining/mutators.js` – External wrappers to modify mining state.
+- `src/features/mining/mutators.js` – External wrappers to modify mining state and listeners for `ACTIVITY:START` to apply default values.
 - `src/features/mining/selectors.js` – Provides accessors for mining state and derived rates.
 - `src/features/mining/ui/miningDisplay.js` – Updates mining activity and sidebar displays.
 

--- a/src/features/activity/mutators.js
+++ b/src/features/activity/mutators.js
@@ -13,10 +13,7 @@ export function startActivity(root, name) {
   for (const k of Object.keys(root.activities)) root.activities[k] = (k === name);
 
   // Let features react without coupling:
-  emit("ACTIVITY:START", { name });
-
-  // Convenience side-effects that used to live in ui/index.js:
-  if (name === "mining") root.mining ??= { level: 1, exp: 0, expMax: 100, selectedResource: root.mining?.selectedResource || "stones" };
+  emit("ACTIVITY:START", { root, name });
 }
 
 export function stopActivity(root, name) {

--- a/src/features/mining/mutators.js
+++ b/src/features/mining/mutators.js
@@ -1,5 +1,17 @@
 import { S } from '../../shared/state.js';
+import { on } from '../../shared/events.js';
+import { miningState } from './state.js';
 import { selectResource as logicSelectResource, advanceMining as logicAdvanceMining } from './logic.js';
+
+// Initialize defaults when mining starts
+on('ACTIVITY:START', ({ root, name }) => {
+  if (name !== 'mining') return;
+  root.mining ??= {
+    ...miningState,
+    unlockedResources: [...miningState.unlockedResources],
+    selectedResource: root.mining?.selectedResource || miningState.selectedResource,
+  };
+});
 
 export function selectResource(resource, state = S) {
   logicSelectResource(resource, state);


### PR DESCRIPTION
## Summary
- startActivity now emits the activity start event with state instead of hard-coding mining defaults
- mining mutators listen for the ACTIVITY:START event to apply default mining state
- document the event-driven activity initialization in architecture and project structure docs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and DOM usage warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ed3aec408326bacb401fdb13b87d