### PR TITLE
feat: add retreat qi reset mutator

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -413,6 +413,7 @@ Formats large numbers with shorthand suffixes (k, m, b, t).
 Stateful helpers for manipulating adventure progression.
 - `startAdventure()` - Create and initialize the `S.adventure` state container.
 - `retreatFromCombat()` - Retreat from combat and apply Qi penalty.
+- `resetQiOnRetreat()` - Reset Qi to zero when the player dies while retreating.
 
 #### `src/features/adventure/ui/adventureDisplay.js` - Adventure Sidebar Display
 **Purpose**: Renders adventure progress and current area in the sidebar.

--- a/src/features/adventure/mutators.js
+++ b/src/features/adventure/mutators.js
@@ -52,3 +52,13 @@ export function retreatFromCombat(state = S) {
   }
   log(`Retreated from combat. Lost ${loss} Qi.`, 'neutral');
 }
+
+/**
+ * Reset the player's Qi to zero when retreating due to defeat.
+ * Used when a retreat countdown ends because the player was killed mid-retreat.
+ *
+ * @param {object} state - The game state (defaults to shared state S).
+ */
+export function resetQiOnRetreat(state = S) {
+  state.qi = 0;
+}

--- a/src/features/adventure/ui/adventureDisplay.js
+++ b/src/features/adventure/ui/adventureDisplay.js
@@ -1,7 +1,7 @@
 import { S } from '../../../shared/state.js';
 import { setFill, setText } from '../../../shared/utils/dom.js';
 import { ZONES } from '../data/zones.js';
-import { startAdventure, startAdventureCombat, startBossCombat, progressToNextArea, retreatFromCombat } from '../mutators.js';
+import { startAdventure, startAdventureCombat, startBossCombat, progressToNextArea, retreatFromCombat, resetQiOnRetreat } from '../mutators.js';
 import { updateActivityAdventure } from '../logic.js';
 
 export function updateAdventureProgress(state = S) {
@@ -36,7 +36,7 @@ export function mountAdventureControls(root) {
         btn.classList.remove('warn'); btn.classList.add('primary');
         btn.textContent = '⚔️ Start Battle';
         (globalThis.stopActivity?.('adventure'));
-        root.qi = 0;
+        resetQiOnRetreat(root);
         updateActivityAdventure();
         return;
       }


### PR DESCRIPTION
## Summary
- add `resetQiOnRetreat` mutator to centralize Qi reset logic
- use the mutator in adventure display when retreat interrupted by death
- document new mutator in project structure guide

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation reports)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ed4f8f588326b3486bc005553bf9