### PR TITLE
Add codex output blacklist scan

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -73,6 +73,7 @@ way-of-ascension/
 ├── node_modules/
 ├── scripts/
 │   ├── balance-validate.js
+│   ├── scan-codex-output.js
 │   └── validate-structure.js
 ├── src/
 │   ├── index.js

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "validate-fix": "node scripts/validate-structure.js --auto-update",
     "start": "node server.js",
     "enforce-ai": "node .windsurf/ai-enforcement.js",
-    "lint:balance": "node scripts/balance-validate.js"
+    "lint:balance": "node scripts/balance-validate.js",
+    "scan-output": "node scripts/scan-codex-output.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/scan-codex-output.js
+++ b/scripts/scan-codex-output.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+
+const file = process.argv[2];
+
+async function readInput() {
+  if (file) {
+    return readFileSync(file, 'utf8');
+  }
+  return await new Promise(resolve => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => data += chunk);
+    process.stdin.on('end', () => resolve(data));
+  });
+}
+
+const content = await readInput();
+const patterns = [/(?:^|\s)rm\s+-rf\b/, /\beval\b/, /\bexec\b/];
+const matched = patterns.filter(p => p.test(content));
+
+if (matched.length) {
+  console.error(`Disallowed tokens detected: ${matched.map(p => p.source).join(', ')}`);
+  process.exit(1);
+} else {
+  console.log('No disallowed tokens found.');
+}


### PR DESCRIPTION
## Summary
- add script to scan text for rm -rf, eval, or exec tokens
- expose scan via npm script and document script in project structure

## Testing
- `node .windsurf/ai-enforcement.js` *(fails: UNDOCUMENTED FILES FOUND, MISSING CORE FILES)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations, DOM usage)*
- `npm run scan-output -- README.md`


------
https://chatgpt.com/codex/tasks/task_e_68a906cefea48326925f939f0e0dc5c1