### PR TITLE
Refactor ability effects into mutators and emit heal events

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ Other folders such as `scripts/` (build or deployment scripts), `browser-tools-m
 
 #### Events Bus
 
-A tiny pub/sub lives in `src/shared/events.js` exposing `on`, `off` and `emit`. The controller emits `TICK` (fixed step) and `RENDER` (per frame). Feature UIs subscribe to `RENDER` to redraw, and systems can listen to `TICK` for simulation updates. Mutators can also broadcast domain events; for example `startActivity` emits `ACTIVITY:START` with the root state and activity name so features like mining can initialise themselves without direct dependencies.
+A tiny pub/sub lives in `src/shared/events.js` exposing `on`, `off` and `emit`. The controller emits `TICK` (fixed step) and `RENDER` (per frame). Feature UIs subscribe to `RENDER` to redraw, and systems can listen to `TICK` for simulation updates. Mutators can also broadcast domain events; for example `startActivity` emits `ACTIVITY:START` with the root state and activity name so features like mining can initialise themselves without direct dependencies. Ability mutators emit `ABILITY:HEAL` with the healed amount so the UI can show floating heal numbers.
 
 #### Entrypoint & Bootstrap
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -90,6 +90,7 @@ way-of-ascension/
 │   │   │   ├── logic.js
 │   │   │   ├── migrations.js
 │   │   │   ├── mutators.js
+│   │   │   ├── ui.js
 │   │   │   ├── selectors.js
 │   │   │   └── state.js
 │   │   ├── index.js
@@ -101,6 +102,7 @@ way-of-ascension/
 │   │   │   ├── logic.js
 │   │   │   ├── migrations.js
 │   │   │   ├── mutators.js
+│   │   │   ├── ui.js
 │   │   │   ├── selectors.js
 │   │   │   └── state.js
 │   │   ├── affixes/
@@ -444,16 +446,19 @@ Stateful helpers for manipulating adventure progression.
 Tracks ability cooldown timers and pending action queue.
 
 #### `src/features/ability/mutators.js` - Ability Mutators
-Validate casts, tick cooldowns, and process queued ability actions.
+Validate casts, tick cooldowns, apply ability results, and emit events for UI effects.
 
 #### `src/features/ability/selectors.js` - Ability Selectors
 Expose ability slots and cooldown information using inventory data.
 
 #### `src/features/ability/logic.js` - Ability Resolution
-Resolves ability effects like Power Slash damage and healing.
+Pure computations describing ability effects like Power Slash damage and healing.
 
 #### `src/features/ability/data/abilities.js` - Ability Definitions
 Defines metadata for active abilities such as cost and cooldown.
+
+#### `src/features/ability/ui.js` - Ability UI Helpers
+Listens for `ABILITY:HEAL` events and displays floating heal numbers.
 
 #### `src/features/affixes/state.js` - Affix Feature State
 Holds affix-related tracking data.

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -1,17 +1,13 @@
-import { processAttack } from '../combat/mutators.js';
 import { getEquippedWeapon } from '../inventory/selectors.js';
-import { qCap } from '../progression/selectors.js';
 
 export function resolveAbilityHit(abilityKey, state) {
   switch (abilityKey) {
     case 'powerSlash':
-      resolvePowerSlash(state);
-      break;
+      return resolvePowerSlash(state);
     case 'seventyFive':
-      resolveSeventyFive(state);
-      break;
+      return resolveSeventyFive();
     default:
-      break;
+      return null;
   }
 }
 
@@ -19,54 +15,16 @@ function resolvePowerSlash(state) {
   const weapon = getEquippedWeapon(state);
   const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
   const raw = Math.round(1.3 * roll);
-  const dealt = processAttack(
-    raw,
-    { target: state.adventure.currentEnemy, type: 'physical' },
-    state
-  );
-  state.adventure.combatLog.push(`You used Power Slash for ${dealt} Physical damage.`);
-  if (dealt > 0) {
-    const healed = Math.min(5, state.hpMax - state.hp);
-    state.hp += healed;
-    state.adventure.playerHP = state.hp;
-    state.adventure.combatLog.push('You recovered 5 HP.');
-    showHeal(healed);
-  }
+  return {
+    attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
+    healOnHit: 5,
+  };
 }
 
-function resolveSeventyFive(state) {
-  if (!state?.adventure) return;
-  // Deal 100% of enemy HP (instant defeat)
-  const before = state.adventure.enemyHP || 0;
-  state.adventure.enemyHP = 0;
-  // Heal player to full
-  const healAmt = Math.max(0, (state.hpMax || 0) - (state.hp || 0));
-  state.hp = state.hpMax;
-  state.adventure.playerHP = state.hpMax;
-  if (!state.adventure.combatLog) state.adventure.combatLog = [];
-  state.adventure.combatLog.push(`You unleash 75%! It deals ${Math.round(before)} true damage and fells the enemy.`);
-  if (healAmt > 0) {
-    state.adventure.combatLog.push(`You are restored for ${healAmt} HP.`);
-    showHeal(healAmt);
-  }
-  // Restore Qi to full
-  try {
-    state.qi = qCap(state);
-  } catch {
-    // Fallback if qCap unavailable for some reason
-    state.qi = state.qiMax || state.qi || 0;
-  }
-}
-
-function showHeal(amount) {
-  const el = document.getElementById('hpVal');
-  if (!el) return;
-  const rect = el.getBoundingClientRect();
-  const note = document.createElement('div');
-  note.className = 'heal-float';
-  note.textContent = `+${amount}`;
-  note.style.left = rect.left + 'px';
-  note.style.top = rect.top - 20 + 'px';
-  document.body.appendChild(note);
-  setTimeout(() => note.remove(), 1000);
+function resolveSeventyFive() {
+  return {
+    defeatEnemy: true,
+    healToFull: true,
+    restoreQi: true,
+  };
 }

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -2,6 +2,9 @@ import { S } from '../../shared/state.js';
 import { ABILITIES } from './data/abilities.js';
 import { resolveAbilityHit } from './logic.js';
 import { getEquippedWeapon } from '../inventory/selectors.js';
+import { processAttack } from '../combat/mutators.js';
+import { emit } from '../../shared/events.js';
+import { qCap } from '../progression/selectors.js';
 
 export function tryCastAbility(abilityKey, state = S) {
   const ability = ABILITIES[abilityKey];
@@ -36,6 +39,48 @@ export function processAbilityQueue(state = S) {
   if (!state.actionQueue || !state.actionQueue.length) return;
   while (state.actionQueue.length) {
     const action = state.actionQueue.shift();
-    if (action.type === 'ABILITY_HIT') resolveAbilityHit(action.abilityKey, state);
+    if (action.type === 'ABILITY_HIT') {
+      const res = resolveAbilityHit(action.abilityKey, state);
+      applyAbilityResult(action.abilityKey, res, state);
+    }
+  }
+}
+
+function applyAbilityResult(abilityKey, res, state) {
+  if (!res) return;
+  const ability = ABILITIES[abilityKey];
+  const logs = state.adventure?.combatLog;
+  if (res.attack) {
+    const { amount, type, target } = res.attack;
+    const dealt = processAttack(amount, { target, type }, state);
+    logs?.push(`You used ${ability.displayName} for ${dealt} ${type === 'physical' ? 'Physical ' : ''}damage.`);
+    if (res.healOnHit && dealt > 0) {
+      const healed = Math.min(res.healOnHit, state.hpMax - state.hp);
+      state.hp += healed;
+      state.adventure.playerHP = state.hp;
+      logs?.push(`You recovered ${healed} HP.`);
+      emit('ABILITY:HEAL', { amount: healed });
+    }
+  }
+  if (res.defeatEnemy) {
+    const before = state.adventure.enemyHP || 0;
+    state.adventure.enemyHP = 0;
+    logs?.push(`You unleash 75%! It deals ${Math.round(before)} true damage and fells the enemy.`);
+  }
+  if (res.healToFull) {
+    const healAmt = Math.max(0, state.hpMax - state.hp);
+    state.hp = state.hpMax;
+    state.adventure.playerHP = state.hpMax;
+    if (healAmt > 0) {
+      logs?.push(`You are restored for ${healAmt} HP.`);
+      emit('ABILITY:HEAL', { amount: healAmt });
+    }
+  }
+  if (res.restoreQi) {
+    try {
+      state.qi = qCap(state);
+    } catch {
+      state.qi = state.qiMax || state.qi || 0;
+    }
   }
 }

--- a/src/features/ability/ui.js
+++ b/src/features/ability/ui.js
@@ -1,0 +1,20 @@
+import { on } from '../../shared/events.js';
+
+export function setupAbilityUI() {
+  on('ABILITY:HEAL', ({ amount }) => {
+    showHeal(amount);
+  });
+}
+
+function showHeal(amount) {
+  const el = document.getElementById('hpVal');
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  const note = document.createElement('div');
+  note.className = 'heal-float';
+  note.textContent = `+${amount}`;
+  note.style.left = rect.left + 'px';
+  note.style.top = rect.top - 20 + 'px';
+  document.body.appendChild(note);
+  setTimeout(() => note.remove(), 1000);
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -47,6 +47,7 @@ import { renderEquipmentPanel, setupEquipmentTab } from '../src/features/invento
 import { ZONES } from '../src/features/adventure/data/zones.js'; // MAP-UI-UPDATE
 import { setReduceMotion } from '../src/features/combat/ui/index.js';
 import { tickAbilityCooldowns } from '../src/features/ability/mutators.js';
+import { setupAbilityUI } from '../src/features/ability/ui.js';
 import { advanceMining } from '../src/features/mining/logic.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
@@ -99,6 +100,7 @@ function initUI(){
   const mhName = WEAPONS[mhKey]?.displayName || (mhKey === 'fist' ? 'Fists' : mhKey);
   initializeWeaponChip({ key: mhKey, name: mhName });
   mountTrainingGameUI(S);
+  setupAbilityUI();
 
   // Assign buttons
   // Buttons (with safe null checks)


### PR DESCRIPTION
## Summary
- Move ability hit resolution to pure logic returning effect objects
- Apply ability results in mutators and emit `ABILITY:HEAL` for UI
- Add ability UI module showing heal floats and wire it into UI bootstrap
- Document new ability UI and event

## Testing
- `node scripts/validate-structure.js` *(fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js, UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js, UI state violation: src/features/adventure/ui/progressBar.js imports S from shared/state.js, UI state violation: src/features/combat/ui/combatStats.js imports S from shared/state.js, UI state violation: src/features/cooking/ui/cookControls.js imports S from shared/state.js, UI state violation: src/features/cooking/ui/cookingDisplay.js imports S from shared/state.js, UI state violation: src/features/inventory/ui/resourceDisplay.js imports S from shared/state.js, UI state violation: src/features/karma/ui/karmaHUD.js imports S from shared/state.js, UI state violation: src/features/loot/ui/lootTab.js imports S from shared/state.js, UI state violation: src/features/mining/ui/miningDisplay.js imports S from shared/state.js, UI state violation: src/features/proficiency/ui/weaponProficiencyDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/lawDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiOrb.js imports S from shared/state.js, UI state violation: src/features/progression/ui/realm.js imports S from shared/state.js, DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a9070b3c5883269e9f6bb890b98df8