### PR TITLE
Refactor timers and random rolls

### DIFF
--- a/src/features/ability/index.js
+++ b/src/features/ability/index.js
@@ -1,6 +1,14 @@
 import { abilityState } from "./state.js";
+import { tickAbility } from "./mutators.js";
+import { registerFeature } from "../registry.js";
 
 export const AbilityFeature = {
   key: "ability",
   initialState: () => ({ ...abilityState, _v: 0 }),
 };
+
+registerFeature({
+  id: AbilityFeature.key,
+  init: AbilityFeature.initialState,
+  tick: tickAbility,
+});

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -1,11 +1,12 @@
 import { processAttack } from '../combat/mutators.js';
 import { getEquippedWeapon } from '../inventory/selectors.js';
 import { qCap } from '../progression/selectors.js';
+import { showHeal } from '../combat/ui/fx.js';
 
-export function resolveAbilityHit(abilityKey, state) {
+export function resolveAbilityHit(abilityKey, state, { roll = 0 } = {}) {
   switch (abilityKey) {
     case 'powerSlash':
-      resolvePowerSlash(state);
+      resolvePowerSlash(state, roll);
       break;
     case 'seventyFive':
       resolveSeventyFive(state);
@@ -15,10 +16,10 @@ export function resolveAbilityHit(abilityKey, state) {
   }
 }
 
-function resolvePowerSlash(state) {
+function resolvePowerSlash(state, roll) {
   const weapon = getEquippedWeapon(state);
-  const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
-  const raw = Math.round(1.3 * roll);
+  const scaled = Math.floor(roll * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
+  const raw = Math.round(1.3 * scaled);
   const dealt = processAttack(
     raw,
     { target: state.adventure.currentEnemy, type: 'physical' },
@@ -58,15 +59,3 @@ function resolveSeventyFive(state) {
   }
 }
 
-function showHeal(amount) {
-  const el = document.getElementById('hpVal');
-  if (!el) return;
-  const rect = el.getBoundingClientRect();
-  const note = document.createElement('div');
-  note.className = 'heal-float';
-  note.textContent = `+${amount}`;
-  note.style.left = rect.left + 'px';
-  note.style.top = rect.top - 20 + 'px';
-  document.body.appendChild(note);
-  setTimeout(() => note.remove(), 1000);
-}

--- a/src/features/combat/ui/fx.js
+++ b/src/features/combat/ui/fx.js
@@ -11,14 +11,15 @@ export function setReduceMotion(v) {
   reduceMotion = v;
 }
 
-function spawn(svg, el, duration = 400) {
+function spawn(svg, el) {
   if (!svg || reduceMotion || active >= MAX_FX) return;
   active++;
   svg.appendChild(el);
-  setTimeout(() => {
+  const remove = () => {
     if (el.parentNode === svg) svg.removeChild(el);
     active--;
-  }, duration);
+  };
+  el.addEventListener('animationend', remove, { once: true });
 }
 
 export function setFxTint(svg, tint = 'auto') {
@@ -41,7 +42,7 @@ export function playSlashArc(svg, from, to) {
   const midY = Math.min(from.y, to.y) - 10;
   path.setAttribute('d', `M${from.x},${from.y} Q${midX},${midY} ${to.x},${to.y}`);
   path.classList.add('fx-stroke');
-  spawn(svg, path, 400);
+  spawn(svg, path);
 }
 
 export function playThrustLine(svg, from, to) {
@@ -61,7 +62,7 @@ export function playThrustLine(svg, from, to) {
   line.setAttribute('x2', String(to.x));
   line.setAttribute('y2', String(to.y));
   line.classList.add('fx-thrust');
-  spawn(svg, line, 300);
+  spawn(svg, line);
 }
 
 export function playRingShockwave(svg, center, radius = 20) {
@@ -71,7 +72,7 @@ export function playRingShockwave(svg, center, radius = 20) {
   circle.setAttribute('r', 0);
   circle.style.setProperty('--fx-radius', radius);
   circle.classList.add('fx-ring');
-  spawn(svg, circle, 600);
+  spawn(svg, circle);
 }
 
 function playRuneCircle(svg, at) {
@@ -81,7 +82,7 @@ function playRuneCircle(svg, at) {
   const use = document.createElementNS(NS, 'use');
   use.setAttribute('href', '#rune-circle');
   g.appendChild(use);
-  spawn(svg, g, 600);
+  spawn(svg, g);
 }
 
 export function playBeam(svg, from, to) {
@@ -92,7 +93,7 @@ export function playBeam(svg, from, to) {
   line.setAttribute('x2', to.x);
   line.setAttribute('y2', to.y);
   line.classList.add('fx-beam');
-  spawn(svg, line, 400);
+  spawn(svg, line);
 }
 
 export function playChakram(svg, from, to) {
@@ -117,12 +118,12 @@ export function playChakram(svg, from, to) {
       requestAnimationFrame(animate);
     } else {
       svg.removeChild(g);
+      active--;
     }
   }
   if (!reduceMotion && active < MAX_FX) {
     active++;
     requestAnimationFrame(animate);
-    setTimeout(() => { active--; }, duration);
   } else if (svg.contains(g)) {
     svg.removeChild(g);
   }
@@ -134,11 +135,24 @@ export function playShieldDome(svg, center, radius = 25) {
   circle.setAttribute('cy', center.y);
   circle.style.setProperty('--fx-radius', radius);
   circle.classList.add('fx-shield');
-  spawn(svg, circle, 600);
+  spawn(svg, circle);
 }
 
 export function playSparkBurst(svg, center) {
   playRingShockwave(svg, center, 6);
+}
+
+export function showHeal(amount) {
+  const el = document.getElementById('hpVal');
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  const note = document.createElement('div');
+  note.className = 'heal-float';
+  note.textContent = `+${amount}`;
+  note.style.left = rect.left + 'px';
+  note.style.top = rect.top - 20 + 'px';
+  document.body.appendChild(note);
+  note.addEventListener('animationend', () => note.remove(), { once: true });
 }
 
 export { reduceMotion };

--- a/src/features/physique/ui/trainingGame.js
+++ b/src/features/physique/ui/trainingGame.js
@@ -77,7 +77,15 @@ function showHitFeedback(message, color){
     el.textContent = message;
     el.style.color = color;
     el.style.opacity = '1';
-    setTimeout(() => { el.style.opacity = '0'; }, 500);
+    const start = performance.now();
+    const fade = (now) => {
+      if (now - start >= 500) {
+        el.style.opacity = '0';
+      } else {
+        requestAnimationFrame(fade);
+      }
+    };
+    requestAnimationFrame(fade);
   }
 }
 

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -53,7 +53,7 @@ export function updateActivityCultivation() {
   const foundationNumbers = document.querySelector('.foundation-inline');
   if (foundationNumbers && currentFoundation > prevFoundation) {
     foundationNumbers.classList.add('flash');
-    setTimeout(() => foundationNumbers.classList.remove('flash'), 600);
+    foundationNumbers.addEventListener('animationend', () => foundationNumbers.classList.remove('flash'), { once: true });
   }
   
   // Pulse effect when at max foundation

--- a/src/game/GameController.js
+++ b/src/game/GameController.js
@@ -8,6 +8,7 @@ import "../features/proficiency/index.js";
 import "../features/weaponGeneration/index.js";
 import "../features/sect/index.js";
 import "../features/alchemy/index.js";
+import "../features/ability/index.js";
 
 export function createGameController() {
   const state = {

--- a/src/ui/dev/devQuickMenu.js
+++ b/src/ui/dev/devQuickMenu.js
@@ -130,7 +130,7 @@ export function mountDevQuickMenu() {
 
   // Consolidate existing dev panels if present (non-breaking)
   // Move any #debugPanel/#debugConsole into our panel
-  setTimeout(() => {
+  requestAnimationFrame(() => {
     const existing = document.getElementById("debugPanel") || document.getElementById("debugConsole");
     if (existing && !panel.contains(existing)) {
       existing.style.display = "block";
@@ -143,7 +143,7 @@ export function mountDevQuickMenu() {
       wrap.appendChild(existing);
       panel.append(hdr, wrap);
     }
-  }, 0);
+  });
 
   // Toggle
   btn.onclick = () => { panel.style.display = panel.style.display === "none" ? "block" : "none"; };

--- a/style.css
+++ b/style.css
@@ -4046,7 +4046,8 @@ tr:last-child td {
 .ability-card.cooling { opacity:0.6; }
 .cooldown-overlay { position:absolute; inset:0; background:rgba(0,0,0,0.6); color:#fff; display:flex; align-items:center; justify-content:center; }
 .ability-card.insufficient { filter:grayscale(1); }
-.ability-card.flash { box-shadow:0 0 4px 2px var(--accent); }
+.ability-card.flash { box-shadow:0 0 4px 2px var(--accent); animation:ability-flash 0.15s; }
+@keyframes ability-flash { from{box-shadow:0 0 4px 2px var(--accent);} to{box-shadow:none;} }
 .ability-card.shake { animation:ability-shake 0.3s; }
 @keyframes ability-shake { 0%{transform:translateX(0);}25%{transform:translateX(-2px);}50%{transform:translateX(2px);}75%{transform:translateX(-2px);}100%{transform:translateX(0);} }
 .heal-float { position:fixed; color:#0f0; font-weight:bold; pointer-events:none; animation:heal-float 1s forwards; }


### PR DESCRIPTION
## Summary
- Move ability casting delays into a tick-based queue and accept precomputed damage rolls
- Replace setTimeout UI effects with animation-based handlers across adventure, realm, and combat modules
- Centralize heal floating text in combat FX and add animation-driven flash styles

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state and DOM violations in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a9071bf8f8832692cdfb0c1182e45b