### PR TITLE
Refactor bootstrap into initApp

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ A tiny pub/sub lives in `src/shared/events.js` exposing `on`, `off` and `emit`. 
 
 #### Entrypoint & Bootstrap
 
-`src/index.js` is a minimal entry that creates the controller, mounts feature UIs via `mountAllFeatureUIs(state)` and then calls `start()`. `src/features/index.js` centralises these UI mounts for all features. A placeholder app shell lives at `src/ui/app.js` for future global UI composition.
+`src/ui/app.js` exports `initApp()`, which creates the game controller, mounts feature UIs via `mountAllFeatureUIs(state)`, mounts debug helpers and starts the loop. `src/index.js` is a minimal entry that simply calls `initApp()`.
 
 #### State Access Rules
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -745,7 +745,8 @@ Paths added:
 - `src/shared/saveLoad.js`
 - `src/features/index.js` – UI bootstrap
 - `src/features/registry.js` – Feature registration hooks
-- `src/index.js` – entry that bootstraps and starts the controller
+- `src/ui/app.js` – creates the controller, mounts feature UIs and starts the loop
+- `src/index.js` – minimal entry that calls `initApp()`
 - `docs/ARCHITECTURE.md`
 - `docs/To-dos/stats-to-implement.md`
 - `src/shared/utils/number.js` - number formatting helper
@@ -775,8 +776,11 @@ Paths added:
 #### `src/features/registry.js` - Feature Registry
 **Purpose**: Collects feature `init` and `tick` hooks and exposes helpers to initialise slices and advance ticks.
 
+#### `src/ui/app.js` - App Bootstrap
+**Purpose**: Creates the controller, mounts feature UIs and debug tools, then starts the game loop.
+
 #### `src/index.js` - Entrypoint
-**Purpose**: Minimal bootstrap that creates the controller, mounts feature UIs and starts the game.
+**Purpose**: Minimal entry that calls `initApp()`.
 
 #### `docs/ARCHITECTURE.md` - Architecture Overview
 **Purpose**: Documents the controller, events bus and bootstrap pattern.

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,3 @@
-import { createGameController } from "./game/GameController.js";
-import { mountAllFeatureUIs } from "./features/index.js";
-import { mountDevQuickMenu } from "./ui/dev/devQuickMenu.js";
+import { initApp } from "./ui/app.js";
 
-const game = createGameController();
-mountAllFeatureUIs(game.state);
-game.start();
-
-// window.game = game; // optional for debugging
-
-// Expose hooks for the dev menu if needed
-window.__PAUSE = () => game.pause();
-window.__RESUME = () => game.resume();
-window.__STEP = () => game.step();
-window.__GET_SPEED = () => game.getSpeed();
-window.__SET_SPEED = (v) => game.setSpeed(v);
-
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", () => mountDevQuickMenu());
-} else {
-  mountDevQuickMenu();
-}
+initApp();

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -1,3 +1,25 @@
-// Core UI bootstrap placeholder.
-// Exported for validation purposes; real implementation pending.
-export function initApp() {}
+import { createGameController } from "../game/GameController.js";
+import { mountAllFeatureUIs } from "../features/index.js";
+import { mountDevQuickMenu } from "./dev/devQuickMenu.js";
+
+// Bootstraps the game controller, mounts feature UIs and starts the loop.
+export function initApp() {
+  const game = createGameController();
+  mountAllFeatureUIs(game.state);
+  game.start();
+
+  // window.game = game; // optional for debugging
+
+  window.__PAUSE = () => game.pause();
+  window.__RESUME = () => game.resume();
+  window.__STEP = () => game.step();
+  window.__GET_SPEED = () => game.getSpeed();
+  window.__SET_SPEED = (v) => game.setSpeed(v);
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => mountDevQuickMenu());
+  } else {
+    mountDevQuickMenu();
+  }
+}
+

--- a/validation.log
+++ b/validation.log
@@ -1,7 +1,34 @@
-🤖 ENFORCING AI VERIFICATION PROTOCOL...
+🤖 ENFORCING AI VERIFICATION PROTOCOL (feature-first + doc-sync)...
 
 📋 AI VERIFICATION ENFORCEMENT REPORT
 =====================================
-✅ VERIFICATION PASSED - AI may proceed
+❌ VERIFICATION FAILED - MUST fix before proceeding
+
+🚨 VIOLATIONS DETECTED:
+   • UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js
+   • UI state violation: src/features/adventure/ui/progressBar.js imports S from shared/state.js
+   • UI state violation: src/features/combat/ui/combatStats.js imports S from shared/state.js
+   • UI state violation: src/features/cooking/ui/cookControls.js imports S from shared/state.js
+   • UI state violation: src/features/cooking/ui/cookingDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/inventory/ui/resourceDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/karma/ui/karmaHUD.js imports S from shared/state.js
+   • UI state violation: src/features/loot/ui/lootTab.js imports S from shared/state.js
+   • UI state violation: src/features/mining/ui/miningDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/proficiency/ui/weaponProficiencyDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/progression/ui/lawDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/progression/ui/qiDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/progression/ui/qiOrb.js imports S from shared/state.js
+   • UI state violation: src/features/progression/ui/realm.js imports S from shared/state.js
+   • DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js
+
+⚠️  WARNINGS:
+   • UI timer: src/features/adventure/ui/adventureDisplay.js uses timers/RAF — prefer feature.tick and RENDER
+   • UI timer: src/features/combat/ui/fx.js uses timers/RAF — prefer feature.tick and RENDER
+   • UI timer: src/features/physique/ui/trainingGame.js uses timers/RAF — prefer feature.tick and RENDER
+   • UI rule: src/features/progression/ui/realm.js uses Math.random() — move randomness to logic.js
+   • UI timer: src/features/progression/ui/realm.js uses timers/RAF — prefer feature.tick and RENDER
 
 =====================================
+
+🚫 AI CHANGES BLOCKED UNTIL VALIDATION PASSES


### PR DESCRIPTION
## Summary
- centralize game bootstrap in `initApp` within `src/ui/app.js`
- simplify `src/index.js` to call `initApp`
- update docs for new application bootstrap flow

## Testing
- `npm run validate` *(fails: UI state imports from shared/state.js, DOM usage in logic files, timer usage)*

------
https://chatgpt.com/codex/tasks/task_e_68a90a5f28f88326a8dccec33bbaaf71