### PR TITLE
feat: add alchemy activity

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,7 +798,8 @@
         </div>
       </section>
 
-      <section id="tab-alchemy">
+      <section id="activity-alchemy" class="activity-content" style="display:none;">
+        <h2>⚗️ Alchemy</h2>
         <div class="cards">
           <div class="card">
             <h4>Alchemy Cauldron</h4>

--- a/src/features/activity/state.js
+++ b/src/features/activity/state.js
@@ -7,6 +7,7 @@ export function ensureActivities(root) {
       mining: false,
       adventure: false,
       cooking: false,
+      alchemy: false,
       sect: false,
     };
   }

--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -34,6 +34,14 @@ export function updateActivitySelectors(root) {
 
   const selected = root.ui?.selectedActivity || 'cultivation';
 
+  // Generic highlight for dynamically rendered sidebar items
+  document.querySelectorAll('.activity-item[data-activity]')
+    .forEach(el => {
+      const act = el.dataset.activity;
+      el.classList.toggle('active', act === selected);
+      el.classList.toggle('running', !!root.activities?.[act]);
+    });
+
   document.querySelectorAll('.activity-content')
     .forEach(panel => {
       panel.style.display = panel.id === `activity-${selected}` ? 'block' : 'none';
@@ -95,7 +103,14 @@ export function updateActivitySelectors(root) {
 export function updateCurrentTaskDisplay(root) {
   const el = document.getElementById('currentTask');
   if (!el) return;
-  const map = { cultivation:'Cultivating', physique:'Physique Training', mining:'Mining', adventure:'Adventuring', cooking:'Cooking' };
+  const map = {
+    cultivation: 'Cultivating',
+    physique: 'Physique Training',
+    mining: 'Mining',
+    adventure: 'Adventuring',
+    cooking: 'Cooking',
+    alchemy: 'Brewing'
+  };
   const active = getActiveActivity(root);
   el.textContent = active ? (map[active] || 'Idle') : 'Idle';
 }

--- a/src/features/alchemy/ui/alchemyDisplay.js
+++ b/src/features/alchemy/ui/alchemyDisplay.js
@@ -10,6 +10,7 @@ function renderAlchemyUI(state) {
   setText('alchLvl', state.alchemy.level);
   setText('alchXp', state.alchemy.xp);
   setText('slotCount', getMaxSlots(state));
+  setText('alchemyLevelSidebar', `Level ${state.alchemy.level}`);
 
   const recipeSelect = document.getElementById('recipeSelect');
   const brewBtn = document.getElementById('brewBtn');

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -66,7 +66,8 @@ export const defaultState = () => {
     physique: false,
     mining: false,
     adventure: false,
-    cooking: false
+    cooking: false,
+    alchemy: false
   },
   // Activity data containers
   physique: structuredClone(physiqueState),

--- a/src/ui/sidebar.js
+++ b/src/ui/sidebar.js
@@ -45,6 +45,15 @@ export function renderSidebarActivities() {
       cost: {}
     },
     {
+      id: 'alchemy',
+      label: 'Alchemy',
+      icon: '<iconify-icon icon="mdi:flask" class="ui-icon" width="20"></iconify-icon>',
+      group: 'leveling',
+      levelId: 'alchemyLevelSidebar',
+      initialLevel: 'Level 1',
+      cost: {},
+    },
+    {
       id: 'adventure',
       label: 'Adventure',
       icon: '<iconify-icon icon="lucide:mountain" class="ui-icon"></iconify-icon>',

--- a/ui/index.js
+++ b/ui/index.js
@@ -307,7 +307,7 @@ function updateActivityCards() {
 
 function updateActivityUI() {
   // Update activity status displays
-  const activities = ['cultivation', 'physique', 'adventure', 'mining', 'cooking'];
+  const activities = ['cultivation', 'physique', 'adventure', 'mining', 'cooking', 'alchemy'];
 
   activities.forEach(activity => {
     const statusEl = document.getElementById(`${activity}Status`);


### PR DESCRIPTION
## Summary
- expose Alchemy as a selectable activity from game start
- add sidebar entry and activity panel for brewing
- generalize activity UI highlighting and show brewing status

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a90bc6f93883269c51eaf6889ffe56