### PR TITLE
Ensure sect buildings render correctly

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -51,6 +51,7 @@ import { setupAbilityUI } from '../src/features/ability/ui.js';
 import { advanceMining } from '../src/features/mining/logic.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
+import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
 import { updateQiAndFoundation } from '../src/features/progression/ui/qiDisplay.js';
 import { updateCombatStats } from '../src/features/combat/ui/combatStats.js';
 import { updateAdventureProgress, mountAdventureControls } from '../src/features/adventure/ui/adventureDisplay.js';
@@ -439,6 +440,7 @@ window.addEventListener('load', ()=>{
   mountAdventureControls(S);
   setupAdventureTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI
+  mountSectUI(S);
   mountAlchemyUI(S);
   mountKarmaUI(S);
   selectActivity('cultivation'); // Start with cultivation selected


### PR DESCRIPTION
## Summary
- Mount sect UI during app initialization so building list renders when selecting the sect tab

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation: src/features/karma/ui/karmaHUD.js imports S from shared/state.js; DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js)


------
https://chatgpt.com/codex/tasks/task_e_68a915ea21fc8326ac3f27098b5f07d9