### PR TITLE
Clamp adventure progress display to 100%

### DIFF
--- a/src/features/adventure/ui/adventureDisplay.js
+++ b/src/features/adventure/ui/adventureDisplay.js
@@ -3,6 +3,7 @@ import { setFill, setText } from '../../../shared/utils/dom.js';
 import { ZONES } from '../data/zones.js';
 import { startAdventure, startAdventureCombat, startBossCombat, progressToNextArea, retreatFromCombat, resetQiOnRetreat } from '../mutators.js';
 import { updateActivityAdventure } from '../logic.js';
+import { clamp } from '../../progression/selectors.js';
 
 export function updateAdventureProgress(state = S) {
   if (!state.adventure) return;
@@ -10,7 +11,7 @@ export function updateAdventureProgress(state = S) {
   const currentArea = currentZone ? currentZone.areas[state.adventure.currentArea] : null;
   const location = currentArea ? currentArea.name : 'Village Outskirts';
   if (currentArea) {
-    const progress = state.adventure.killsInCurrentArea / currentArea.killReq;
+    const progress = clamp(state.adventure.killsInCurrentArea / currentArea.killReq, 0, 1);
     setFill('adventureProgressFill', progress);
     setText('adventureProgressText', `${Math.floor(progress * 100)}%`);
   }


### PR DESCRIPTION
## Summary
- Clamp adventure progress ratio to prevent percentages exceeding 100%

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68a9160f85cc8326b5d8672bc4dd3166