### PR TITLE
Fix mining XP bar initial fill

### DIFF
--- a/style.css
+++ b/style.css
@@ -3638,6 +3638,7 @@ tr:last-child td {
 
 #miningProgressFill {
   background: linear-gradient(90deg, #f59e0b, #d97706) !important; /* Orange for mining */
+  width: 0%;
 }
 
 #cookingProgressFillSidebar {


### PR DESCRIPTION
## Summary
- Initialize mining sidebar XP bar width at zero without affecting other progress bars

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations in unrelated modules)


------
https://chatgpt.com/codex/tasks/task_e_68a90c12840c832693ab00e4c4239a45