### PR TITLE
Ensure sect buildings render after DOM loads

### DIFF
--- a/src/features/sect/ui/sectScreen.js
+++ b/src/features/sect/ui/sectScreen.js
@@ -39,6 +39,11 @@ function render(state){
 }
 
 export function mountSectUI(state){
-  on('RENDER', () => render(state));
-  render(state);
+  const rerender = () => render(state);
+  on('RENDER', rerender);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', rerender, { once: true });
+  } else {
+    rerender();
+  }
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -51,6 +51,7 @@ import { setupAbilityUI } from '../src/features/ability/ui.js';
 import { advanceMining } from '../src/features/mining/logic.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
+import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
 import { updateQiAndFoundation } from '../src/features/progression/ui/qiDisplay.js';
 import { updateCombatStats } from '../src/features/combat/ui/combatStats.js';
 import { updateAdventureProgress, mountAdventureControls } from '../src/features/adventure/ui/adventureDisplay.js';
@@ -439,6 +440,7 @@ window.addEventListener('load', ()=>{
   mountAdventureControls(S);
   setupAdventureTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI
+  mountSectUI(S);
   mountAlchemyUI(S);
   mountKarmaUI(S);
   selectActivity('cultivation'); // Start with cultivation selected


### PR DESCRIPTION
## Summary
- Wait for the DOM to be ready before attempting to render sect buildings
- Keep sect UI in sync by re-rendering on global RENDER events

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations in other modules)


------
https://chatgpt.com/codex/tasks/task_e_68a915ea21fc8326ac3f27098b5f07d9