### PR TITLE
Ensure sect buildings render after DOM loads

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -20,7 +20,11 @@ export function mountActivityUI(root) {
   document.getElementById('physiqueSelector')?.addEventListener('click', () => handle('physique'));
   document.getElementById('miningSelector')?.addEventListener('click', () => handle('mining'));
   document.getElementById('adventureSelector')?.addEventListener('click', () => handle('adventure'));
-  document.getElementById('sectSelector')?.addEventListener('click', () => handle('sect'));
+  document.getElementById('sectSelector')?.addEventListener('click', () => {
+    handle('sect');
+    if (typeof switchTab === 'function') switchTab('sect');
+    else if (typeof showTab === 'function') showTab('sect');
+  });
 
   // Initial paint
   updateActivitySelectors(root);

--- a/src/features/sect/ui/sectScreen.js
+++ b/src/features/sect/ui/sectScreen.js
@@ -39,6 +39,11 @@ function render(state){
 }
 
 export function mountSectUI(state){
-  on('RENDER', () => render(state));
-  render(state);
+  const rerender = () => render(state);
+  on('RENDER', rerender);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', rerender, { once: true });
+  } else {
+    rerender();
+  }
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -51,6 +51,7 @@ import { setupAbilityUI } from '../src/features/ability/ui.js';
 import { advanceMining } from '../src/features/mining/logic.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
+import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
 import { updateQiAndFoundation } from '../src/features/progression/ui/qiDisplay.js';
 import { updateCombatStats } from '../src/features/combat/ui/combatStats.js';
 import { updateAdventureProgress, mountAdventureControls } from '../src/features/adventure/ui/adventureDisplay.js';
@@ -164,6 +165,13 @@ function initUI(){
       const inp=document.createElement('input'); inp.type='file'; inp.accept='application/json';
       inp.onchange=()=>{ const f=inp.files[0]; const r=new FileReader(); r.onload=()=>{ try{ setState(JSON.parse(r.result)); save(); location.reload(); }catch{ alert('Invalid file'); } }; r.readAsText(f); };
       inp.click();
+    });
+  }
+  const manageSectBtn = qs('#manageSectActivity');
+  if (manageSectBtn) {
+    manageSectBtn.addEventListener('click', () => {
+      if (typeof switchTab === 'function') switchTab('sect');
+      else if (typeof showTab === 'function') showTab('sect');
     });
   }
   const debugRunBtn = qs('#debugRunBtn');
@@ -439,6 +447,7 @@ window.addEventListener('load', ()=>{
   mountAdventureControls(S);
   setupAdventureTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI
+  mountSectUI(S);
   mountAlchemyUI(S);
   mountKarmaUI(S);
   selectActivity('cultivation'); // Start with cultivation selected


### PR DESCRIPTION
## Summary
- Select the Sect activity to immediately reveal the building management tab
- Wire the "Manage Buildings" button to navigate to the sect tab

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations in other modules)


------
https://chatgpt.com/codex/tasks/task_e_68a915ea21fc8326ac3f27098b5f07d9