### PR TITLE
feat: add mobile responsiveness

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -280,7 +280,8 @@ way-of-ascension/
 ├── ui/
 │   ├── components/
 │   │   └── progressBar.js
-│   └── index.js
+│   ├── index.js
+│   └── mobile.js
 ├── README.md
 ├── CHANGELOG.md
 ├── eslint.config.mjs
@@ -604,6 +605,10 @@ function updateAll() {
 ```
 
 **When to modify**: Add new UI elements, modify display logic, add event handlers
+
+#### `mobile.js` - Mobile Enhancements
+**Purpose**: Handles responsive canvas resizing and touch input mapping for mobile devices.
+**When to modify**: Adjust mobile layout behavior or touch controls.
 
 #### `src/features/progression/ui/realm.js` - Realm UI Components
 **Purpose**: Realm-specific UI components and cultivation displays

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Way of Ascension — Idle Xianxia</title>
   <link href="https://fonts.googleapis.com/css2?family=IM+Fell+English&family=Uncial+Antiqua&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />

--- a/style.css
+++ b/style.css
@@ -4103,3 +4103,55 @@ tr:last-child td {
             drop-shadow(0 0 0.25rem rgba(179, 36, 36, 0.35));
   }
 }
+
+/* Responsive adjustments */
+@media screen and (max-width: 800px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  main aside.left {
+    display: none;
+  }
+
+  .cards {
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    width: 100%;
+  }
+
+  .btn {
+    padding: 2vh 4vw;
+    font-size: 4vw;
+    margin: 1vh 0;
+  }
+
+  header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: 2vh;
+  }
+
+  .chip {
+    width: 100%;
+  }
+
+  .hp-chip .hp-bar {
+    width: 100%;
+  }
+
+  .right-actions {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+    margin-top: 1vh;
+  }
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -3,6 +3,7 @@
 
 // Way of Ascension — Modular JS
 
+import './mobile.js';
 import { S, defaultState, save, setState } from '../src/shared/state.js';
 import {
   clamp,

--- a/ui/mobile.js
+++ b/ui/mobile.js
@@ -1,0 +1,48 @@
+// Handles responsive canvas sizing and touch controls for mobile devices
+const canvas = document.getElementById('gameCanvas') || document.querySelector('canvas');
+
+function resizeCanvas() {
+  if (!canvas) return;
+  const ratio = canvas.width / canvas.height || 1;
+  const w = window.innerWidth;
+  const h = window.innerHeight;
+  if (w / h > ratio) {
+    canvas.style.height = `${h}px`;
+    canvas.style.width = `${h * ratio}px`;
+  } else {
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${w / ratio}px`;
+  }
+}
+
+window.addEventListener('resize', resizeCanvas);
+window.addEventListener('load', resizeCanvas);
+
+function dispatchArrow(key) {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key }));
+}
+
+let startX = 0;
+let startY = 0;
+
+window.addEventListener('touchstart', e => {
+  const t = e.touches[0];
+  startX = t.clientX;
+  startY = t.clientY;
+});
+
+window.addEventListener('touchend', e => {
+  const t = e.changedTouches[0];
+  const dx = t.clientX - startX;
+  const dy = t.clientY - startY;
+  if (Math.abs(dx) > Math.abs(dy)) {
+    dispatchArrow(dx > 0 ? 'ArrowRight' : 'ArrowLeft');
+  } else {
+    dispatchArrow(dy > 0 ? 'ArrowDown' : 'ArrowUp');
+  }
+});
+
+window.addEventListener('touchmove', e => {
+  // prevent default scrolling during game interaction
+  if (canvas) e.preventDefault();
+}, { passive: false });


### PR DESCRIPTION
## Summary
- ensure viewport meta tag is present
- add responsive media query to stack layout and hide sidebar on small screens
- implement mobile helpers for canvas resizing and touch controls
- stretch header chips and HP bar to full width on narrow screens

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a94d898a308326af45b57643f7a581