### PR TITLE
Show building catalog on Sect tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,11 +628,9 @@
         <h2>🏛️ Sect Management</h2>
         <div class="cards">
           <div class="card">
-            <h4>Sect Overview</h4>
-            <div class="stat"><span>Buildings</span><span id="buildingCountActivity">0</span></div>
-            <div class="stat"><span>Disciples</span><span>Coming Soon</span></div>
-            <div class="stat"><span>Sect Power</span><span>Coming Soon</span></div>
-            <button class="btn primary" id="manageSectActivity">🏗️ Manage Buildings</button>
+            <h4>Sect Buildings</h4>
+            <p class="muted">Construct and upgrade buildings to enhance your sect's capabilities. Buildings unlock as you advance in cultivation and provide powerful bonuses.</p>
+            <div id="buildingsContainer"></div>
           </div>
         </div>
       </section>
@@ -838,15 +836,6 @@
         </div>
       </section>
 
-      <section id="tab-sect">
-        <div class="cards">
-          <div class="card">
-            <h4>Sect Buildings</h4>
-            <p class="muted">Construct and upgrade buildings to enhance your sect's capabilities. Buildings unlock as you advance in cultivation and provide powerful bonuses.</p>
-            <div id="buildingsContainer"></div>
-          </div>
-        </div>
-      </section>
 
       <div class="log" id="log"></div>
     </section>

--- a/ui/index.js
+++ b/ui/index.js
@@ -52,6 +52,7 @@ import { advanceMining } from '../src/features/mining/logic.js';
 import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
+import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
 import { updateQiAndFoundation } from '../src/features/progression/ui/qiDisplay.js';
 import { updateCombatStats } from '../src/features/combat/ui/combatStats.js';
 import { updateAdventureProgress, mountAdventureControls } from '../src/features/adventure/ui/adventureDisplay.js';
@@ -443,6 +444,7 @@ window.addEventListener('load', ()=>{
   setupEquipmentTab(); // EQUIP-CHAR-UI
   mountAlchemyUI(S);
   mountKarmaUI(S);
+  mountSectUI(S);
   selectActivity('cultivation'); // Start with cultivation selected
   updateAll();
   tick();


### PR DESCRIPTION
## Summary
- Mount sect buildings UI so building list renders on sect tab

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (UI state violations)
- `npm run lint:balance`

------
https://chatgpt.com/codex/tasks/task_e_68a94e8ce04083268e9dea197cf316bb