### PR TITLE
Fix auto combat preventing boss spawn

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -532,11 +532,17 @@ function defeatEnemy() {
 
   const { gained, qiSpent } = refillShieldFromQi(S);
   if (gained > 0) log(`Your Qi reforms ${gained} shield (${qiSpent.toFixed(1)} Qi).`);
+  const zone = ZONES[S.adventure.currentZone];
+  const area = zone?.areas?.[S.adventure.currentArea];
 
   if (S.activities.adventure && S.adventure.playerHP > 0 && !isBoss) {
-    startAdventureCombat();
-    updateActivityAdventure();
+    const killReq = area?.killReq ?? Infinity;
+    if (S.adventure.killsInCurrentArea < killReq) {
+      startAdventureCombat();
+    }
   }
+
+  updateActivityAdventure();
   updateLootTab(); // EQUIP-CHAR-UI
 }
 


### PR DESCRIPTION
## Summary
- Stop auto-combat from auto spawning enemies after area cleared
- Always refresh adventure UI after fights for proper boss button state

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68a950ca8f308326bcc6a824b46dc91e