### PR TITLE
feat: highlight cultivation tab for breakthrough readiness

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -1,7 +1,7 @@
 // src/features/activity/ui/activityUI.js
 import { selectActivity } from "../mutators.js";
 import { getActiveActivity } from "../selectors.js";
-import { fCap } from "../../progression/selectors.js";
+import { fCap, qCap } from "../../progression/selectors.js";
 
 export function mountActivityUI(root) {
   const handle = name => {
@@ -57,6 +57,12 @@ export function updateActivitySelectors(root) {
     const foundationPct = (root.foundation / fCap(root)) * 100;
     cultivationFill.style.width = `${foundationPct}%`;
     cultivationInfo.textContent = root.activities?.cultivation ? 'Cultivating...' : 'Foundation Progress';
+  }
+
+  const cultivationTab = document.querySelector('.activity-item[data-activity="cultivation"]');
+  if (cultivationTab) {
+    const breakthroughReady = root.foundation >= fCap(root) && (root.qi ?? 0) >= qCap(root);
+    cultivationTab.classList.toggle('breakthrough-ready', breakthroughReady);
   }
 
   // Physique

--- a/style.css
+++ b/style.css
@@ -3575,6 +3575,21 @@ tr:last-child td {
   color: #16a34a !important;
 }
 
+.activity-item[data-activity="cultivation"].breakthrough-ready {
+  border-color: #fbbf24;
+  box-shadow: 0 0 8px rgba(251, 191, 36, 0.7);
+  animation: cultivation-gold-sheen 1.5s ease-in-out infinite alternate;
+}
+
+@keyframes cultivation-gold-sheen {
+  from {
+    box-shadow: 0 0 4px rgba(251, 191, 36, 0.5);
+  }
+  to {
+    box-shadow: 0 0 12px rgba(251, 191, 36, 0.9);
+  }
+}
+
 .activity-info {
   flex-grow: 1;
 }


### PR DESCRIPTION
## Summary
- add gold sheen border styling for cultivation sidebar item when breakthrough is available
- toggle breakthrough-ready class when Qi and Foundation are full

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d12428f483269a3f635201c411f6