### PR TITLE
Show qi gain rate on cultivation tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,7 @@
                   <button class="btn cultivation-btn secondary" id="toggleProgressBtn"> View Progress</button>
                 </div>
                 <div class="cultivation-rate">Foundation gain: <span id="foundationRate">0.0</span>/s</div>
+                <div class="cultivation-rate">Qi gain: <span id="qiRegenActivity">0.0</span>/s</div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Add Qi gain per second to cultivation controls below Foundation gain display so players can see their Qi regeneration rate.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation and other enforcement errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d1388a9883268b79431532efa5e9