### PR TITLE
feat: show breakthrough result overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -852,6 +852,16 @@
         </div>
       </div>
     </div>
+    <div class="modal-overlay" id="breakthroughResultOverlay" style="display: none;">
+      <div class="modal-backdrop"></div>
+      <div class="modal-content card" id="breakthroughResultCard">
+        <div class="card-header">
+          <h4 id="breakthroughResultTitle">Breakthrough Result</h4>
+          <button class="btn small ghost" id="closeBreakthroughResultBtn">×</button>
+        </div>
+        <div id="breakthroughResultBody"></div>
+      </div>
+    </div>
   </main>
 
   <div id="debugConsole" class="debug-console" style="display:none;">

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -8,6 +8,7 @@ import { clamp, fCap, foundationGainPerMeditate } from './selectors.js';
 export function advanceRealm(state = progressionState) {
   const wasRealmAdvancement = state.realm.stage > REALMS[state.realm.tier].stages;
   const oldRealm = state.realm.tier;
+  const result = { type: wasRealmAdvancement ? 'realm' : 'stage' };
 
   state.realm.stage++;
   if (state.realm.stage > REALMS[state.realm.tier].stages) {
@@ -17,6 +18,8 @@ export function advanceRealm(state = progressionState) {
 
   const currentRealm = REALMS[state.realm.tier];
   log?.(`Advanced to ${currentRealm.name} ${state.realm.stage}!`, 'good');
+  result.realmName = currentRealm.name;
+  result.stage = state.realm.stage;
 
   if (wasRealmAdvancement) {
     const realmBonus = Math.max(1, Math.floor(state.realm.tier * 1.5));
@@ -24,6 +27,7 @@ export function advanceRealm(state = progressionState) {
     state.defBase += realmBonus;
     state.hpMax += Math.floor(state.hpMax * 0.25);
     state.hp = state.hpMax;
+    result.statMsg = `ATK +${realmBonus * 2}, DEF +${realmBonus}, HP +25%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.stats = state.stats || {
@@ -34,6 +38,7 @@ export function advanceRealm(state = progressionState) {
 
     state.cultivation.talent += 0.15;
     state.cultivation.foundationMult += 0.08;
+    result.extraMsg = `Talent +15%, Comprehension +10%, Foundation Mult +8%`;
 
     const realmStatPoints = 3 + state.realm.tier;
     state.stats.physique += Math.ceil(realmStatPoints * 0.3);
@@ -51,6 +56,7 @@ export function advanceRealm(state = progressionState) {
     state.defBase += Math.floor(stageBonus * 0.7);
     state.hpMax += Math.floor(state.hpMax * 0.08);
     state.hp = Math.min(state.hpMax, state.hp + Math.floor(state.hpMax * 0.5));
+    result.statMsg = `ATK +${stageBonus}, DEF +${Math.floor(stageBonus * 0.7)}, HP +8%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.stats = state.stats || {
@@ -60,6 +66,7 @@ export function advanceRealm(state = progressionState) {
     };
 
     state.cultivation.talent += 0.03;
+    result.extraMsg = `Talent +3%, Comprehension +2%`;
 
     const stageStatPoints = 1 + Math.floor(state.realm.tier * 0.5);
     const statDistribution = Math.random();
@@ -79,6 +86,7 @@ export function advanceRealm(state = progressionState) {
 
   checkLawUnlocks(state);
   awardLawPoints(state);
+  return result;
 }
 
 export function checkLawUnlocks(state = progressionState) {

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -339,6 +339,29 @@ function hideCultivationProgressModal() {
   }
 }
 
+function showBreakthroughResult(success, info = {}) {
+  const overlay = document.getElementById('breakthroughResultOverlay');
+  const title = document.getElementById('breakthroughResultTitle');
+  const body = document.getElementById('breakthroughResultBody');
+  if (!overlay || !title || !body) return;
+
+  if (success) {
+    title.textContent = 'Breakthrough Succeeded!';
+    body.innerHTML = `<p class="good">Advanced to ${info.realmName} ${info.stage}.</p>` +
+      `<p>Stats increased:</p><ul><li>${info.statMsg}</li><li>${info.extraMsg}</li></ul>`;
+  } else {
+    title.textContent = 'Breakthrough Failed';
+    body.innerHTML = '<p class="bad">Tribulation backlash! Breakthrough failed.</p>';
+  }
+
+  overlay.style.display = 'flex';
+}
+
+function hideBreakthroughResult() {
+  const overlay = document.getElementById('breakthroughResultOverlay');
+  if (overlay) overlay.style.display = 'none';
+}
+
 export function setupProgressToggle() {
   const toggleBtn = document.getElementById('toggleProgressBtn');
   const closeBtn = document.getElementById('closeProgressBtn');
@@ -405,13 +428,15 @@ export function updateBreakthrough() {
     if(Math.random() < ch) {
       S.qi = 0;
       S.foundation = 0;
-      advanceRealm();
+      const info = advanceRealm();
       log('Breakthrough succeeded! Realm advanced.', 'good');
+      showBreakthroughResult(true, info);
     } else {
       S.qi = 0;
       S.foundation = Math.max(0, S.foundation - Math.ceil(fCap(S) * 0.25));
       S.hp = Math.max(1, S.hp - Math.ceil(S.hpMax * 0.2));
       log('Tribulation backlash! Breakthrough failed.', 'bad');
+      showBreakthroughResult(false);
     }
 
     S.breakthrough.inProgress = false;
@@ -424,5 +449,11 @@ export function updateBreakthrough() {
 export function initRealmUI(){
   const breakthroughBtn = qs('#breakthroughBtn');
   if (breakthroughBtn) breakthroughBtn.addEventListener('click', tryBreakthrough);
+
+  const closeBtn = qs('#closeBreakthroughResultBtn');
+  const overlay = qs('#breakthroughResultOverlay');
+  const backdrop = overlay?.querySelector('.modal-backdrop');
+  if (closeBtn) closeBtn.addEventListener('click', hideBreakthroughResult);
+  if (backdrop) backdrop.addEventListener('click', hideBreakthroughResult);
 }
 


### PR DESCRIPTION
## Summary
- add modal overlay to report breakthrough success or failure
- return stat gain details from `advanceRealm` for display
- hook UI to show overlay and allow closing

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js, and others)


------
https://chatgpt.com/codex/tasks/task_e_68a9d65a233c8326810f376d33ecf2e0