### PR TITLE
feat(ui): add Qi shield overlay to HP bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,32 @@
       <div class="chip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
       <div class="chip">Stones: <span id="stonesVal">0</span></div>
       <div class="chip hp-chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span>
-        <div class="hp-bar"><div class="fill" id="hpFill"></div><div class="shield-fill" id="shieldFill"></div></div>
+        <div class="hp-bar" id="hpBar" role="img" aria-label="HP 100/100, Shield 0/0">
+          <div class="fill" id="hpFill"></div>
+          <svg class="shield-overlay" id="shieldOverlay" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true" style="display:none">
+            <defs>
+              <mask id="hpMask" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" x="0" y="0" width="100" height="8">
+                <rect id="hpMaskRect" x="0" y="0" width="0" height="8" rx="4" ry="4" fill="#fff" />
+              </mask>
+              <linearGradient id="shieldGradient" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stop-color="#3cf" stop-opacity="0.7" />
+                <stop offset="100%" stop-color="#0ff" stop-opacity="0.3" />
+              </linearGradient>
+              <linearGradient id="shieldShimmer" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stop-color="#fff0" />
+                <stop offset="50%" stop-color="#fff8" />
+                <stop offset="100%" stop-color="#fff0" />
+                <animate attributeName="x1" from="-1" to="1" dur="2s" repeatCount="indefinite" />
+                <animate attributeName="x2" from="0" to="2" dur="2s" repeatCount="indefinite" />
+              </linearGradient>
+            </defs>
+            <g id="shieldGroup" mask="url(#hpMask)">
+              <rect id="shieldFill" class="shield-fill" x="0" y="0" width="0" height="8" rx="4" fill="url(#shieldGradient)" />
+              <rect class="shield-shimmer" x="0" y="0" width="100" height="8" fill="url(#shieldShimmer)" />
+            </g>
+          </svg>
+          <span id="hpA11y" class="sr-only">HP 100/100, Shield 0/0</span>
+        </div>
       </div>
       <div class="chip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
     </div>

--- a/src/shared/utils/dom.js
+++ b/src/shared/utils/dom.js
@@ -10,7 +10,10 @@ export function setText(id, v) {
 export function setFill(id, ratio) {
   ratio = clamp(ratio, 0, 1);
   const el = document.getElementById(id);
-  if (el) el.style.width = (ratio * 100).toFixed(1) + '%';
+  if (!el) return;
+  const pct = (ratio * 100).toFixed(1);
+  if (el instanceof SVGElement) el.setAttribute('width', pct);
+  else el.style.width = pct + '%';
 }
 
 export function log(msg, cls = '') {

--- a/style.css
+++ b/style.css
@@ -1631,9 +1631,13 @@ h1{font-size:20px; margin:0; letter-spacing:.5px}
 /* STYLE-GUIDE-UPDATE: Parchment chip style */
 .chip{background:var(--panel); border:1px solid var(--accent); padding:8px 12px; border-radius:999px; font-size:12px; box-shadow: inset 0 1px 3px rgba(139, 117, 95, 0.2);}
 .hp-chip{display:flex; flex-direction:column; align-items:flex-start;}
-.hp-chip .hp-bar{position:relative; width:100px; height:8px; background:rgba(239,68,68,0.3); border-radius:4px; margin-top:2px;}
-.hp-chip .hp-bar .fill{height:100%; background:linear-gradient(90deg,#ef4444,#f87171); border-radius:4px; transition:width 0.3s ease; width:0%;}
-.hp-chip .hp-bar .shield-fill{position:absolute; top:0; left:0; height:2px; background:cyan; border-radius:4px; width:0%; transition:width 0.3s ease;}
+.hp-chip .hp-bar{position:relative; width:100px; height:8px; background:rgba(239,68,68,0.3); border-radius:4px; margin-top:2px; overflow:hidden;}
+.hp-chip .hp-bar .fill{height:100%; background:linear-gradient(90deg,#ef4444,#f87171); border-radius:4px; transition:width .2s ease; width:0%;}
+.hp-chip .hp-bar svg.shield-overlay{position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none;}
+#shieldFill,#hpMaskRect{transition:width .2s ease;}
+.shield-shimmer{opacity:.5; mix-blend-mode:screen; transform-origin:0 0; transform-box:fill-box; animation:shield-shimmer 2s linear infinite;}
+.sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;}
+@keyframes shield-shimmer{from{transform:translateX(-100%);}to{transform:translateX(100%);}}
 
 main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -195,11 +195,23 @@ function updateAll(){
   updateRealmUI();
   updateQiAndFoundation();
 
-  // HP
+  // HP & Shield
+  const hpFrac = Math.max(0, Math.min(1, S.hp / S.hpMax));
+  const shieldFrac = S.shield?.max ? Math.max(0, Math.min(1, S.shield.current / S.shield.max)) : 0;
   setText('hpVal', fmt(S.hp)); setText('hpMax', fmt(S.hpMax));
   setText('hpValL', fmt(S.hp)); setText('hpMaxL', fmt(S.hpMax));
-  setFill('hpFill', S.hp / S.hpMax);
-  setFill('shieldFill', S.shield?.max ? S.shield.current / S.shield.max : 0);
+  setFill('hpFill', hpFrac);
+  setFill('hpMaskRect', hpFrac);
+  setFill('shieldFill', shieldFrac);
+  const shieldOverlay = document.getElementById('shieldOverlay');
+  if (shieldOverlay) {
+    shieldOverlay.style.display = shieldFrac > 0 ? 'block' : 'none';
+  }
+  const ariaText = `HP ${fmt(S.hp)}/${fmt(S.hpMax)}, Shield ${fmt(S.shield?.current||0)}/${fmt(S.shield?.max||0)}`;
+  const hpBar = document.getElementById('hpBar');
+  if (hpBar) hpBar.setAttribute('aria-label', ariaText);
+  const sr = document.getElementById('hpA11y');
+  if (sr) sr.textContent = ariaText;
   updateCombatStats();
   updateCurrentTaskDisplay(S);
 


### PR DESCRIPTION
## Summary
- render Qi shield overlay above HP using an SVG mask for clipping
- animate HP and shield widths and expose accessible text labels
- extend DOM utils to update SVG widths
- ensure Qi shield overlay displays correctly via proper mask units and width handling

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e35561248326afd3e1bcf2b66b99