### PR TITLE
feat: validate imported state

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -3,7 +3,7 @@
 
 // Way of Ascension — Modular JS
 
-import { S, defaultState, save, setState } from '../src/shared/state.js';
+import { S, defaultState, save, setState, validateState } from '../src/shared/state.js';
 import {
   clamp,
   qCap,
@@ -165,7 +165,7 @@ function initUI(){
   if (importBtn) {
     importBtn.addEventListener('click', async()=>{
       const inp=document.createElement('input'); inp.type='file'; inp.accept='application/json';
-      inp.onchange=()=>{ const f=inp.files[0]; const r=new FileReader(); r.onload=()=>{ try{ setState(JSON.parse(r.result)); save(); location.reload(); }catch{ alert('Invalid file'); } }; r.readAsText(f); };
+      inp.onchange=()=>{ const f=inp.files[0]; const r=new FileReader(); r.onload=()=>{ try{ const parsed = JSON.parse(r.result); const v = validateState(parsed); if(!v) throw new Error('bad'); setState(v); save(); location.reload(); }catch{ alert('Invalid file'); } }; r.readAsText(f); };
       inp.click();
     });
   }


### PR DESCRIPTION
## Summary
- add helper to validate save data against expected structure
- ensure `setState` and import flow run migrations and use validation before assigning new state

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: VERIFICATION FAILED - UI state violation, DOM usage, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e9ad0c8c832692788ac2f22ccacc