### PR TITLE
Validate cooking amount and clamp to available meat

### DIFF
--- a/src/features/cooking/logic.js
+++ b/src/features/cooking/logic.js
@@ -18,8 +18,14 @@ export function getFoodSlotData(state) {
 }
 
 export function cookMeat(amount, state) {
-  const amt = parseInt(amount) || 1;
-  if ((state.meat || 0) < amt) {
+  const parsed = Number(amount);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    console.warn(`Invalid cook amount: ${amount}`);
+    return;
+  }
+  const availableMeat = state.meat || 0;
+  const amt = Math.min(parsed, availableMeat);
+  if (amt < 1) {
     log('Not enough raw meat!', 'bad');
     return;
   }


### PR DESCRIPTION
## Summary
- ensure cookMeat validates amount as integer >=1
- clamp cooking amount to available meat
- warn and return when validation fails

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: VERIFICATION FAILED - MUST fix before proceeding)


------
https://chatgpt.com/codex/tasks/task_e_68a9e9b961ac8326abfff066e8cbec68