### PR TITLE
Add floating combat text renderer

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -130,6 +130,7 @@ way-of-ascension/
 │   │   │   ├── statusEngine.js
 │   │   │   └── ui/
 │   │   │       ├── combatStats.js
+│   │   │       ├── floatingText.js
 │   │   │       ├── fx.js
 │   │   │       └── index.js
 │   │   ├── cooking/
@@ -723,6 +724,11 @@ function updateAll() {
 **Key Functions**: `playSlashArc()`, `playThrustLine()`, `playRingShockwave()`, `playBeam()`, `playChakram()`, `playShieldDome()`, `playSparkBurst()`, `setFxTint()`, `setReduceMotion()`.
 **When to modify**: Extend or adjust visual effect primitives.
 
+#### `src/features/combat/ui/floatingText.js` - Floating Combat Text
+**Purpose**: Renders animated combat text (damage numbers, misses, critical hits) above HP bars.
+**Key Functions**: `showFloatingText()`, `setFloatingTextEnabled()`.
+**When to modify**: Change floating combat text behavior or styling.
+
 ### HTML Structure (`index.html`)
 **Purpose**: Main game interface structure
 **Key Elements**:
@@ -771,6 +777,7 @@ Paths added:
 - `src/features/automation/mutators.js` – automation mutators
 - `src/features/automation/selectors.js` – automation selectors
 - `src/features/automation/state.js` – automation state slice
+- `src/features/combat/ui/floatingText.js` – floating combat text renderer
 
 #### `src/game/GameController.js` - Game Orchestrator
 **Purpose**: Boots the game, runs the fixed-step loop, emits events and handles simple routing.

--- a/src/features/combat/ui/floatingText.js
+++ b/src/features/combat/ui/floatingText.js
@@ -1,0 +1,99 @@
+const MAX_NODES = 24;
+const pool = [];
+const active = [];
+let enabled = true;
+
+function createNode() {
+  const el = document.createElement('div');
+  el.className = 'fct';
+  el.style.position = 'absolute';
+  el.style.pointerEvents = 'none';
+  el.style.zIndex = '9999';
+  el.style.willChange = 'transform, opacity';
+  return el;
+}
+
+function obtainNode() {
+  let el = pool.pop();
+  if (el) return el;
+  if (active.length >= MAX_NODES) {
+    el = active.shift();
+    el.getAnimations().forEach(a => a.cancel());
+    if (el.parentNode) el.parentNode.removeChild(el);
+    return el;
+  }
+  return createNode();
+}
+
+function recycle(el) {
+  const idx = active.indexOf(el);
+  if (idx !== -1) active.splice(idx, 1);
+  el.textContent = '';
+  el.removeAttribute('class');
+  el.className = 'fct';
+  if (el.parentNode) el.parentNode.removeChild(el);
+  pool.push(el);
+}
+
+export function setFloatingTextEnabled(v) {
+  enabled = v;
+}
+
+export function showFloatingText({ targetEl, result, amount = 0 }) {
+  if (!enabled || !targetEl) return;
+
+  const rect = targetEl.getBoundingClientRect();
+  const vw = document.documentElement.clientWidth;
+  const baseX = rect.left + rect.width / 2 + window.scrollX;
+  const baseY = rect.top + window.scrollY;
+  const node = obtainNode();
+
+  // Prepare text
+  let text = '';
+  if (result === 'miss') text = 'Miss';
+  else text = result === 'crit' ? `${amount}!` : String(amount);
+  node.textContent = text;
+  node.className = `fct fct-${result}`;
+  node.style.visibility = 'hidden';
+  document.body.appendChild(node);
+
+  const { offsetWidth: w, offsetHeight: h } = node;
+  let x = baseX - w / 2;
+  let y = baseY - h;
+  const jitterX = (Math.random() * 6 + 12) * (Math.random() < 0.5 ? -1 : 1);
+  const jitterY = Math.random() * 8;
+  x += jitterX;
+  y -= jitterY;
+  x = Math.min(Math.max(x, window.scrollX), window.scrollX + vw - w);
+  node.style.left = `${x}px`;
+  node.style.top = `${y}px`;
+  node.style.visibility = 'visible';
+
+  const size = Math.max(12, Math.min(32, rect.width / 3));
+  node.style.fontSize = `${result === 'crit' ? size * 1.3 : size}px`;
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const distance = prefersReducedMotion ? 20 : 40 + Math.random() * 30;
+  const duration = prefersReducedMotion ? 400 : 600 + Math.random() * 300;
+  const dx = jitterX;
+
+  const keyframes = [];
+  if (result === 'crit' && !prefersReducedMotion) {
+    keyframes.push({ transform: `translate(${dx}px,0) scale(1)`, opacity: 1, offset: 0 });
+    keyframes.push({ transform: `translate(${dx}px,0) scale(1.25)`, opacity: 1, offset: 0.1 });
+    keyframes.push({ transform: `translate(${dx}px,0) scale(1)`, opacity: 1, offset: 0.2 });
+  } else if (result === 'miss' && !prefersReducedMotion) {
+    keyframes.push({ transform: `translate(${dx - 4}px,0)`, opacity: 1, offset: 0 });
+    keyframes.push({ transform: `translate(${dx + 4}px,0)`, opacity: 1, offset: 0.05 });
+    keyframes.push({ transform: `translate(${dx}px,0)`, opacity: 1, offset: 0.1 });
+  } else {
+    keyframes.push({ transform: `translate(${dx}px,0)`, opacity: 1, offset: 0 });
+  }
+  keyframes.push({ transform: `translate(${dx}px,-${distance}px)`, opacity: 0, offset: 1 });
+
+  const anim = node.animate(keyframes, { duration, easing: 'ease-out' });
+  active.push(node);
+  anim.onfinish = () => recycle(node);
+}
+
+export { enabled as floatingTextEnabled };

--- a/src/features/combat/ui/index.js
+++ b/src/features/combat/ui/index.js
@@ -2,4 +2,5 @@
 // Re-export combat UI helpers for shared use
 
 export * from './fx.js';
+export * from './floatingText.js';
 

--- a/style.css
+++ b/style.css
@@ -4118,3 +4118,23 @@ tr:last-child td {
             drop-shadow(0 0 0.25rem rgba(179, 36, 36, 0.35));
   }
 }
+
+/* Floating combat text */
+.fct{
+  position:absolute;
+  pointer-events:none;
+  color:#fff;
+  text-shadow:0 0 2px #000;
+  font-weight:400;
+  user-select:none;
+  z-index:9999;
+  will-change:transform,opacity;
+}
+.fct-crit{
+  color:#ffd700;
+  font-weight:700;
+}
+.fct-miss{
+  color:#9ab;
+  font-style:italic;
+}


### PR DESCRIPTION
## Summary
- implement reusable floating combat text pool with hit, miss, and crit styling
- expose showFloatingText API from combat UI
- document new module and add supporting styles

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations in unrelated modules)

------
https://chatgpt.com/codex/tasks/task_e_68a9eb4579948326b7e02c8062521d36