### PR TITLE
Add mobile drawer and responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
     <div class="elemental-ice"></div>
   </div>
   <header>
+    <button id="menuButton" class="hamburger" aria-label="Menu" aria-controls="sidebar" aria-expanded="false">☰</button>
     <div class="brand">
       <div class="qi-orb" id="qiOrb" aria-hidden="true">
         <svg class="yin-yang-svg" viewBox="0 0 512 512" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false">
@@ -53,14 +54,14 @@
       </div>
     </div>
     <div class="topbar" id="top-chips">
-      <div class="chip">Task: <span id="currentTask">Idle</span></div>
-      <div class="chip">Realm: <span id="realmName">Mortal 1</span></div>
-      <div class="chip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
-      <div class="chip">Stones: <span id="stonesVal">0</span></div>
+      <div class="chip" id="taskChip">Task: <span id="currentTask">Idle</span></div>
+      <div class="chip" id="realmChip">Realm: <span id="realmName">Mortal 1</span></div>
+      <div class="chip" id="qiChip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
+      <div class="chip" id="stonesChip">Stones: <span id="stonesVal">0</span></div>
       <div class="chip hp-chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span>
         <div class="hp-bar"><div class="fill" id="hpFill"></div><div class="shield-fill" id="shieldFill"></div></div>
       </div>
-      <div class="chip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
+      <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
     </div>
     <div class="right-actions">
       <button class="btn small ghost" id="saveBtn">💾 Save</button>
@@ -70,8 +71,9 @@
     </div>
   </header>
 
+  <div id="drawerScrim" class="drawer-scrim" hidden></div>
   <main>
-    <aside class="left">
+    <aside class="left" id="sidebar" aria-hidden="true" tabindex="-1" role="dialog" aria-modal="true">
       
       <!-- Leveling Activities Group -->
       <div class="activity-group">

--- a/style.css
+++ b/style.css
@@ -16,6 +16,9 @@
   --danger: #b32424; /* clearer alert red */
   --shadow: 0 10px 30px rgba(45, 37, 32, 0.25); /* Soft brown shadow */
   --radius: 16px;
+  --gap: 20px;
+  --pad: 16px;
+  --header-h: 76px;
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
   --mortal-primary: #a66c4c; /* lighter saddle brown */
@@ -4118,3 +4121,32 @@ tr:last-child td {
             drop-shadow(0 0 0.25rem rgba(179, 36, 36, 0.35));
   }
 }
+
+.hamburger{display:none;background:none;border:none;font-size:1.5rem;line-height:1;padding:4px;cursor:pointer;}
+.drawer-scrim{position:fixed;inset:0;background:rgba(0,0,0,0.4);opacity:0;pointer-events:none;transition:opacity .3s;z-index:1000;}
+.drawer-scrim.active{opacity:1;pointer-events:auto;}
+.debug-overflow *{outline:1px dashed red;}
+
+@media (max-width:768px){
+  :root{--gap:12px;--pad:12px;--header-h:64px;}
+  html,body{overflow-x:hidden;}
+  header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
+  .brand{width:100%;display:flex;align-items:center;justify-content:space-between;}
+  .hamburger{display:block;}
+  .topbar{display:flex;gap:var(--gap);overflow-x:auto;}
+  #taskChip,#realmChip,#stonesChip{display:none;}
+  main{display:block;height:auto;}
+  #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);}
+  #sidebar.open{transform:translateX(0);}
+  body.drawer-open{overflow:hidden;}
+  .content{padding:var(--pad);}
+  img,canvas{max-width:100%;height:auto;}
+  .hp-chip .hp-bar{width:100%;max-width:100%;}
+  .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}
+}
+@media (prefers-reduced-motion:reduce){
+  #sidebar{transition:none;}
+  .drawer-scrim{transition:none;}
+}
+html.reduce-motion #sidebar{transition:none;}
+html.reduce-motion .drawer-scrim{transition:none;}

--- a/ui/index.js
+++ b/ui/index.js
@@ -432,11 +432,64 @@ function tick(){
   updateAbilityBar();
 }
 
+function setupMobileUI() {
+  const menu = qs('#menuButton');
+  const sidebar = qs('#sidebar');
+  const scrim = qs('#drawerScrim');
+  if (!menu || !sidebar || !scrim) return;
+  const focusable = sidebar.querySelectorAll('a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])');
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  function trap(e) {
+    if (e.key !== 'Tab') return;
+    if (e.shiftKey && document.activeElement === first) { e.preventDefault(); (last || first).focus(); }
+    else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); (first || last).focus(); }
+  }
+  function close() {
+    sidebar.classList.remove('open');
+    scrim.classList.remove('active');
+    scrim.hidden = true;
+    document.body.classList.remove('drawer-open');
+    menu.setAttribute('aria-expanded', 'false');
+    sidebar.setAttribute('aria-hidden', 'true');
+    window.removeEventListener('keydown', esc);
+    window.removeEventListener('keydown', trap);
+    menu.focus();
+  }
+  function esc(e) { if (e.key === 'Escape') close(); }
+  menu.addEventListener('click', () => {
+    sidebar.classList.add('open');
+    scrim.hidden = false;
+    scrim.classList.add('active');
+    document.body.classList.add('drawer-open');
+    menu.setAttribute('aria-expanded', 'true');
+    sidebar.setAttribute('aria-hidden', 'false');
+    (first || sidebar).focus();
+    window.addEventListener('keydown', esc);
+    window.addEventListener('keydown', trap);
+  });
+  scrim.addEventListener('click', close);
+}
+
+function enableDebug() {
+  if (!window.DEBUG) return;
+  document.documentElement.classList.add('debug-overflow');
+  const check = () => {
+    const w = document.documentElement.scrollWidth;
+    const vw = document.documentElement.clientWidth;
+    if (w > vw) console.warn('[layout] overflow', w - vw);
+  };
+  window.addEventListener('resize', check);
+  check();
+}
+
 
 
 // Init
 window.addEventListener('load', ()=>{
   initUI();
+  setupMobileUI();
+  enableDebug();
   initLawSystem();
   mountActivityUI(S);
   mountAdventureControls(S);


### PR DESCRIPTION
## Summary
- add hamburger menu and off-canvas sidebar with scrim and basic focus management
- introduce responsive CSS variables and mobile breakpoint to stack content and lock horizontal overflow
- provide optional DEBUG mode to highlight layout overflow issues

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation and timer warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ebd95e7c8326bbddc513ab71d907