### PR TITLE
Add mind state defaults and data registries

### DIFF
--- a/src/features/mind/data/manuals.js
+++ b/src/features/mind/data/manuals.js
@@ -1,1 +1,16 @@
-export const mindManuals = [];
+// src/features/mind/data/manuals.js
+
+export const MANUALS = {
+  logic101: { id: 'logic101', name: 'Logic 101', xpRate: 0.5, reqLevel: 1, category: 'Logic' },
+  mnemonics: { id: 'mnemonics', name: 'Mnemonics Primer', xpRate: 0.4, reqLevel: 2, category: 'Memory' },
+  paradox: { id: 'paradox', name: 'Paradox Studies', xpRate: 0.3, reqLevel: 4, category: 'Abstraction' },
+};
+
+export function getManual(id) {
+  return MANUALS[id] || null;
+}
+
+export function listManuals() {
+  return Object.values(MANUALS);
+}
+

--- a/src/features/mind/data/talismans.js
+++ b/src/features/mind/data/talismans.js
@@ -1,1 +1,16 @@
-export const mindTalismans = [];
+// src/features/mind/data/talismans.js
+
+export const TALISMANS = {
+  wardPaper: { id: 'wardPaper', name: 'Paper Ward', tier: 1, type: 'defense', xpMult: 1.0, cost: { fiber: 5 } },
+  inkSeal:   { id: 'inkSeal',   name: 'Ink Seal',   tier: 2, type: 'focus',   xpMult: 1.4, cost: { fiber: 10, ink: 3 } },
+  jadeGlyph: { id: 'jadeGlyph', name: 'Jade Glyph', tier: 3, type: 'clarity', xpMult: 1.9, cost: { jade: 1, ink: 5 } },
+};
+
+export function getTalisman(id) {
+  return TALISMANS[id] || null;
+}
+
+export function listTalismans() {
+  return Object.values(TALISMANS);
+}
+

--- a/src/features/mind/index.js
+++ b/src/features/mind/index.js
@@ -1,4 +1,4 @@
-export * from './state.js';
+export { defaultMindState, ensureMindState } from './state.js';
 export * from './logic.js';
 export * from './mutators.js';
 export * from './selectors.js';

--- a/src/features/mind/state.js
+++ b/src/features/mind/state.js
@@ -1,1 +1,22 @@
-export const mindState = {};
+// src/features/mind/state.js
+
+export const defaultMindState = {
+  xp: 0,
+  level: 1,
+  multiplier: 1,
+  fromProficiency: 0,
+  fromReading: 0,
+  fromCrafting: 0,
+  activeManualId: null,
+  manualProgress: {},
+  // { manualId: { xp: number, done: boolean } }
+  solvedPuzzles: 0,
+};
+
+export function ensureMindState(root = {}) {
+  if (!root.mind) {
+    root.mind = { ...defaultMindState };
+  }
+  return root;
+}
+


### PR DESCRIPTION
## Summary
- define default mind state and safe initializer
- expose mind manuals and talismans registries with lookup helpers

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: Missing contract for feature: mind; undocumented file warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a9f6f84a0c8326b07c6c775e31a153