### PR TITLE
feat: add mind feature calculations and mutators

### DIFF
--- a/src/features/mind/index.js
+++ b/src/features/mind/index.js
@@ -1,4 +1,28 @@
+// src/features/mind/index.js
+
 export { defaultMindState, ensureMindState } from './state.js';
-export * from './logic.js';
-export * from './mutators.js';
-export * from './selectors.js';
+
+export {
+  calcFromProficiency,
+  calcFromManual,
+  calcFromCraft,
+  applyPuzzleMultiplier,
+  levelForXp,
+} from './logic.js';
+
+export {
+  awardFromProficiency,
+  startReading,
+  stopReading,
+  craftTalisman,
+  solvePuzzle,
+  onTick,
+} from './mutators.js';
+
+export {
+  getMind,
+  mindBreakdown,
+  currentMindLevel,
+  currentMindXp,
+} from './selectors.js';
+

--- a/src/features/mind/logic.js
+++ b/src/features/mind/logic.js
@@ -1,3 +1,33 @@
-export function mindLogic() {
-  // placeholder logic
+// src/features/mind/logic.js
+
+// Pure calculation helpers for the Mind feature. These functions do not
+// mutate state and are easily unit testable.
+
+export function calcFromProficiency(profXp) {
+  return Math.max(0, profXp) * 0.25;
 }
+
+export function calcFromManual(manual, dt) {
+  return manual ? manual.xpRate * dt : 0;
+}
+
+export function calcFromCraft(talisman) {
+  return (talisman?.tier || 0) * (talisman?.xpMult || 1) * 5;
+}
+
+export function applyPuzzleMultiplier(base, mult) {
+  return base * (mult || 1);
+}
+
+export function levelForXp(xp) {
+  // simple curve placeholder
+  let lvl = 1;
+  let need = 50;
+  while (xp >= need) {
+    xp -= need;
+    lvl += 1;
+    need = Math.ceil(need * 1.35);
+  }
+  return lvl;
+}
+

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -1,3 +1,69 @@
-export function mutateMind(state) {
-  return state;
+// src/features/mind/mutators.js
+
+import { getManual } from './data/manuals.js';
+import { getTalisman } from './data/talismans.js';
+import {
+  calcFromProficiency,
+  calcFromManual,
+  calcFromCraft,
+  applyPuzzleMultiplier,
+  levelForXp,
+} from './logic.js';
+
+export function awardFromProficiency(S, profXp) {
+  const add = calcFromProficiency(profXp);
+  S.mind.fromProficiency += add;
+  S.mind.xp += applyPuzzleMultiplier(add, S.mind.multiplier);
+  S.mind.level = levelForXp(S.mind.xp);
 }
+
+export function startReading(S, manualId) {
+  const m = getManual(manualId);
+  if (!m) return false;
+  if (S.mind.level < m.reqLevel) return false;
+  S.mind.activeManualId = manualId;
+  if (!S.mind.manualProgress[manualId]) {
+    S.mind.manualProgress[manualId] = { xp: 0, done: false };
+  }
+  return true;
+}
+
+export function stopReading(S) {
+  S.mind.activeManualId = null;
+}
+
+export function craftTalisman(S, talismanId) {
+  const t = getTalisman(talismanId);
+  if (!t) return false;
+  // assume resource checks done elsewhere for now
+  const add = calcFromCraft(t);
+  S.mind.fromCrafting += add;
+  S.mind.xp += applyPuzzleMultiplier(add, S.mind.multiplier);
+  S.mind.level = levelForXp(S.mind.xp);
+  return true;
+}
+
+export function solvePuzzle(S, difficultyIndex) {
+  // permanent multiplier: 1 + 0.05 per difficulty step
+  const inc = 1 + Math.max(0, difficultyIndex) * 0.05;
+  S.mind.multiplier *= inc;
+  S.mind.solvedPuzzles += 1;
+}
+
+export function onTick(S, dt) {
+  const id = S.mind.activeManualId;
+  if (!id) return;
+  const manual = getManual(id);
+  if (!manual) return;
+  const add = calcFromManual(manual, dt);
+  const applied = applyPuzzleMultiplier(add, S.mind.multiplier);
+  S.mind.fromReading += add;
+  S.mind.xp += applied;
+  const rec = S.mind.manualProgress[id];
+  rec.xp += add;
+  if (rec.xp >= manual.reqLevel * 100) {
+    rec.done = true;
+  }
+  S.mind.level = levelForXp(S.mind.xp);
+}
+

--- a/src/features/mind/selectors.js
+++ b/src/features/mind/selectors.js
@@ -1,3 +1,26 @@
 export function getMind(state = {}) {
   return state.mind || {};
 }
+
+export function mindBreakdown(S) {
+  const m = S.mind;
+  const base = m.fromProficiency + m.fromReading + m.fromCrafting;
+  return {
+    base,
+    multiplier: m.multiplier,
+    total: base * m.multiplier,
+    sources: {
+      proficiency: m.fromProficiency,
+      reading: m.fromReading,
+      crafting: m.fromCrafting,
+    },
+  };
+}
+
+export function currentMindLevel(S) {
+  return S.mind.level;
+}
+
+export function currentMindXp(S) {
+  return S.mind.xp;
+}


### PR DESCRIPTION
## Summary
- implement pure mind logic calculators and leveling curve
- add selectors for mind stats and breakdown
- provide mutators for proficiency, reading, crafting, puzzles, and tick updates
- re-export all mind feature utilities

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: Balance validation failed: missing contracts and undocumented files)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fd8484308326bfb5504f132ada91