### PR TITLE
feat: improve mobile tab layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,12 +115,12 @@
         <div class="cultivation-header">
           
         </div>
-        <div class="cultivation-tabs">
+        <div class="cultivation-tabs tab-bar">
           <button class="cultivation-tab-btn active" data-tab="cultivation">Cultivation</button>
           <button class="cultivation-tab-btn" data-tab="stats">Stats</button>
         </div>
 
-        <div id="cultivationSubTab" class="cultivation-tab-content active">
+        <div id="cultivationSubTab" class="cultivation-tab-content tab-content active">
           <div class="cultivation-layout">
             <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
@@ -262,7 +262,7 @@
         </div>
 
         <div id="statsSubTab" class="cultivation-tab-content" style="display:none;">
-          <div class="cards">
+          <div class="cards tab-content">
             <div class="card">
               <h4>Breakthrough Details</h4>
               <div class="stat"><span>Success Chance</span><span id="btChanceActivity">0%</span></div>
@@ -294,7 +294,7 @@
 
       <section id="activity-physique" class="activity-content" style="display:none;">
         <h2> Physique Training</h2>
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Training Status</h4>
             <div class="stat"><span>Physique Level</span><span id="physiqueLevelActivity">1</span></div>
@@ -360,7 +360,7 @@
 
       <section id="activity-mining" class="activity-content" style="display:none;">
         <h2> Mining</h2>
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Mining Status</h4>
             <div class="stat"><span>Mining Level</span><span id="miningLevelActivity">1</span></div>
@@ -423,7 +423,7 @@
             </div>
           </div>
         
-        <div class="cards adventure-cards"> <!-- MAP-UI-UPDATE -->
+        <div class="cards adventure-cards tab-content"> <!-- MAP-UI-UPDATE -->
           
           <!-- Persistent Battle Display -->
           <div class="card battle-card expanded-battle"> <!-- MAP-UI-UPDATE -->
@@ -524,7 +524,7 @@
           
           <!-- Adventure Tabs -->
           <div class="card adventure-tabs-card">
-            <div class="adventure-tabs">
+            <div class="adventure-tabs tab-bar">
               <button class="adventure-tab-btn active" data-tab="progress">📊 Progress</button>
               <button class="adventure-tab-btn" data-tab="bestiary">📖 Bestiary</button>
               <button class="adventure-tab-btn" data-tab="loot">💰 Loot</button>
@@ -592,7 +592,7 @@
 
       <section id="activity-character" class="activity-content" style="display:none;">
         <h2>🧙 Character</h2>
-        <div class="cards character-cards">
+        <div class="cards character-cards tab-content">
           <div class="card">
             <h4>Stats</h4>
             <div class="stat"><span>HP</span><span id="stat-hp">100/100</span></div>
@@ -639,7 +639,7 @@
 
       <section id="activity-sect" class="activity-content" style="display:none;">
         <h2>🏛️ Sect Management</h2>
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Sect Buildings</h4>
             <p class="muted">Construct and upgrade buildings to enhance your sect's capabilities. Buildings unlock as you advance in cultivation and provide powerful bonuses.</p>
@@ -650,7 +650,7 @@
 
       <section id="activity-cooking" class="activity-content" style="display:none;">
         <h2>🍳 Cooking</h2>
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Cooking Skill</h4>
             <div class="stat"><span>Level</span><span id="cookingLevel">1</span></div>
@@ -718,8 +718,8 @@
         </div>
       </section>
 
-      <section id="tab-cultivation">
-        <div class="cards">
+      <section id="tab-cultivation" class="activity-content">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Cultivation Training</h4>
             <p class="muted">Meditate to gain <strong>Foundation</strong>. Qi regenerates passively. Both must be full to attempt a breakthrough. Pills can boost success.</p>
@@ -751,8 +751,8 @@
         </div>
       </section>
 
-      <section id="tab-laws">
-        <div class="cards">
+      <section id="tab-laws" class="activity-content">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Cultivation Laws</h4>
             <p class="muted">Choose your cultivation path after reaching Foundation stage. Each law provides unique bonuses and unlocks powerful skill trees.</p>
@@ -771,8 +771,8 @@
         </div>
       </section>
 
-      <section id="tab-gathering">
-        <div class="cards">
+      <section id="tab-gathering" class="activity-content">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Disciples</h4>
             <p class="muted">Assign disciples to gather herbs, ore, and wood. Yields scale with upgrades.</p>
@@ -811,7 +811,7 @@
 
       <section id="activity-alchemy" class="activity-content" style="display:none;">
         <h2>⚗️ Alchemy</h2>
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Alchemy Cauldron</h4>
             <p class="muted">Brew pills that boost cultivation and breakthroughs. Success grows with Alchemy level.</p>
@@ -836,8 +836,8 @@
         </div>
       </section>
 
-      <section id="tab-combat">
-        <div class="cards">
+      <section id="tab-combat" class="activity-content">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Combat Stats</h4>
             <div class="stat"><span>Your ATK</span><span id="atkVal2">5</span></div>

--- a/style.css
+++ b/style.css
@@ -19,6 +19,9 @@
   --gap: 20px;
   --pad: 16px;
   --header-h: 76px;
+  --tabs-h: 0px;
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --float-pad: 0px;
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
   --mortal-primary: #a66c4c; /* lighter saddle brown */
@@ -133,6 +136,12 @@ h1, .ability-name {
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
 }
 
 .card {
@@ -4158,7 +4167,11 @@ tr:last-child td {
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
   .content{padding:var(--pad);}
-  .activity-content{padding:var(--pad);}
+    .activity-content{padding:var(--pad);}
+    .tab-bar{position:sticky;top:var(--header-h);z-index:999;background:var(--panel);}
+    .tab-content{min-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));max-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:var(--float-pad);}
+    .tab-content>.card{width:100%;max-width:100%;}
+    .tab-content>.card:only-child{flex:1;}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}

--- a/ui/index.js
+++ b/ui/index.js
@@ -507,6 +507,7 @@ function setupStatusToggle() {
     window.removeEventListener('keydown', esc);
     toggle.textContent = 'Status \u25BE';
     toggle.focus();
+    requestAnimationFrame(updateViewportVars);
   }
   function open() {
     row.setAttribute('data-open', 'true');
@@ -516,6 +517,7 @@ function setupStatusToggle() {
     toggle.textContent = 'Status \u25B4';
     document.addEventListener('click', outside, true);
     window.addEventListener('keydown', esc);
+    requestAnimationFrame(updateViewportVars);
   }
   function esc(e) { if (e.key === 'Escape') close(); }
   function outside(e) { if (!row.contains(e.target)) close(); }
@@ -536,12 +538,32 @@ function enableDebug() {
   check();
 }
 
+function updateViewportVars() {
+  const root = document.documentElement;
+  const header = document.querySelector('header');
+  const bars = document.querySelectorAll('.tab-bar');
+  let activeBar = null;
+  for (const b of bars) {
+    if (b.offsetParent !== null) { activeBar = b; break; }
+  }
+  if (header) root.style.setProperty('--header-h', `${header.offsetHeight}px`);
+  root.style.setProperty('--tabs-h', activeBar ? `${activeBar.offsetHeight}px` : '0px');
+}
+
+window.addEventListener('resize', updateViewportVars);
+document.addEventListener('click', (e) => {
+  if (e.target.closest('.cultivation-tab-btn') || e.target.closest('.adventure-tab-btn') || e.target.closest('[data-activity]')) {
+    requestAnimationFrame(updateViewportVars);
+  }
+});
+
 
 
 // Init
 window.addEventListener('load', ()=>{
   initUI();
   setupMobileUI();
+  updateViewportVars();
   setupStatusToggle();
   enableDebug();
   initLawSystem();


### PR DESCRIPTION
## Summary
- keep feature tab bars sticky under the header and mark card containers with a stable `tab-content` hook
- size tab content regions to the viewport on mobile and allow vertical scrolling when multiple cards exist
- calculate header and tab bar heights in UI layer to drive mobile CSS vars
- recompute header height when status row toggles to avoid offset gaps

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: missing contract for feature: mind)
- `npm run lint:balance` (fails: missing contract for feature: mind)


------
https://chatgpt.com/codex/tasks/task_e_68a9fc547db88326ad2b04d9b7cc71f0