### PR TITLE
feat: add mobile tab content layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,12 +115,12 @@
         <div class="cultivation-header">
           
         </div>
-        <div class="cultivation-tabs">
+        <div class="cultivation-tabs tab-bar">
           <button class="cultivation-tab-btn active" data-tab="cultivation">Cultivation</button>
           <button class="cultivation-tab-btn" data-tab="stats">Stats</button>
         </div>
 
-        <div id="cultivationSubTab" class="cultivation-tab-content active">
+        <div id="cultivationSubTab" class="cultivation-tab-content tab-content active">
           <div class="cultivation-layout">
             <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
@@ -261,7 +261,7 @@
           </div>
         </div>
 
-        <div id="statsSubTab" class="cultivation-tab-content" style="display:none;">
+        <div id="statsSubTab" class="cultivation-tab-content tab-content" style="display:none;">
           <div class="cards">
             <div class="card">
               <h4>Breakthrough Details</h4>
@@ -524,7 +524,7 @@
           
           <!-- Adventure Tabs -->
           <div class="card adventure-tabs-card">
-            <div class="adventure-tabs">
+            <div class="adventure-tabs tab-bar">
               <button class="adventure-tab-btn active" data-tab="progress">📊 Progress</button>
               <button class="adventure-tab-btn" data-tab="bestiary">📖 Bestiary</button>
               <button class="adventure-tab-btn" data-tab="loot">💰 Loot</button>
@@ -532,7 +532,7 @@
             </div>
             
             <!-- Progress Tab -->
-            <div id="progressTab" class="adventure-tab-content active">
+            <div id="progressTab" class="adventure-tab-content tab-content active">
               <div class="stat"><span>Total Kills</span><span id="totalKills">0</span></div>
               <div class="stat"><span>Areas Completed</span><span id="areasCompleted">0</span></div>
               <div class="stat"><span>Zones Unlocked</span><span id="zonesUnlocked">1</span></div>
@@ -548,14 +548,14 @@
             </div>
             
             <!-- Bestiary Tab -->
-            <div id="bestiaryTab" class="adventure-tab-content" style="display: none;">
+            <div id="bestiaryTab" class="adventure-tab-content tab-content" style="display: none;">
               <div class="bestiary-list" id="bestiaryList">
                 <div class="muted">Defeat enemies to unlock their information...</div>
               </div>
             </div>
 
             <!-- Loot Tab -->
-            <div id="lootTab" class="adventure-tab-content" style="display: none;">
+            <div id="lootTab" class="adventure-tab-content tab-content" style="display: none;">
               <div class="muted warn">Items here are not safe. Retreat to claim; death forfeits them.</div>
               <div class="session-loot-list" id="sessionLootList"></div>
               <div class="loot-actions" style="text-align:right; margin-top:8px;">
@@ -565,7 +565,7 @@
             </div>
             
             <!-- Proficiencies Tab -->
-            <div id="proficienciesTab" class="adventure-tab-content" style="display: none;">
+            <div id="proficienciesTab" class="adventure-tab-content tab-content" style="display: none;">
               <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
               <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
               <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>

--- a/style.css
+++ b/style.css
@@ -4132,7 +4132,7 @@ tr:last-child td {
 .debug-overflow *{outline:1px dashed red;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;}
   html,body{overflow-x:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
@@ -4159,6 +4159,10 @@ tr:last-child td {
   body.drawer-open{overflow:hidden;}
   .content{padding:var(--pad);}
   .activity-content{padding:var(--pad);}
+  .tab-bar{position:sticky;top:var(--header-h);z-index:900;background:var(--panel);margin-bottom:0;}
+  .tab-content{padding-top:var(--gap);display:flex;flex-direction:column;gap:var(--gap);min-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));max-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:var(--float-pad);}
+  .tab-content>.card{width:100%;max-width:100%;}
+  .tab-content>.card:only-child{flex:1 0 auto;}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}


### PR DESCRIPTION
## Summary
- keep header and tabs sticky on mobile
- size tab content to viewport and allow internal scrolling

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: update docs/project-structure.md)*

------
https://chatgpt.com/codex/tasks/task_e_68aa02cd6d4083269cf89fb2ab035d39