### PR TITLE
Fix physique training cards not visible

### DIFF
--- a/src/features/physique/ui/trainingGame.js
+++ b/src/features/physique/ui/trainingGame.js
@@ -82,6 +82,13 @@ function showHitFeedback(message, color){
 }
 
 export function mountTrainingGameUI(state){
+  // Ensure the associated Physique cards are visible when the feature mounts
+  const cardIds = ['activeTrainingCard', 'passiveTrainingCard', 'physiqueEffectsCard'];
+  for (const id of cardIds) {
+    const el = document.getElementById(id);
+    if (el) el.style.display = 'block';
+  }
+
   const startBtn = document.getElementById('startTrainingSession');
   if(startBtn){
     startBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Ensure Physique training UI shows training session, passive training, and effects cards

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: missing documentation and UI contract issues)

------
https://chatgpt.com/codex/tasks/task_e_68aa0c1a73c08326b1dd839f75ac24b1