### PR TITLE
feat: mobile-friendly tab content

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
           <button class="cultivation-tab-btn" data-tab="stats">Stats</button>
         </div>
 
-        <div id="cultivationSubTab" class="cultivation-tab-content active">
+        <div id="cultivationSubTab" class="cultivation-tab-content tab-content active">
           <div class="cultivation-layout">
             <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
@@ -261,7 +261,7 @@
           </div>
         </div>
 
-        <div id="statsSubTab" class="cultivation-tab-content" style="display:none;">
+        <div id="statsSubTab" class="cultivation-tab-content tab-content" style="display:none;">
           <div class="cards">
             <div class="card">
               <h4>Breakthrough Details</h4>
@@ -294,7 +294,7 @@
 
       <section id="activity-physique" class="activity-content" style="display:none;">
         <h2> Physique Training</h2>
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Training Status</h4>
             <div class="stat"><span>Physique Level</span><span id="physiqueLevelActivity">1</span></div>
@@ -532,7 +532,7 @@
             </div>
             
             <!-- Progress Tab -->
-            <div id="progressTab" class="adventure-tab-content active">
+            <div id="progressTab" class="adventure-tab-content tab-content active">
               <div class="stat"><span>Total Kills</span><span id="totalKills">0</span></div>
               <div class="stat"><span>Areas Completed</span><span id="areasCompleted">0</span></div>
               <div class="stat"><span>Zones Unlocked</span><span id="zonesUnlocked">1</span></div>
@@ -548,14 +548,14 @@
             </div>
             
             <!-- Bestiary Tab -->
-            <div id="bestiaryTab" class="adventure-tab-content" style="display: none;">
+            <div id="bestiaryTab" class="adventure-tab-content tab-content" style="display: none;">
               <div class="bestiary-list" id="bestiaryList">
                 <div class="muted">Defeat enemies to unlock their information...</div>
               </div>
             </div>
 
             <!-- Loot Tab -->
-            <div id="lootTab" class="adventure-tab-content" style="display: none;">
+            <div id="lootTab" class="adventure-tab-content tab-content" style="display: none;">
               <div class="muted warn">Items here are not safe. Retreat to claim; death forfeits them.</div>
               <div class="session-loot-list" id="sessionLootList"></div>
               <div class="loot-actions" style="text-align:right; margin-top:8px;">
@@ -565,7 +565,7 @@
             </div>
             
             <!-- Proficiencies Tab -->
-            <div id="proficienciesTab" class="adventure-tab-content" style="display: none;">
+            <div id="proficienciesTab" class="adventure-tab-content tab-content" style="display: none;">
               <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
               <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
               <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>
@@ -752,7 +752,7 @@
       </section>
 
       <section id="tab-laws">
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Cultivation Laws</h4>
             <p class="muted">Choose your cultivation path after reaching Foundation stage. Each law provides unique bonuses and unlocks powerful skill trees.</p>
@@ -772,7 +772,7 @@
       </section>
 
       <section id="tab-gathering">
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Disciples</h4>
             <p class="muted">Assign disciples to gather herbs, ore, and wood. Yields scale with upgrades.</p>
@@ -837,7 +837,7 @@
       </section>
 
       <section id="tab-combat">
-        <div class="cards">
+        <div class="cards tab-content">
           <div class="card">
             <h4>Combat Stats</h4>
             <div class="stat"><span>Your ATK</span><span id="atkVal2">5</span></div>

--- a/style.css
+++ b/style.css
@@ -4132,7 +4132,7 @@ tr:last-child td {
 .debug-overflow *{outline:1px dashed red;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;}
   html,body{overflow-x:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
@@ -4162,6 +4162,11 @@ tr:last-child td {
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}
+  .tabs,.cultivation-tabs,.adventure-tabs{position:sticky;top:var(--header-h);z-index:1000;background:var(--panel);}
+  .tab-content{box-sizing:border-box;min-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));max-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:var(--float-pad);}
+  .tab-content .cards{display:flex;flex-direction:column;gap:var(--gap);}
+  .tab-content .cards .card{width:100%;max-width:100%;}
+  .tab-content .cards .card:only-child{flex:1;}
 }
 @media (prefers-reduced-motion:reduce){
   #sidebar{transition:none;}

--- a/ui/index.js
+++ b/ui/index.js
@@ -536,12 +536,25 @@ function enableDebug() {
   check();
 }
 
+function updateTabHeights() {
+  const root = document.documentElement;
+  const header = qs('header');
+  if (header) root.style.setProperty('--header-h', `${header.offsetHeight}px`);
+  document.querySelectorAll('.tab-content').forEach(el => {
+    const prev = el.previousElementSibling;
+    const h = prev ? prev.offsetHeight : 0;
+    el.style.setProperty('--tabs-h', `${h}px`);
+  });
+}
+window.addEventListener("resize", updateTabHeights);
+
 
 
 // Init
 window.addEventListener('load', ()=>{
   initUI();
   setupMobileUI();
+  updateTabHeights();
   setupStatusToggle();
   enableDebug();
   initLawSystem();


### PR DESCRIPTION
## Summary
- make cultivation and adventure tabs sticky on mobile and constrain content to viewport
- introduce `tab-content` container and CSS vars to size and scroll tab panels
- compute header and tab heights at runtime to keep layout responsive

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: undocumented files, UI state violations, balance contract validation failed)


------
https://chatgpt.com/codex/tasks/task_e_68aa02cd6d4083269cf89fb2ab035d39