### PR TITLE
feat: add mind tabs and puzzles UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -837,7 +837,14 @@
       </section>
 
       <section id="activity-mind" class="activity-content" style="display:none;">
-        <div id="mindReadingTab"></div>
+        <div class="mind-tabs">
+          <button class="mind-tab-btn active" data-tab="mindMain">Main</button>
+          <button class="mind-tab-btn" data-tab="mindReading">Reading</button>
+          <button class="mind-tab-btn" data-tab="mindPuzzles">Puzzles</button>
+        </div>
+        <div id="mindMainTab" class="mind-tab-content active"></div>
+        <div id="mindReadingTab" class="mind-tab-content" style="display:none;"></div>
+        <div id="mindPuzzlesTab" class="mind-tab-content" style="display:none;"></div>
       </section>
 
       <section id="tab-combat">

--- a/src/features/mind/ui/mindMainTab.js
+++ b/src/features/mind/ui/mindMainTab.js
@@ -1,3 +1,128 @@
-export function mountMindMainTab() {
-  // placeholder UI
+// src/features/mind/ui/mindMainTab.js
+
+import { mindBreakdown } from '../selectors.js';
+import { craftTalisman } from '../mutators.js';
+import { listTalismans } from '../data/talismans.js';
+import { renderMindReadingTab } from './mindReadingTab.js';
+import { renderMindPuzzlesTab } from './mindPuzzlesTab.js';
+import { S, save } from '../../../shared/state.js';
+
+let lastXp = 0;
+let lastTime = Date.now();
+
+/**
+ * Render the Mind Main tab UI.
+ * @param {HTMLElement} rootEl container element
+ * @param {object} state game state
+ */
+export function renderMindMainTab(rootEl, state) {
+  if (!rootEl) return;
+  const breakdown = mindBreakdown(state);
+
+  const now = Date.now();
+  const dt = (now - lastTime) / 1000;
+  const gained = state.mind.xp - lastXp;
+  const perHour = dt > 0 ? (gained / dt) * 3600 : 0;
+  lastXp = state.mind.xp;
+  lastTime = now;
+
+  rootEl.innerHTML = '';
+
+  const card = document.createElement('div');
+  card.className = 'card';
+  card.innerHTML = `
+    <h3>Mind Overview</h3>
+    <div class="stat"><span>Level</span><span>${state.mind.level}</span></div>
+    <div class="stat"><span>Total XP</span><span>${breakdown.total.toFixed(1)}</span></div>
+    <div class="stat"><span>XP/hr</span><span>${perHour.toFixed(1)}</span></div>
+  `;
+
+  const table = document.createElement('table');
+  table.innerHTML = `
+    <thead><tr><th>Source</th><th>XP</th></tr></thead>
+    <tbody>
+      <tr><td>Proficiency</td><td>${(breakdown.sources.proficiency * breakdown.multiplier).toFixed(1)}</td></tr>
+      <tr><td>Reading</td><td>${(breakdown.sources.reading * breakdown.multiplier).toFixed(1)}</td></tr>
+      <tr><td>Crafting</td><td>${(breakdown.sources.crafting * breakdown.multiplier).toFixed(1)}</td></tr>
+      <tr><td>Multiplier</td><td>x${breakdown.multiplier.toFixed(2)}</td></tr>
+    </tbody>
+  `;
+  card.appendChild(table);
+  rootEl.appendChild(card);
+
+  // Temporary talisman craft tester
+  const craftCard = document.createElement('div');
+  craftCard.className = 'card';
+  craftCard.innerHTML = '<h4>Craft Test</h4>';
+
+  const select = document.createElement('select');
+  select.className = 'btn';
+  for (const t of listTalismans()) {
+    const opt = document.createElement('option');
+    opt.value = t.id;
+    opt.textContent = t.name;
+    select.appendChild(opt);
+  }
+
+  const craftBtn = document.createElement('button');
+  craftBtn.className = 'btn primary';
+  craftBtn.textContent = 'Craft';
+  const result = document.createElement('div');
+  result.className = 'muted';
+
+  craftBtn.addEventListener('click', () => {
+    const id = select.value;
+    const before = state.mind.xp;
+    if (craftTalisman(state, id)) {
+      const gainedXp = state.mind.xp - before;
+      result.textContent = `Gained ${gainedXp.toFixed(1)} xp`;
+      save?.();
+      renderMindMainTab(rootEl, state);
+    }
+  });
+
+  const row = document.createElement('div');
+  row.className = 'row';
+  row.appendChild(select);
+  row.appendChild(craftBtn);
+  craftCard.appendChild(row);
+  craftCard.appendChild(result);
+  rootEl.appendChild(craftCard);
 }
+
+let tabsInitialized = false;
+export function setupMindTabs() {
+  if (tabsInitialized) return;
+  const tabButtons = document.querySelectorAll('.mind-tab-btn');
+  tabButtons.forEach(btn => {
+    btn.onclick = () => {
+      const tab = btn.dataset.tab;
+      tabButtons.forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.mind-tab-content').forEach(el => {
+        el.classList.remove('active');
+        el.style.display = 'none';
+      });
+      btn.classList.add('active');
+      const content = document.getElementById(tab + 'Tab');
+      if (content) {
+        content.classList.add('active');
+        content.style.display = 'block';
+      }
+      switch (tab) {
+        case 'mindMain':
+          renderMindMainTab(content, S);
+          break;
+        case 'mindReading':
+          renderMindReadingTab(content, S);
+          break;
+        case 'mindPuzzles':
+          renderMindPuzzlesTab(content, S);
+          break;
+      }
+    };
+  });
+  tabsInitialized = true;
+}
+
+export default renderMindMainTab;
+

--- a/src/features/mind/ui/mindPuzzlesTab.js
+++ b/src/features/mind/ui/mindPuzzlesTab.js
@@ -1,3 +1,58 @@
-export function mountMindPuzzlesTab() {
-  // placeholder UI
+// src/features/mind/ui/mindPuzzlesTab.js
+
+import { solvePuzzle } from '../mutators.js';
+import { save } from '../../../shared/state.js';
+
+/**
+ * Render the Mind Puzzles tab UI.
+ * @param {HTMLElement} rootEl container element
+ * @param {object} S game state
+ */
+export function renderMindPuzzlesTab(rootEl, S) {
+  if (!rootEl) return;
+  rootEl.innerHTML = '';
+
+  const multCard = document.createElement('div');
+  multCard.className = 'card';
+  multCard.innerHTML = `
+    <h3>Puzzles</h3>
+    <div class="stat"><span>Permanent Multiplier</span><span id="mindPuzzleMult">x${S.mind.multiplier.toFixed(2)}</span></div>
+    <div class="stat"><span>Solved</span><span id="mindPuzzleSolved">${S.mind.solvedPuzzles}</span></div>
+  `;
+  rootEl.appendChild(multCard);
+
+  const nextCard = document.createElement('div');
+  nextCard.className = 'card';
+  nextCard.innerHTML = '<h4>Next Puzzle</h4>';
+
+  const diffSelect = document.createElement('select');
+  diffSelect.className = 'btn';
+  for (let i = 0; i < 5; i += 1) {
+    const opt = document.createElement('option');
+    opt.value = String(i);
+    opt.textContent = `Difficulty ${i + 1}`;
+    diffSelect.appendChild(opt);
+  }
+
+  const solveBtn = document.createElement('button');
+  solveBtn.className = 'btn primary';
+  solveBtn.textContent = 'Solve';
+
+  solveBtn.addEventListener('click', () => {
+    const idx = parseInt(diffSelect.value, 10) || 0;
+    solvePuzzle(S, idx);
+    save?.();
+    renderMindPuzzlesTab(rootEl, S);
+  });
+
+  const row = document.createElement('div');
+  row.className = 'row';
+  row.appendChild(diffSelect);
+  row.appendChild(solveBtn);
+
+  nextCard.appendChild(row);
+  rootEl.appendChild(nextCard);
 }
+
+export default renderMindPuzzlesTab;
+

--- a/style.css
+++ b/style.css
@@ -1965,6 +1965,50 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   box-shadow: none;
 }
 
+/* Mind Activity Tabs */
+.mind-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #3b82f6;
+}
+
+.mind-tab-btn {
+  padding: 10px 16px;
+  border: none;
+  border-bottom: 2px solid #3b82f6;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-radius: 0;
+  font-family: 'Trajan Pro', 'Palatino Linotype', 'Book Antiqua', Palatino, serif;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+}
+
+.mind-tab-btn:hover {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--ink);
+  border-bottom-color: #2563eb;
+}
+
+.mind-tab-btn.active {
+  background: transparent;
+  color: var(--ink);
+  border-bottom: 2px solid #2563eb;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.mind-tab-content {
+  display: none;
+}
+
+.mind-tab-content.active {
+  display: block;
+}
+
 .cultivation-tab-content {
   display: none;
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -54,7 +54,9 @@ import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
 import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
 import { ensureMindState } from '../src/features/mind/index.js';
+import { renderMindMainTab, setupMindTabs } from '../src/features/mind/ui/mindMainTab.js';
 import { renderMindReadingTab } from '../src/features/mind/ui/mindReadingTab.js';
+import { renderMindPuzzlesTab } from '../src/features/mind/ui/mindPuzzlesTab.js';
 import { updateQiAndFoundation } from '../src/features/progression/ui/qiDisplay.js';
 import { updateCombatStats } from '../src/features/combat/ui/combatStats.js';
 import { updateAdventureProgress, mountAdventureControls } from '../src/features/adventure/ui/adventureDisplay.js';
@@ -229,7 +231,9 @@ function updateAll(){
   updateKarmaDisplay();
   updateLawsUI();
   updateActivityCards();
+  renderMindMainTab(document.getElementById('mindMainTab'), S);
   renderMindReadingTab(document.getElementById('mindReadingTab'), S);
+  renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
 
   emit('RENDER');
 }
@@ -250,9 +254,17 @@ function updateActivityContent() {
     case 'cooking':
       updateActivityCooking();
       break;
-    case 'mind':
-      renderMindReadingTab(document.getElementById('mindReadingTab'), S);
+    case 'mind': {
+      const active = document.querySelector('.mind-tab-btn.active')?.dataset.tab;
+      if (active === 'mindMain') {
+        renderMindMainTab(document.getElementById('mindMainTab'), S);
+      } else if (active === 'mindPuzzles') {
+        renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
+      } else {
+        renderMindReadingTab(document.getElementById('mindReadingTab'), S);
+      }
       break;
+    }
   }
 }
 globalThis.updateActivityContent = updateActivityContent;
@@ -558,11 +570,14 @@ window.addEventListener('load', ()=>{
   mountActivityUI(S);
   mountAdventureControls(S);
   setupAdventureTabs();
+  setupMindTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI
   mountAlchemyUI(S);
   mountKarmaUI(S);
   mountSectUI(S);
+  renderMindMainTab(document.getElementById('mindMainTab'), S);
   renderMindReadingTab(document.getElementById('mindReadingTab'), S);
+  renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
   selectActivity('cultivation'); // Start with cultivation selected
   updateAll();
   tick();


### PR DESCRIPTION
## Summary
- implement Mind Main and Puzzles tabs with blue styling
- show puzzle multiplier and difficulty solver
- display Mind XP breakdown and add talisman craft tester

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance` *(fails: Missing contract for feature: mind)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0dc981708326a5d9fe2332dfced7