### PR TITLE
Add manual reading timers

### DIFF
--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -24,6 +24,8 @@ export function startReading(S, manualId) {
   S.mind.activeManualId = manualId;
   if (!S.mind.manualProgress[manualId]) {
     S.mind.manualProgress[manualId] = { xp: 0, done: false };
+  } else {
+    S.mind.manualProgress[manualId].done = false;
   }
   return true;
 }
@@ -55,13 +57,16 @@ export function onTick(S, dt) {
   if (!id) return;
   const manual = getManual(id);
   if (!manual) return;
+  const rec = S.mind.manualProgress[id];
+  if (!rec || rec.done) return;
   const add = calcFromManual(manual, dt);
   const applied = applyPuzzleMultiplier(add, S.mind.multiplier);
   S.mind.fromReading += add;
   S.mind.xp += applied;
-  const rec = S.mind.manualProgress[id];
   rec.xp += add;
-  if (rec.xp >= manual.reqLevel * 100) {
+  const maxXp = (manual.maxLevel || 1) * 100;
+  if (rec.xp >= maxXp) {
+    rec.xp = maxXp;
     rec.done = true;
   }
   S.mind.level = levelForXp(S.mind.xp);

--- a/src/features/mind/ui/mindReadingTab.js
+++ b/src/features/mind/ui/mindReadingTab.js
@@ -2,6 +2,7 @@
 
 import { listManuals, getManual } from '../data/manuals.js';
 import { startReading, stopReading } from '../mutators.js';
+import { formatDuration } from '../../../shared/utils/time.js';
 
 /**
  * Render the Mind Reading tab UI.
@@ -17,16 +18,25 @@ export function renderMindReadingTab(rootEl, S) {
     const manual = getManual(activeId);
     if (manual) {
       const rec = S.mind.manualProgress[activeId] || { xp: 0 };
-      const max = manual.reqLevel * 100;
-      const ratio = Math.min(rec.xp / max, 1);
+      const maxXp = (manual.maxLevel || 1) * 100;
+      const ratio = Math.min(rec.xp / maxXp, 1);
+      const level = Math.floor(rec.xp / 100);
+      const nextLevelXp = Math.min((level + 1) * 100, maxXp);
+      const xpToNext = nextLevelXp - rec.xp;
+      const xpToMax = maxXp - rec.xp;
+      const timeToNext = manual.xpRate > 0 ? xpToNext / manual.xpRate : Infinity;
+      const timeToMax = manual.xpRate > 0 ? xpToMax / manual.xpRate : Infinity;
       const card = document.createElement('div');
       card.className = 'card';
       card.innerHTML = `
         <h3>Reading: ${manual.name}</h3>
+        <div>Level: ${Math.min(level, manual.maxLevel)} / ${manual.maxLevel}</div>
         <div class="progress-bar">
           <div class="progress-fill" style="width:${(ratio * 100).toFixed(1)}%"></div>
-          <div class="progress-text">${rec.xp.toFixed(0)} / ${max}</div>
+          <div class="progress-text">${rec.xp.toFixed(0)} / ${maxXp}</div>
         </div>
+        <div>Time to next level: ${xpToNext > 0 ? formatDuration(timeToNext) : 'Done'}</div>
+        <div>Time to max level: ${xpToMax > 0 ? formatDuration(timeToMax) : 'Done'}</div>
       `;
       const stopBtn = document.createElement('button');
       stopBtn.className = 'btn small';

--- a/src/shared/utils/time.js
+++ b/src/shared/utils/time.js
@@ -1,0 +1,12 @@
+export function formatDuration(seconds) {
+  seconds = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(seconds / 3600);
+  seconds -= h * 3600;
+  const m = Math.floor(seconds / 60);
+  const s = seconds - m * 60;
+  let out = '';
+  if (h > 0) out += h + 'h ';
+  if (m > 0 || h > 0) out += m + 'm ';
+  out += s + 's';
+  return out.trim();
+}


### PR DESCRIPTION
## Summary
- Reset manual progress when starting reading so XP accrues
- Stop XP gain after manual reaches its max level
- Display current manual level and time remaining to next and max level
- Provide a shared `formatDuration` helper

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance` *(fails: Missing contract for feature: mind)*
- `npm run validate` *(fails: Missing contract for feature: mind)*

------
https://chatgpt.com/codex/tasks/task_e_68aa20f74080832683ef0a7a1a1eab80