### PR TITLE
Add mind XP progress display

### DIFF
--- a/src/features/mind/index.js
+++ b/src/features/mind/index.js
@@ -8,6 +8,7 @@ export {
   calcFromCraft,
   applyPuzzleMultiplier,
   levelForXp,
+  xpProgress,
 } from './logic.js';
 
 export {

--- a/src/features/mind/logic.js
+++ b/src/features/mind/logic.js
@@ -31,3 +31,12 @@ export function levelForXp(xp) {
   return lvl;
 }
 
+export function xpProgress(xp) {
+  let need = 50;
+  while (xp >= need) {
+    xp -= need;
+    need = Math.ceil(need * 1.35);
+  }
+  return { current: xp, next: need };
+}
+

--- a/src/ui/sidebar.js
+++ b/src/ui/sidebar.js
@@ -60,6 +60,8 @@ export function renderSidebarActivities() {
       group: 'management',
       levelId: 'mindLevel',
       initialLevel: 'Level 1',
+      progressFillId: 'mindProgressFill',
+      progressTextId: 'mindProgressText',
       cost: {},
     },
     {

--- a/ui/index.js
+++ b/ui/index.js
@@ -53,7 +53,7 @@ import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
 import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
-import { ensureMindState } from '../src/features/mind/index.js';
+import { ensureMindState, xpProgress as mindXpProgress } from '../src/features/mind/index.js';
 import { renderMindMainTab, setupMindTabs } from '../src/features/mind/ui/mindMainTab.js';
 import { renderMindReadingTab } from '../src/features/mind/ui/mindReadingTab.js';
 import { renderMindPuzzlesTab } from '../src/features/mind/ui/mindPuzzlesTab.js';
@@ -215,6 +215,9 @@ function updateAll(){
   setFill('physiqueProgressFill', S.physique.exp / S.physique.expMax);
   setText('physiqueProgressText', `${fmt(S.physique.exp)} / ${fmt(S.physique.expMax)} XP`);
   setText('physiqueLevel', `Level ${S.physique.level}`);
+  const mindProg = mindXpProgress(S.mind.xp);
+  setFill('mindProgressFill', mindProg.current / mindProg.next);
+  setText('mindProgressText', `${fmt(mindProg.current)} / ${fmt(mindProg.next)} XP`);
   setText('mindLevel', `Level ${S.mind.level}`);
 
   updateCookingSidebar();


### PR DESCRIPTION
## Summary
- show Mind XP progress like Physique, including sidebar progress bar and text
- export `xpProgress` helper for Mind XP calculations
- update UI refresh to reflect current Mind XP and level

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: Missing contract for feature: mind)*
- `npm run lint:balance` *(fails: Missing contract for feature: mind)*

------
https://chatgpt.com/codex/tasks/task_e_68aa645c564083268ccd042e53e940f2