### PR TITLE
Enable manual reading XP accrual with level timing

### DIFF
--- a/src/features/mind/state.js
+++ b/src/features/mind/state.js
@@ -9,7 +9,7 @@ export const defaultMindState = {
   fromCrafting: 0,
   activeManualId: null,
   manualProgress: {},
-  // { manualId: { xp: number, done: boolean } }
+  // { manualId: { xp: number, level: number, done: boolean } }
   solvedPuzzles: 0,
 };
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -53,7 +53,7 @@ import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
 import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
-import { ensureMindState } from '../src/features/mind/index.js';
+import { ensureMindState, onTick as mindOnTick } from '../src/features/mind/index.js';
 import { renderMindMainTab, setupMindTabs } from '../src/features/mind/ui/mindMainTab.js';
 import { renderMindReadingTab } from '../src/features/mind/ui/mindReadingTab.js';
 import { renderMindPuzzlesTab } from '../src/features/mind/ui/mindPuzzlesTab.js';
@@ -427,7 +427,10 @@ function tick(){
   
   // Passive mining progression
   advanceMining(S);
-  
+
+  // Manual reading progression
+  mindOnTick(S, 1);
+
   // Physique training progression
   const sessionEnd = tickPhysiqueTraining(S);
   if(sessionEnd){


### PR DESCRIPTION
## Summary
- Track manual reading progress with levels and XP so starting a manual accrues progress
- Display time remaining to next and max manual levels in the Mind Reading tab
- Disable starting manuals that have reached max level
- Re-render Mind Reading tab on each frame so progress bar fills in real time
- Tick manual reading progression each second so manuals actually grant XP

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance` (fails: Missing contract for feature: mind)
- `npm run validate` (fails: Balance validation failed and undocumented files)


------
https://chatgpt.com/codex/tasks/task_e_68aa6431fa3083268184115599d88b76