### PR TITLE
feat: implement mobile bottom log sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -861,7 +861,10 @@
       </section>
 
 
-      <div class="log" id="log"></div>
+      <div class="log-sheet" id="logSheet" data-open="false">
+        <button class="log-toggle" id="logToggle" aria-controls="log" aria-expanded="false">Log ▾</button>
+        <div class="log" id="log"></div>
+      </div>
     </section>
     <div class="modal-overlay" id="cultivationProgressionOverlay" style="display: none;">
       <div class="modal-backdrop"></div>

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@
   --gap: 20px;
   --pad: 16px;
   --header-h: 76px;
+  --bottom-log-h: 0px;
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
   --mortal-primary: #a66c4c; /* lighter saddle brown */
@@ -4173,10 +4174,11 @@ tr:last-child td {
 .hamburger{display:none;background:none;border:none;font-size:1.5rem;line-height:1;padding:4px;cursor:pointer;}
 .drawer-scrim{position:fixed;inset:0;background:rgba(0,0,0,0.4);opacity:0;pointer-events:none;transition:opacity .3s;z-index:1000;}
 .drawer-scrim.active{opacity:1;pointer-events:auto;}
-.debug-overflow *{outline:1px dashed red;}
+.layout-debug *{outline:1px dashed red;}
+.log-toggle{display:none;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:0px;}
   html,body{overflow-x:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
@@ -4204,19 +4206,27 @@ tr:last-child td {
   .content{padding:var(--pad);}
   .activity-content{padding:var(--pad);}
   .tab-bar{position:sticky;top:var(--header-h);z-index:900;background:var(--panel);margin-bottom:0;}
-  .tab-content{padding-top:var(--gap);display:flex;flex-direction:column;gap:var(--gap);min-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));max-height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--safe-bottom));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:var(--float-pad);}
+  .tab-content{padding-top:var(--gap);display:flex;flex-direction:column;gap:var(--gap);height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:var(--float-pad);}
   .tab-content>.card{width:100%;max-width:100%;}
   .tab-content>.card:only-child{flex:1 0 auto;}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}
+
+  .log-toggle{display:flex;align-items:center;justify-content:center;width:100%;height:48px;background:none;border:none;font-family:inherit;font-size:1rem;}
+  .log-sheet{position:fixed;left:0;right:0;bottom:0;background:var(--panel);box-shadow:0 -2px 10px rgba(58,45,28,0.1);display:flex;flex-direction:column;transform:translateY(calc(100% - 48px));max-height:60dvh;transition:transform .3s;padding-bottom:env(safe-area-inset-bottom,0px);z-index:1000;}
+  .log-sheet[data-open="true"]{transform:translateY(0);}
+  .log-sheet[data-open="false"] .log{display:none;}
+  .log{position:relative;left:auto;right:auto;bottom:auto;height:auto;flex:1;overflow-y:auto;}
 }
 @media (prefers-reduced-motion:reduce){
   #sidebar{transition:none;}
   .drawer-scrim{transition:none;}
+  .log-sheet{transition:none;}
 }
 html.reduce-motion #sidebar{transition:none;}
 html.reduce-motion .drawer-scrim{transition:none;}
+html.reduce-motion .log-sheet{transition:none;}
 
 /* Floating combat text */
 .fct{

--- a/ui/index.js
+++ b/ui/index.js
@@ -549,13 +549,58 @@ function setupStatusToggle() {
   });
 }
 
-function enableDebug() {
+function setupLogSheet() {
+  const sheet = qs('#logSheet');
+  const toggle = qs('#logToggle');
+  if (!sheet || !toggle) return;
+  const mq = window.matchMedia('(max-width: 768px)');
+  function setHeight() {
+    if (!mq.matches) {
+      document.documentElement.style.setProperty('--bottom-log-h', '0px');
+      return;
+    }
+    const h = sheet.getAttribute('data-open') === 'true'
+      ? sheet.getBoundingClientRect().height
+      : toggle.getBoundingClientRect().height;
+    document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
+  }
+  function close() {
+    sheet.setAttribute('data-open', 'false');
+    toggle.setAttribute('aria-expanded', 'false');
+    sheet.removeAttribute('role');
+    sheet.removeAttribute('aria-modal');
+    toggle.textContent = 'Log \u25BE';
+    toggle.focus();
+    setHeight();
+    window.removeEventListener('keydown', esc);
+  }
+  function open() {
+    sheet.setAttribute('data-open', 'true');
+    toggle.setAttribute('aria-expanded', 'true');
+    sheet.setAttribute('role', 'dialog');
+    sheet.setAttribute('aria-modal', 'true');
+    toggle.textContent = 'Log \u25B4';
+    setHeight();
+    window.addEventListener('keydown', esc);
+  }
+  function esc(e) { if (e.key === 'Escape') close(); }
+  toggle.addEventListener('click', () => {
+    sheet.getAttribute('data-open') === 'true' ? close() : open();
+  });
+  window.addEventListener('resize', setHeight);
+  mq.addEventListener('change', setHeight);
+  setHeight();
+}
+
+function enableLayoutDebug() {
   if (!window.DEBUG) return;
-  document.documentElement.classList.add('debug-overflow');
+  document.documentElement.classList.add('layout-debug');
   const check = () => {
-    const w = document.documentElement.scrollWidth;
-    const vw = document.documentElement.clientWidth;
-    if (w > vw) console.warn('[layout] overflow', w - vw);
+    document.querySelectorAll('body *').forEach(el => {
+      if (el.scrollWidth > el.clientWidth + 1) {
+        console.warn('[layout]', el);
+      }
+    });
   };
   window.addEventListener('resize', check);
   check();
@@ -568,7 +613,8 @@ window.addEventListener('load', ()=>{
   initUI();
   setupMobileUI();
   setupStatusToggle();
-  enableDebug();
+  setupLogSheet();
+  enableLayoutDebug();
   initLawSystem();
   mountActivityUI(S);
   mountAdventureControls(S);


### PR DESCRIPTION
## Summary
- dock log/history as a mobile bottom sheet and track its height via `--bottom-log-h`
- adjust tab content to scroll within viewport and hide horizontal overflow
- add `layout-debug` mode to outline overflow issues

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: validation issues)

------
https://chatgpt.com/codex/tasks/task_e_68aa6a18cd24832680d14767f514a113