### PR TITLE
fix: allow character tab scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -2416,6 +2416,14 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 .card h4{margin:0 0 8px; font-size:15px}
 .muted{color:var(--muted); font-size:12px}
 
+/* Character tab cards */
+.character-cards{
+  display:flex;
+  flex-direction:column;
+  overflow-y:auto;
+  max-height:calc(100vh - 120px);
+}
+
 /* Adventure Layout - MAP-UI-UPDATE */
 .adventure-layout {
   display: flex;


### PR DESCRIPTION
## Summary
- allow character tab cards to scroll so inventory and equipment panels are accessible

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: requires docs update)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa683d16c83268159bf4db53e6b7a