### PR TITLE
Ensure tabs scroll vertically across screen sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
         </div>
       </section>
 
-      <section id="activity-physique" class="activity-content" style="display:none;">
+      <section id="activity-physique" class="activity-content tab-content" style="display:none;">
         <h2> Physique Training</h2>
         <div class="cards">
           <div class="card">
@@ -358,7 +358,7 @@
         </div>
       </section>
 
-      <section id="activity-mining" class="activity-content" style="display:none;">
+      <section id="activity-mining" class="activity-content tab-content" style="display:none;">
         <h2> Mining</h2>
         <div class="cards">
           <div class="card">
@@ -590,7 +590,7 @@
         </div>
       </section>
 
-      <section id="activity-character" class="activity-content" style="display:none;">
+      <section id="activity-character" class="activity-content tab-content" style="display:none;">
         <h2>🧙 Character</h2>
         <div class="cards character-cards">
           <div class="card">
@@ -637,7 +637,7 @@
         </div>
       </section>
 
-      <section id="activity-sect" class="activity-content" style="display:none;">
+      <section id="activity-sect" class="activity-content tab-content" style="display:none;">
         <h2>🏛️ Sect Management</h2>
         <div class="cards">
           <div class="card">
@@ -648,7 +648,7 @@
         </div>
       </section>
 
-      <section id="activity-cooking" class="activity-content" style="display:none;">
+      <section id="activity-cooking" class="activity-content tab-content" style="display:none;">
         <h2>🍳 Cooking</h2>
         <div class="cards">
           <div class="card">
@@ -809,7 +809,7 @@
         </div>
       </section>
 
-      <section id="activity-alchemy" class="activity-content" style="display:none;">
+      <section id="activity-alchemy" class="activity-content tab-content" style="display:none;">
         <h2>⚗️ Alchemy</h2>
         <div class="cards">
           <div class="card">
@@ -842,9 +842,9 @@
           <button class="mind-tab-btn" data-tab="mindReading">Reading</button>
           <button class="mind-tab-btn" data-tab="mindPuzzles">Puzzles</button>
         </div>
-        <div id="mindMainTab" class="mind-tab-content active"></div>
-        <div id="mindReadingTab" class="mind-tab-content" style="display:none;"></div>
-        <div id="mindPuzzlesTab" class="mind-tab-content" style="display:none;"></div>
+        <div id="mindMainTab" class="mind-tab-content tab-content active"></div>
+        <div id="mindReadingTab" class="mind-tab-content tab-content" style="display:none;"></div>
+        <div id="mindPuzzlesTab" class="mind-tab-content tab-content" style="display:none;"></div>
       </section>
 
       <section id="tab-combat">

--- a/style.css
+++ b/style.css
@@ -20,6 +20,9 @@
   --pad: 16px;
   --header-h: 76px;
   --bottom-log-h: 0px;
+  --tabs-h: 48px;
+  --safe-bottom: env(safe-area-inset-bottom,0px);
+  --float-pad: 0px;
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
   --mortal-primary: #a66c4c; /* lighter saddle brown */
@@ -38,6 +41,34 @@
   --bg-contrast: .98; /* 1 = none */
 }
 html,body{height:100%}
+
+.tab-bar{
+  position:sticky;
+  top:var(--header-h);
+  z-index:900;
+  background:var(--panel);
+  margin-bottom:0;
+}
+
+.tab-content{
+  padding-top:var(--gap);
+  display:flex;
+  flex-direction:column;
+  gap:var(--gap);
+  height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));
+  overflow-y:auto;
+  -webkit-overflow-scrolling:touch;
+  padding-bottom:var(--float-pad);
+}
+
+.tab-content>.card{
+  width:100%;
+  max-width:100%;
+}
+
+.tab-content>.card:only-child{
+  flex:1 0 auto;
+}
 
 /* --- Parchment-style custom scrollbar --- */
 html {
@@ -4205,10 +4236,6 @@ tr:last-child td {
   body.drawer-open{overflow:hidden;}
   .content{padding:var(--pad);}
   .activity-content{padding:var(--pad);}
-  .tab-bar{position:sticky;top:var(--header-h);z-index:900;background:var(--panel);margin-bottom:0;}
-  .tab-content{padding-top:var(--gap);display:flex;flex-direction:column;gap:var(--gap);height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:var(--float-pad);}
-  .tab-content>.card{width:100%;max-width:100%;}
-  .tab-content>.card:only-child{flex:1 0 auto;}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}


### PR DESCRIPTION
## Summary
- Add `tab-content` class to activity panels lacking scroll containers so character, mining, physique, sect, cooking, and alchemy tabs scroll vertically
- Apply `tab-content` class to mind sub-tabs to enable scrolling within the mind feature

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa812e5a88326a5a6b7091ed964eb