### PR TITLE
Add shield overlay and accessibility for HP bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,6 @@
 <body>
   <svg width="0" height="0" style="position:absolute">
     <defs>
-      <mask id="hpMask" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">
-        <rect x="0" y="0" width="100%" height="100%" fill="#fff" />
-      </mask>
       <mask id="playerHpMask" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">
         <rect x="0" y="0" width="100%" height="100%" fill="#fff" />
       </mask>
@@ -74,7 +71,24 @@
         <div class="chip" id="qiChip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
         <div class="chip" id="stonesChip">Stones: <span id="stonesVal">0</span></div>
         <div class="chip hp-chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span>
-          <div class="hp-bar"><div class="fill" id="hpFill"></div><div class="shield-fill" id="shieldFill"></div></div>
+          <div class="hp-bar">
+            <div class="fill" id="hpFill"></div>
+            <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
+              <defs>
+                <linearGradient id="shieldGradient">
+                  <stop offset="0%" stop-color="rgba(255,255,255,0)" />
+                  <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
+                  <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+                </linearGradient>
+              </defs>
+              <mask id="hpMask">
+                <rect id="hpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
+              </mask>
+              <rect id="shieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#hpMask)" />
+              <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#hpMask)" fill="url(#shieldGradient)" />
+            </svg>
+          </div>
+          <span id="hpA11y" class="sr-only">HP 100/100, Shield 0/0</span>
         </div>
         <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
       </div>

--- a/src/shared/utils/dom.js
+++ b/src/shared/utils/dom.js
@@ -10,7 +10,10 @@ export function setText(id, v) {
 export function setFill(id, ratio) {
   ratio = clamp(ratio, 0, 1);
   const el = document.getElementById(id);
-  if (el) el.style.width = (ratio * 100).toFixed(1) + '%';
+  if (!el) return;
+  const pct = (ratio * 100).toFixed(1) + '%';
+  if (el instanceof SVGElement) el.setAttribute('width', pct);
+  else el.style.width = pct;
 }
 
 export function log(msg, cls = '') {

--- a/style.css
+++ b/style.css
@@ -42,6 +42,18 @@
 }
 html,body{height:100%}
 
+.sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
+
 .tab-bar{
   position:sticky;
   top:var(--header-h);
@@ -1672,7 +1684,12 @@ h1{font-size:20px; margin:0; letter-spacing:.5px}
 .hp-chip{display:flex; flex-direction:column; align-items:flex-start;}
 .hp-chip .hp-bar{position:relative; width:100px; height:8px; background:rgba(239,68,68,0.3); border-radius:4px; margin-top:2px;}
 .hp-chip .hp-bar .fill{height:100%; background:linear-gradient(90deg,#ef4444,#f87171); border-radius:4px; transition:width 0.3s ease; width:0%;}
-.hp-chip .hp-bar .shield-fill{position:absolute; top:0; left:0; height:2px; background:cyan; border-radius:4px; width:0%; transition:width 0.3s ease;}
+.hp-chip .hp-bar .shield-overlay{position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none; transition:width 0.2s linear;}
+.hp-chip .hp-bar .shield-fill{fill:rgba(0,255,255,0.6); height:100%; transition:width 0.2s linear;}
+.hp-chip .hp-bar .shield-shimmer{fill:url(#shieldGradient); height:100%; transition:width 0.2s linear; animation:shield-shimmer 1.5s linear infinite; opacity:0.6;}
+@keyframes shield-shimmer{from{transform:translateX(-100%);}to{transform:translateX(100%);}}
+html.reduce-motion .shield-overlay,html.reduce-motion .shield-fill,html.reduce-motion .shield-shimmer{transition:none;}
+html.reduce-motion .shield-shimmer{animation:none;}
 
 main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -203,10 +203,19 @@ function updateAll(){
   updateQiAndFoundation();
 
   // HP
+  const hpFrac = S.hpMax ? S.hp / S.hpMax : 0;
+  const shieldMax = S.shield?.max || 0;
+  const shieldCur = S.shield?.current || 0;
+  const shieldFrac = shieldMax ? shieldCur / shieldMax : 0;
   setText('hpVal', fmt(S.hp)); setText('hpMax', fmt(S.hpMax));
   setText('hpValL', fmt(S.hp)); setText('hpMaxL', fmt(S.hpMax));
-  setFill('hpFill', S.hp / S.hpMax);
-  setFill('shieldFill', S.shield?.max ? S.shield.current / S.shield.max : 0);
+  setFill('hpFill', hpFrac);
+  setFill('hpMaskRect', hpFrac);
+  setFill('shieldFill', shieldFrac);
+  const overlay = qs('.shield-overlay');
+  if (overlay) overlay.style.display = shieldFrac > 0 ? '' : 'none';
+  const hpA11y = qs('#hpA11y');
+  if (hpA11y) hpA11y.textContent = `HP ${fmt(S.hp)}/${fmt(S.hpMax)}, Shield ${fmt(shieldCur)}/${fmt(shieldMax)}`;
   updateCombatStats();
   updateCurrentTaskDisplay(S);
 


### PR DESCRIPTION
## Summary
- add inline SVG mask to HP bar with shield fill and shimmer
- expose shield status to assistive tech and handle reduced motion
- support SVG widths in setFill utility

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UNDOCUMENTED FILE: src/features/mind/...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab217228388326bb76119b3887ec20