### PR TITLE
feat(mind): scale manual reading by stats

### DIFF
--- a/src/features/mind/index.js
+++ b/src/features/mind/index.js
@@ -4,6 +4,7 @@ export { defaultMindState, ensureMindState } from './state.js';
 
 export {
   calcFromProficiency,
+  calcManualSpeed,
   calcFromManual,
   calcFromCraft,
   applyPuzzleMultiplier,

--- a/src/features/mind/logic.js
+++ b/src/features/mind/logic.js
@@ -7,8 +7,23 @@ export function calcFromProficiency(profXp) {
   return Math.max(0, profXp) * 0.25;
 }
 
-export function calcFromManual(manual, dt) {
-  return manual ? manual.xpRate * dt : 0;
+export function calcManualSpeed(manual, stats) {
+  const weights = manual?.statWeights;
+  if (!weights || !stats) return 1;
+  let boost = 0;
+  for (const [stat, weight] of Object.entries(weights)) {
+    const val = (stats[stat] ?? 0) - 10;
+    if (val > 0) boost += val * weight;
+  }
+  const mult = 1 + boost / 10;
+  const cap = 1 + (manual?.maxSpeedBoostPct || 0) / 100;
+  return Math.min(mult, cap);
+}
+
+export function calcFromManual(manual, dt, stats) {
+  if (!manual) return 0;
+  const speed = calcManualSpeed(manual, stats);
+  return manual.xpRate * dt * speed;
 }
 
 export function calcFromCraft(talisman) {

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -55,7 +55,7 @@ export function onTick(S, dt) {
   if (!id) return;
   const manual = getManual(id);
   if (!manual) return;
-  const add = calcFromManual(manual, dt);
+  const add = calcFromManual(manual, dt, S.stats);
   const applied = applyPuzzleMultiplier(add, S.mind.multiplier);
   S.mind.fromReading += add;
   S.mind.xp += applied;


### PR DESCRIPTION
## Summary
- derive manual reading speed from manual stat weights and player stats
- apply this multiplier to manual XP gains via calcFromManual and onTick

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: docs require updates)*

------
https://chatgpt.com/codex/tasks/task_e_68ab284efce883269ab53911313ea5b8