### PR TITLE
Apply manual reading effects to player stats

### DIFF
--- a/src/features/mind/logic.js
+++ b/src/features/mind/logic.js
@@ -40,3 +40,27 @@ export function xpProgress(xp) {
   return { current: xp, next: need };
 }
 
+// Apply manual reward effects to the player once a manual level is
+// completed.  Supports percentage-based fields (e.g. `armorPct`) which
+// scale existing stats, and flat fields that directly add to the stat.
+export function applyManualEffects(player, manual, level) {
+  const effects = manual?.effects?.[level - 1];
+  if (!effects) return;
+
+  player.stats = player.stats || {};
+  for (const [key, val] of Object.entries(effects)) {
+    if (key.endsWith('Pct')) {
+      const stat = key.slice(0, -3);
+      if (stat in player.stats) {
+        player.stats[stat] = (player.stats[stat] || 0) * (1 + val / 100);
+      } else if (stat in player) {
+        player[stat] = (player[stat] || 0) * (1 + val / 100);
+      }
+    } else if (key in player.stats) {
+      player.stats[key] = (player.stats[key] || 0) + val;
+    } else {
+      player[key] = (player[key] || 0) + val;
+    }
+  }
+}
+

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -8,6 +8,7 @@ import {
   calcFromCraft,
   applyPuzzleMultiplier,
   levelForXp,
+  applyManualEffects,
 } from './logic.js';
 
 export function awardFromProficiency(S, profXp) {
@@ -61,8 +62,10 @@ export function onTick(S, dt) {
   S.mind.xp += applied;
   const rec = S.mind.manualProgress[id];
   rec.xp += add;
-  if (rec.xp >= manual.reqLevel * 100) {
+  const level = Math.floor(rec.xp / (manual.reqLevel * 100));
+  if (!rec.done && rec.xp >= manual.reqLevel * 100) {
     rec.done = true;
+    applyManualEffects(S, manual, level);
   }
   S.mind.level = levelForXp(S.mind.xp);
 }


### PR DESCRIPTION
## Summary
- apply manual reward effects with new `applyManualEffects`
- trigger manual effect application when manual reading is completed

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: verification failed: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2853f1248326b9e2576e25bf6f86