### PR TITLE
feat: add manual reading progression

### DIFF
--- a/src/features/mind/state.js
+++ b/src/features/mind/state.js
@@ -9,7 +9,7 @@ export const defaultMindState = {
   fromCrafting: 0,
   activeManualId: null,
   manualProgress: {},
-  // { manualId: { xp: number, done: boolean } }
+  // { manualId: { xp: number, level: number, done: boolean } }
   solvedPuzzles: 0,
 };
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -25,7 +25,7 @@ import {
 } from '../src/features/progression/index.js';
 import { qs, setText, setFill, log } from '../src/shared/utils/dom.js';
 import { fmt } from '../src/shared/utils/number.js';
-import { emit } from '../src/shared/events.js';
+import { emit, on } from '../src/shared/events.js';
 import { createProgressBar, updateProgressBar } from './components/progressBar.js';
 import { renderSidebarActivities } from '../src/ui/sidebar.js';
 import { initializeWeaponChip } from '../src/features/inventory/ui/weaponChip.js';
@@ -235,7 +235,6 @@ function updateAll(){
   updateLawsUI();
   updateActivityCards();
   renderMindMainTab(document.getElementById('mindMainTab'), S);
-  renderMindReadingTab(document.getElementById('mindReadingTab'), S);
   renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
 
   emit('RENDER');
@@ -625,8 +624,9 @@ window.addEventListener('load', ()=>{
   mountKarmaUI(S);
   mountSectUI(S);
   renderMindMainTab(document.getElementById('mindMainTab'), S);
-  renderMindReadingTab(document.getElementById('mindReadingTab'), S);
   renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
+  on('RENDER', () => renderMindReadingTab(document.getElementById('mindReadingTab'), S));
+  renderMindReadingTab(document.getElementById('mindReadingTab'), S);
   selectActivity('cultivation'); // Start with cultivation selected
   updateAll();
   tick();


### PR DESCRIPTION
## Summary
- dispatch `mind/manuals/startReading` on manual start
- implement per-manual XP and level tracking
- show time remaining and disable maxed manual start
- refresh Mind Reading tab on RENDER events

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: update docs/project-structure.md)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68ab29394e4483269d2f4c1cef241be5