### PR TITLE
feat: add manual reading progression

### DIFF
--- a/src/features/index.js
+++ b/src/features/index.js
@@ -9,6 +9,7 @@ import { mountCookingUI } from "./cooking/ui/cookingDisplay.js";
 import { mountLawDisplay } from "./progression/ui/lawDisplay.js";
 import { mountMiningUI } from "./mining/ui/miningDisplay.js";
 import { mountPhysiqueUI } from "./physique/ui/physiqueDisplay.js";
+import { mountMindReadingUI } from "./mind/ui/mindReadingTab.js";
 
 
 // Example placeholder for later:
@@ -23,6 +24,7 @@ export function mountAllFeatureUIs(state) {
   mountMiningUI(state);
   mountPhysiqueUI(state);
   mountLawDisplay(state);
+  mountMindReadingUI(state);
 
   // mountWeaponGenUI?.(state);
 }

--- a/src/features/mind/ui/mindReadingTab.js
+++ b/src/features/mind/ui/mindReadingTab.js
@@ -1,7 +1,9 @@
 // src/features/mind/ui/mindReadingTab.js
 
 import { listManuals, getManual } from '../data/manuals.js';
-import { startReading, stopReading } from '../mutators.js';
+import { stopReading } from '../mutators.js';
+import { calcManualSpeed } from '../logic.js';
+import { emit, on } from '../../../shared/events.js';
 
 // Mapping of manual effect keys to human readable labels
 const EFFECT_LABELS = {
@@ -27,6 +29,18 @@ function renderEffects(manual) {
   return `<ul class="manual-effects">${rows}</ul>`;
 }
 
+function formatTime(sec) {
+  if (!isFinite(sec) || sec === Infinity) return '∞';
+  const s = Math.max(0, Math.floor(sec));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const r = s % 60;
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, '0')}:${r.toString().padStart(2, '0')}`;
+  }
+  return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
 /**
  * Render the Mind Reading tab UI.
  * @param {HTMLElement} rootEl container element
@@ -40,16 +54,27 @@ export function renderMindReadingTab(rootEl, S) {
   if (activeId) {
     const manual = getManual(activeId);
     if (manual) {
-      const rec = S.mind.manualProgress[activeId] || { xp: 0 };
-      const max = manual.reqLevel * 100;
-      const ratio = Math.min(rec.xp / max, 1);
+      const rec = S.mind.manualProgress[activeId] || { xp: 0, level: 0 };
+      const speed = calcManualSpeed(manual, S.stats);
+      const xpRate = manual.xpRate * speed;
+      const needed = manual.baseTimeSec * manual.levelTimeMult[rec.level] * manual.xpRate;
+      const ratio = Math.min(rec.xp / needed, 1);
+      const timeToNext = (needed - rec.xp) / xpRate;
+      let timeToMax = timeToNext;
+      for (let lvl = rec.level + 1; lvl < manual.maxLevel; lvl++) {
+        timeToMax += manual.baseTimeSec * manual.levelTimeMult[lvl] / speed;
+      }
       const card = document.createElement('div');
       card.className = 'card';
       card.innerHTML = `
-        <h3><iconify-icon icon="iconoir:page-flip"></iconify-icon> Reading: ${manual.name}</h3>
+        <h3><iconify-icon icon="iconoir:page-flip"></iconify-icon> Reading: ${manual.name} (Lv ${rec.level}/${manual.maxLevel})</h3>
         <div class="progress-bar">
           <div class="progress-fill" style="width:${(ratio * 100).toFixed(1)}%"></div>
-          <div class="progress-text">${rec.xp.toFixed(0)} / ${max}</div>
+          <div class="progress-text">${rec.xp.toFixed(1)} / ${needed.toFixed(1)}</div>
+        </div>
+        <div class="timers">
+          <div>Next Level: ${formatTime(timeToNext)}</div>
+          <div>Max Level: ${formatTime(timeToMax)}</div>
         </div>
         ${renderEffects(manual)}
       `;
@@ -79,15 +104,26 @@ export function renderMindReadingTab(rootEl, S) {
     const btn = document.createElement('button');
     btn.className = 'btn small';
     btn.textContent = 'Start';
-    btn.disabled = S.mind.level < m.reqLevel;
+    const progress = S.mind.manualProgress[m.id];
+    const maxed = progress?.level >= m.maxLevel;
+    btn.disabled = S.mind.level < m.reqLevel || maxed;
     btn.addEventListener('click', () => {
-      startReading(S, m.id);
+      emit('mind/manuals/startReading', { root: S, manualId: m.id });
       renderMindReadingTab(rootEl, S);
     });
     item.appendChild(btn);
     list.appendChild(item);
   }
   rootEl.appendChild(list);
+}
+
+export function mountMindReadingUI(state) {
+  on('RENDER', () => {
+    const el = document.getElementById('mindReadingTab');
+    if (el?.classList.contains('active')) {
+      renderMindReadingTab(el, state);
+    }
+  });
 }
 
 export default renderMindReadingTab;

--- a/ui/index.js
+++ b/ui/index.js
@@ -55,7 +55,7 @@ import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
 import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
 import { ensureMindState, xpProgress as mindXpProgress } from '../src/features/mind/index.js';
 import { renderMindMainTab, setupMindTabs } from '../src/features/mind/ui/mindMainTab.js';
-import { renderMindReadingTab } from '../src/features/mind/ui/mindReadingTab.js';
+import { renderMindReadingTab, mountMindReadingUI } from '../src/features/mind/ui/mindReadingTab.js';
 import { renderMindPuzzlesTab } from '../src/features/mind/ui/mindPuzzlesTab.js';
 import { updateQiAndFoundation } from '../src/features/progression/ui/qiDisplay.js';
 import { updateCombatStats } from '../src/features/combat/ui/combatStats.js';
@@ -624,6 +624,7 @@ window.addEventListener('load', ()=>{
   mountAlchemyUI(S);
   mountKarmaUI(S);
   mountSectUI(S);
+  mountMindReadingUI(S);
   renderMindMainTab(document.getElementById('mindMainTab'), S);
   renderMindReadingTab(document.getElementById('mindReadingTab'), S);
   renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);


### PR DESCRIPTION
## Summary
- dispatch action when starting a manual
- accrue manual XP over time and apply level effects
- show manual timers and subscribe reading tab to render loop

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: requires updating docs)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2b3b003483268e5c31333ce421be