### PR TITLE
Consolidate stackable loot drops

### DIFF
--- a/src/features/loot/mutators.js
+++ b/src/features/loot/mutators.js
@@ -1,11 +1,27 @@
 import { S, save } from '../../shared/state.js';
 import { addToInventory } from '../inventory/mutators.js';
 
+// Item types that should be consolidated in the session loot list
+const STACKABLE_TYPES = new Set(['mat']);
+
 // EQUIP-CHAR-UI: session loot helpers
 export function addSessionLoot(item, state = S) {
   state.sessionLoot = state.sessionLoot || [];
-  const id = item.id || Date.now() + Math.random();
-  state.sessionLoot.push({ ...item, id, qty: item.qty || 1 });
+  const qty = item.qty || 1;
+
+  if (STACKABLE_TYPES.has(item.type)) {
+    const existing = state.sessionLoot.find(i => i.key === item.key);
+    if (existing) {
+      existing.qty += qty;
+    } else {
+      const id = item.id || Date.now() + Math.random();
+      state.sessionLoot.push({ ...item, id, qty });
+    }
+  } else {
+    const id = item.id || Date.now() + Math.random();
+    state.sessionLoot.push({ ...item, id, qty });
+  }
+
   console.log('[loot-session] add', item);
   save?.();
 }

--- a/src/features/loot/ui/lootTab.js
+++ b/src/features/loot/ui/lootTab.js
@@ -9,8 +9,7 @@ export function updateLootTab(state = S) {
   getSessionLoot(state).forEach(item => {
     const row = document.createElement('div');
     row.className = 'loot-row';
-    const src = item.source ? ` (${item.source})` : '';
-    row.textContent = `${item.qty || 1} ${item.key}${src}`;
+    row.textContent = `${item.qty || 1} ${item.key}`;
     list.appendChild(row);
   });
 }


### PR DESCRIPTION
## Summary
- aggregate material drops by item type so stackables show a single entry
- remove source display from loot tab rows

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ab2c2e97cc832699748c1b8f132908