### PR TITLE
Calibrate hit chance around baseline accuracy and dodge

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -10,7 +10,7 @@ import { rollGearDropForZone } from '../gearGeneration/selectors.js';
 import { addToInventory } from '../inventory/mutators.js';
 import { ABILITIES } from '../ability/data/abilities.js';
 import { performAttack, decayStunBar } from '../combat/attack.js'; // STATUS-REFORM
-import { chanceToHit } from '../combat/hit.js';
+import { chanceToHit, DODGE_BASE } from '../combat/hit.js';
 import { tryCastAbility, processAbilityQueue } from '../ability/mutators.js';
 import { ENEMY_DATA } from './data/enemies.js';
 import { setText, setFill, log } from '../../shared/utils/dom.js';
@@ -311,7 +311,7 @@ export function updateAdventureCombat() {
     }
     if (now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
       S.adventure.lastPlayerAttack = now;
-      const enemyDodge = S.adventure.currentEnemy?.stats?.dodge ?? S.adventure.currentEnemy?.dodge ?? 0;
+      const enemyDodge = (S.adventure.currentEnemy?.stats?.dodge ?? S.adventure.currentEnemy?.dodge ?? 0) + DODGE_BASE;
       const hitP = chanceToHit(S.stats?.accuracy || 0, enemyDodge);
       if (Math.random() < hitP) {
         const critChance = S.stats?.criticalChance || 0;
@@ -1013,7 +1013,7 @@ export function updateActivityAdventure() {
   setText('baseDamage', baseAttack);
   const enemyData = currentArea ? ENEMY_DATA[currentArea.enemy] : null;
   if (enemyData) {
-    const enemyDodge = enemyData.stats?.dodge ?? enemyData.dodge ?? 0;
+    const enemyDodge = (enemyData.stats?.dodge ?? enemyData.dodge ?? 0) + DODGE_BASE;
     const hitP = chanceToHit(S.stats?.accuracy || 0, enemyDodge);
     setText('hitChance', `${Math.round(hitP * 100)}%`);
     const enemyAcc = enemyData.stats?.accuracy ?? enemyData.accuracy ?? 0;

--- a/src/features/combat/hit.js
+++ b/src/features/combat/hit.js
@@ -2,10 +2,12 @@ export const HIT_FLOOR = 0.05;
 export const HIT_CEIL = 0.95;
 export const DODGE_SCALE = 0.64;
 export const HIT_ALPHA = 1.0;
+export const ACCURACY_BASE = 50;
+export const DODGE_BASE = 5;
 
-export function chanceToHit(accuracy = 0, dodge = 0) {
-  const a = Math.max(0, accuracy);
-  const d = Math.max(0, dodge) * DODGE_SCALE;
+export function chanceToHit(accuracy = ACCURACY_BASE, dodge = DODGE_BASE) {
+  const a = Math.max(0, accuracy - ACCURACY_BASE);
+  const d = Math.max(0, dodge - DODGE_BASE) * DODGE_SCALE;
   const raw = (a <= 0 && d <= 0) ? 0.5 : (a / (a + d));
   const shaped = Math.pow(raw, HIT_ALPHA);
   return HIT_FLOOR + (HIT_CEIL - HIT_FLOOR) * shaped;

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -1,6 +1,7 @@
 // Inventory feature logic helpers
 
 // Recalculate derived player stats based on equipped items
+import { ACCURACY_BASE, DODGE_BASE } from '../combat/hit.js';
 export function recomputePlayerTotals(player) {
   let armor = 0;
   let accuracy = 0;
@@ -21,8 +22,8 @@ export function recomputePlayerTotals(player) {
   }
   player.stats = player.stats || {};
   player.stats.armor = armor;
-  player.stats.accuracy = accuracy;
-  player.stats.dodge = dodge;
+  player.stats.accuracy = ACCURACY_BASE + accuracy;
+  player.stats.dodge = DODGE_BASE + dodge;
   player.shield = player.shield || { current: 0, max: 0 };
   const mind = player.stats.mind || 0;
   const shieldMult = 1 + mind * 0.06;

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -1,4 +1,5 @@
 import { progressionState } from './state.js';
+import { ACCURACY_BASE, DODGE_BASE } from '../combat/hit.js';
 import { REALMS } from './data/realms.js';
 import { LAWS } from './data/laws.js';
 import { log } from '../../shared/utils/dom.js';
@@ -33,7 +34,7 @@ export function advanceRealm(state = progressionState) {
     state.stats = state.stats || {
       physique: 10, mind: 10, dexterity: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0,
-      armor: 0, accuracy: 0, dodge: 0
+      armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE
     };
 
     state.cultivation.talent += 0.15;
@@ -62,7 +63,7 @@ export function advanceRealm(state = progressionState) {
     state.stats = state.stats || {
       physique: 10, mind: 10, dexterity: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0,
-      armor: 0, accuracy: 0, dodge: 0
+      armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE
     };
 
     state.cultivation.talent += 0.03;

--- a/src/features/progression/state.js
+++ b/src/features/progression/state.js
@@ -1,3 +1,4 @@
+import { ACCURACY_BASE, DODGE_BASE } from '../combat/hit.js';
 export const progressionState = {
   qi: 100,
   qiCapMult: 0,
@@ -38,7 +39,7 @@ export const progressionState = {
     cooldownReduction: 0,
     adventureSpeed: 1.0,
     armor: 0,
-    accuracy: 0,
-    dodge: 0,
+    accuracy: ACCURACY_BASE,
+    dodge: DODGE_BASE,
   },
 };

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -1,4 +1,5 @@
 import { initHp } from './utils/hp.js';
+import { ACCURACY_BASE, DODGE_BASE } from '../features/combat/hit.js';
 import { runMigrations, SAVE_VERSION } from '../game/migrations.js';
 import { sectState } from '../features/sect/state.js';
 import { recalculateBuildingBonuses } from '../features/sect/mutators.js';
@@ -45,8 +46,8 @@ export const defaultState = () => {
     cooldownReduction: 0, // Cooldown reduction percentage
     adventureSpeed: 1.0, // Adventure/exploration speed multiplier
     armor: 0,           // Total armor from gear and bonuses
-    accuracy: 0,        // Chance to hit with attacks
-    dodge: 0           // Chance to avoid attacks
+    accuracy: ACCURACY_BASE,        // Chance to hit with attacks
+    dodge: DODGE_BASE           // Chance to avoid attacks
   },
   disciples:1,
   gather:{herbs:0, ore:0, wood:0},


### PR DESCRIPTION
## Summary
- default player stats now start at 50 accuracy and 5 dodge
- chanceToHit interprets accuracy and dodge relative to these baselines
- gear totals and enemy dodge use the new baseline constants

## Testing
- ⚠️ `npm test` (no tests specified)
- ✅ `npm run lint:balance`
- ⚠️ `npm run validate` (documentation enforcement failures)


------
https://chatgpt.com/codex/tasks/task_e_68ab2cc577348326b114135c69b24618