### PR TITLE
feat(mind): add debug manual level-up helper

### DIFF
--- a/src/features/mind/index.js
+++ b/src/features/mind/index.js
@@ -16,6 +16,7 @@ export {
   awardFromProficiency,
   startReading,
   stopReading,
+  debugLevelManual,
   craftTalisman,
   solvePuzzle,
   onTick,

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -34,6 +34,23 @@ export function stopReading(S) {
   S.mind.activeManualId = null;
 }
 
+export function debugLevelManual(S) {
+  const id = S.mind.activeManualId;
+  if (!id) return false;
+  const manual = getManual(id);
+  if (!manual) return false;
+  const rec = S.mind.manualProgress[id] || { xp: 0, level: 0 };
+  if (rec.level >= manual.maxLevel) return false;
+  rec.level += 1;
+  rec.xp = 0;
+  applyManualEffects(S, manual, rec.level);
+  if (rec.level >= manual.maxLevel) {
+    stopReading(S);
+  }
+  S.mind.manualProgress[id] = rec;
+  return true;
+}
+
 export function craftTalisman(S, talismanId) {
   const t = getTalisman(talismanId);
   if (!t) return false;
@@ -83,5 +100,9 @@ export function onTick(S, dt) {
 
 on('mind/manuals/startReading', ({ root, manualId }) => {
   startReading(root, manualId);
+});
+
+on('mind/manuals/debugLevelUp', ({ root }) => {
+  debugLevelManual(root);
 });
 


### PR DESCRIPTION
## Summary
- add `debugLevelManual` to increment the active manual's level for quick testing
- expose `debugLevelManual` via export and new `mind/manuals/debugLevelUp` event

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: project structure documentation needs updating)


------
https://chatgpt.com/codex/tasks/task_e_68ab2f2d756c8326b346b7cb165278e1