### PR TITLE
fix: improve mobile card responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -4262,6 +4262,20 @@ tr:last-child td {
   .log-sheet[data-open="true"]{transform:translateY(0);}
   .log-sheet[data-open="false"] .log{display:none;}
   .log{position:relative;left:auto;right:auto;bottom:auto;height:auto;flex:1;overflow-y:auto;}
+
+  /* Ensure cards and contents fit small screens */
+  .cards{grid-template-columns:1fr;}
+  .cards .card{width:100%;box-sizing:border-box;}
+  .cards .card h4{font-size:1rem;}
+  .cards .btn{font-size:0.9rem;}
+  .cultivation-buttons{flex-direction:column;}
+  .cultivation-layout{flex-direction:column;align-items:stretch;}
+  .cultivation-visualization-container{height:auto;min-height:300px;}
+  .cultivation-controls-card{font-size:0.9rem;}
+  .adventure-cards{grid-template-columns:1fr;}
+  .combat-display{flex-direction:column;gap:12px;}
+  .combat-controls{flex-direction:column;}
+  .combat-controls .btn{width:100%;}
 }
 @media (prefers-reduced-motion:reduce){
   #sidebar{transition:none;}


### PR DESCRIPTION
## Summary
- Stack cultivation visualization and controls vertically on mobile
- Let cultivation card content scale down for small screens

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: undocumented mind files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2df625cc8326ba4283312aab33c9