### PR TITLE
fix: improve mobile card responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -4262,6 +4262,21 @@ tr:last-child td {
   .log-sheet[data-open="true"]{transform:translateY(0);}
   .log-sheet[data-open="false"] .log{display:none;}
   .log{position:relative;left:auto;right:auto;bottom:auto;height:auto;flex:1;overflow-y:auto;}
+
+  /* Ensure cards and contents fit small screens */
+  .cards{grid-template-columns:1fr;}
+  .cards .card{width:100%;box-sizing:border-box;}
+  .cards .card h4{font-size:1rem;}
+  .cards .btn{font-size:0.9rem;}
+  .cultivation-layout{gap:12px;}
+  .cultivation-visualization-container{height:300px;min-height:200px;}
+  .cultivation-controls-card{font-size:0.85rem;}
+  .cultivation-buttons{gap:6px;}
+  .cultivation-btn{font-size:0.85rem;padding:6px 8px;}
+  .adventure-cards{grid-template-columns:1fr;}
+  .combat-display{gap:10px;}
+  .combat-controls{gap:8px;}
+  .combat-controls .btn{flex:1;font-size:0.85rem;padding:6px 8px;min-width:0;}
 }
 @media (prefers-reduced-motion:reduce){
   #sidebar{transition:none;}


### PR DESCRIPTION
## Summary
- Stack cultivation visualization and controls vertically on mobile
- Let cultivation card content scale down for small screens
- Scale internal card elements so they shrink to fit narrow viewports without altering layout

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: undocumented mind files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2df625cc8326ba4283312aab33c9