### PR TITLE
Base adventure accuracy on current zone enemies

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -987,10 +987,11 @@ export function updateActivityAdventure() {
   if (!S.adventure.bestiary) {
     S.adventure.bestiary = {};
   }
-  const currentZone = ZONES[S.adventure.selectedZone || S.adventure.currentZone || 0];
+  // Base combat preview on the zone the player is currently exploring
+  const currentZone = ZONES[S.adventure.currentZone || 0];
   let currentArea = null;
   if (currentZone && currentZone.areas) {
-    currentArea = currentZone.areas[S.adventure.selectedArea || S.adventure.currentArea || 0];
+    currentArea = currentZone.areas[S.adventure.currentArea || 0];
     if (currentArea) {
       setText('currentLocationText', `${currentZone.name} - ${currentArea.name}`);
       setText('killsRequired', `${S.adventure.killsInCurrentArea}/${currentArea.killReq}`);


### PR DESCRIPTION
## Summary
- Derive hit and evade chance in adventure tab from enemies in the zone being explored

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: verification failed - UI state violations and undocumented file)
- `npm run lint:balance`

------
https://chatgpt.com/codex/tasks/task_e_68ab37606a208326bf5c278887e77ee2