### PR TITLE
Add stun status definitions and update project docs

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -77,6 +77,8 @@ way-of-ascension/
 │   └── validate-structure.js
 ├── src/
 │   ├── index.js
+│   ├── data/
+│   │   └── status.ts
 │   ├── features/
 │   │   ├── adventure/
 │   │   │   ├── data/
@@ -244,7 +246,8 @@ way-of-ascension/
 │   │   │   └── ui/
 │   │   │       ├── mindMainTab.js
 │   │   │       ├── mindPuzzlesTab.js
-│   │   │       └── mindReadingTab.js
+│   │   │       ├── mindReadingTab.js
+│   │   │       └── mindStatsTab.js
 │   │   ├── mining/
 │   │   │   ├── logic.js
 │   │   │   ├── migrations.js
@@ -892,6 +895,7 @@ Paths added:
 - `src/features/mind/ui/mindMainTab.js` – Renders summary view for the Mind feature.
 - `src/features/mind/ui/mindPuzzlesTab.js` – Displays puzzle progress and multiplier info.
 - `src/features/mind/ui/mindReadingTab.js` – Lists manuals and controls reading actions.
+- `src/features/mind/ui/mindStatsTab.js` – Shows cumulative manual bonuses.
 
 ### Mining Feature (`src/features/mining/`)
 - `src/features/mining/state.js` – Tracks mining level, experience, unlocked resources and yields.
@@ -938,6 +942,9 @@ Paths added:
 - `src/features/weaponGeneration/logic.js` – Generates weapons from base types and materials.
 - `src/features/weaponGeneration/mutators.js` – Writes generated weapons into state.
 - `src/features/weaponGeneration/selectors.js` – Helpers to roll and access generated weapons.
+
+### Core Data (`src/data/`)
+- `src/data/status.ts` – Global status effect definitions.
 
 ### Sect Feature (`src/features/sect/`)
 - `src/features/sect/index.js` – Registers sect hooks.

--- a/src/data/status.ts
+++ b/src/data/status.ts
@@ -1,0 +1,57 @@
+export const STATUSES = {
+  bruiseMinor: {
+    key: 'bruiseMinor',
+    displayName: 'Bruise',
+    durationMs: 3000,
+    stackCap: 5,
+    rules: { dmgTakenMult: 1.01 },
+    scalesWith: 'physique',
+  },
+  fractureMinor: {
+    key: 'fractureMinor',
+    displayName: 'Fracture',
+    durationMs: 4000,
+    stackCap: 3,
+    rules: { armorMult: 0.98 },
+    scalesWith: 'physique',
+  },
+  staggerMinor: {
+    key: 'staggerMinor',
+    displayName: 'Stagger',
+    durationMs: 1200,
+    stackCap: 3,
+    rules: { attackSpeedMult: 0.9, moveSpeedMult: 0.9 },
+    scalesWith: 'mind',
+  },
+  qiDisruptMinor: {
+    key: 'qiDisruptMinor',
+    displayName: 'Qi Disruption',
+    durationMs: 3000,
+    stackCap: 5,
+    rules: { regenWaterPerSecAdd: -0.2, maxQiMult: 0.99 },
+    scalesWith: 'mind',
+  },
+  stunned: {
+    key: 'stunned',
+    displayName: 'Stunned',
+    durationMs: 2000,
+    stackCap: 1,
+    rules: { attackSpeedMult: 0, moveSpeedMult: 0 },
+  },
+  stunWeakened: {
+    key: 'stunWeakened',
+    displayName: 'Stun Weakened',
+    durationMs: 5000,
+    stackCap: 1,
+    rules: {}, // effect handled externally
+  },
+  stunImmune: {
+    key: 'stunImmune',
+    displayName: 'Stun Immune',
+    durationMs: 15000,
+    stackCap: 1,
+    rules: {}, // effect handled externally
+  },
+};
+
+export const STATUS_REGISTRY = STATUSES;


### PR DESCRIPTION
## Summary
- define `stunned`, `stunWeakened`, and `stunImmune` statuses with durations, stack caps, and rule effects
- document new status data file and Mind stats tab in project structure docs

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations and DOM usage warnings)


------
https://chatgpt.com/codex/tasks/task_e_68ab3b8222c083268a12b254407d3445