### PR TITLE
feat: add balance tuning utilities

### DIFF
--- a/src/features/proficiency/data/_balance.contract.js
+++ b/src/features/proficiency/data/_balance.contract.js
@@ -1,9 +1,19 @@
-export default {
-  fields: {
-    level: { min: 0 }
-  },
-  monotonic: [
-    { field: 'level', direction: 'nondecreasing' },
-    { field: 'level', direction: 'nondecreasing' }
-  ]
-};
+import { getProficiency } from '../logic.js';
+
+export function validate() {
+  const errors = [];
+  const samples = [0, 10, 50, 100, 250, 500, 1000];
+
+  let last = -Infinity;
+  const state = { proficiency: {} };
+  for (const p of samples) {
+    state.proficiency.test = p;
+    const { bonus } = getProficiency('test', state);
+    if (!(bonus >= 0 && bonus <= 3)) {
+      errors.push(`proficiency bonus(${p})=${bonus} out of [0,3]`);
+    }
+    if (bonus < last) errors.push(`proficiency bonus not monotonic at ${p}`);
+    last = bonus;
+  }
+  return { ok: errors.length === 0, errors };
+}

--- a/src/features/proficiency/selectors.js
+++ b/src/features/proficiency/selectors.js
@@ -1,9 +1,12 @@
 import { proficiencyState } from './state.js';
 import { getProficiency as resolveProficiency } from './logic.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { getTunable } from '../../shared/tunables.js';
 
 export function getProficiency(key, state = proficiencyState) {
-  return resolveProficiency(key, state);
+  const res = resolveProficiency(key, state);
+  const xpMult = getTunable('proficiency.xpGainMult', 1);
+  return { ...res, xpMult };
 }
 
 export function getWeaponProficiencyBonuses(state = proficiencyState) {

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -6,6 +6,7 @@ import { getBuildingBonuses } from '../sect/selectors.js';
 import { karmaQiRegenBonus, karmaAtkBonus, karmaDefBonus } from '../karma/logic.js';
 import { getSuccessBonus as getAlchemySuccessBonus } from '../alchemy/selectors.js';
 import { getCookingSuccessBonus } from '../cooking/selectors.js';
+import { getTunable } from '../../shared/tunables.js';
 export const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
 export function getLawBonuses(state = progressionState){
   let bonuses = {
@@ -144,7 +145,8 @@ export function calculatePlayerCombatAttack(state = progressionState) {
   const baseAttack = 5;
   const realmBonus = REALMS[state.realm.tier].atk * state.realm.stage;
   const profBonus = getWeaponProficiencyBonuses(state).damage;
-  return baseAttack + profBonus + realmBonus;
+  const mult = getTunable('combat.damageMult', 1);
+  return (baseAttack + profBonus + realmBonus) * mult;
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {
@@ -152,7 +154,8 @@ export function calculatePlayerAttackRate(state = progressionState) {
   const dexterityBonus = (state.stats.dexterity - 10) * 0.05;
   const attackSpeedBonus = state.stats.attackSpeed || 0;
   const profBonus = getWeaponProficiencyBonuses(state).speed;
-  return baseRate + dexterityBonus + (attackSpeedBonus / 100) + profBonus;
+  const mult = getTunable('combat.attackRateMult', 1);
+  return (baseRate + dexterityBonus + (attackSpeedBonus / 100) + profBonus) * mult;
 }
 
 export function breakthroughChance(state = progressionState){

--- a/src/features/weaponGeneration/data/_balance.contract.js
+++ b/src/features/weaponGeneration/data/_balance.contract.js
@@ -1,9 +1,22 @@
-export default {
-  fields: {
-    tier: { min: 0 }
-  },
-  monotonic: [
-    { field: 'tier', direction: 'nondecreasing' },
-    { field: 'tier', direction: 'nondecreasing' }
-  ]
-};
+import { WEAPON_TYPES } from './weaponTypes.js';
+
+export function validate() {
+  const errors = [];
+
+  for (const [key, def] of Object.entries(WEAPON_TYPES)) {
+    // range checks
+    if (def.base.min <= 0 || def.base.max <= 0 || def.base.max < def.base.min) {
+      errors.push(`weaponTypes.${key}.base min/max invalid`);
+    }
+    if (def.base.rate <= 0 || def.base.rate > 20) {
+      errors.push(`weaponTypes.${key}.rate out of bounds (0,20]`);
+    }
+    // scaling weights sanity (0..1, ~<=1.2 total to allow hybrids)
+    const totalScale = (def.scales?.physique ?? 0) + (def.scales?.agility ?? 0) + (def.scales?.mind ?? 0);
+    if (totalScale < 0 || totalScale > 1.2) {
+      errors.push(`weaponTypes.${key}.scales total ${totalScale.toFixed(2)} out of [0,1.2]`);
+    }
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/src/shared/telemetry.js
+++ b/src/shared/telemetry.js
@@ -1,0 +1,31 @@
+// Minimal counters/timers to detect regressions during tuning.
+// No persistence; gated by DEBUG usage in UI.
+
+const counters = Object.create(null);
+
+export function incCounter(key, by = 1) {
+  counters[key] = (counters[key] || 0) + by;
+}
+
+export function getCounter(key) {
+  return counters[key] || 0;
+}
+
+export function resetCounters(prefix = '') {
+  for (const k of Object.keys(counters)) {
+    if (!prefix || k.startsWith(prefix)) delete counters[k];
+  }
+}
+
+export function withTimer(name, fn) {
+  const t0 = performance.now();
+  const result = fn();
+  const t1 = performance.now();
+  incCounter(`time.${name}.ms`, t1 - t0);
+  incCounter(`time.${name}.calls`, 1);
+  return result;
+}
+
+export function snapshotTelemetry() {
+  return { ...counters };
+}

--- a/src/shared/tunables.js
+++ b/src/shared/tunables.js
@@ -1,0 +1,38 @@
+// Central registry for live balance knobs (non-persistent).
+// Usage: getTunable('combat.damageMult', 1)
+// You can hot-edit values via the dev tuner; defaults leave gameplay unchanged.
+
+const _registry = Object.create(null);
+
+// Default, safe multipliers
+const DEFAULTS = {
+  // buckets
+  'combat.damageMult': 1,
+  'combat.attackRateMult': 1,
+  'combat.accuracyMult': 1,
+  'progression.foundationGainMult': 1,
+  'progression.qiRegenMult': 1,
+  'proficiency.xpGainMult': 1,
+  'loot.dropRateMult': 1,
+};
+
+export function getTunable(key, fallback) {
+  if (key in _registry) return _registry[key];
+  if (key in DEFAULTS) return DEFAULTS[key];
+  return fallback;
+}
+
+// Assign without persisting to saves.
+export function setTunable(key, value) {
+  _registry[key] = Number.isFinite(value) ? value : DEFAULTS[key] ?? 1;
+}
+
+export function resetTunables() {
+  Object.keys(_registry).forEach(k => delete _registry[k]);
+}
+
+export function getAllTunables() {
+  const out = {};
+  for (const k of Object.keys(DEFAULTS)) out[k] = getTunable(k);
+  return out;
+}

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -1,6 +1,7 @@
 import { createGameController } from "../game/GameController.js";
 import { mountAllFeatureUIs } from "../features/index.js";
 import { mountDevQuickMenu } from "./dev/devQuickMenu.js";
+import { mountBalanceTuner, ENABLE_BALANCE_TUNER } from "./dev/balanceTuner.js";
 
 // Bootstraps the game controller, mounts feature UIs and starts the loop.
 export function initApp() {
@@ -17,9 +18,13 @@ export function initApp() {
   window.__SET_SPEED = (v) => game.setSpeed(v);
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => mountDevQuickMenu());
+    document.addEventListener("DOMContentLoaded", () => {
+      mountDevQuickMenu();
+      if (ENABLE_BALANCE_TUNER) mountBalanceTuner();
+    });
   } else {
     mountDevQuickMenu();
+    if (ENABLE_BALANCE_TUNER) mountBalanceTuner();
   }
 }
 

--- a/src/ui/dev/balanceTuner.js
+++ b/src/ui/dev/balanceTuner.js
@@ -1,0 +1,53 @@
+/* global document */
+import { getAllTunables, setTunable, resetTunables } from '../../shared/tunables.js';
+
+// Feature flag; keep off by default.
+export const ENABLE_BALANCE_TUNER = false;
+
+export function mountBalanceTuner() {
+  if (!ENABLE_BALANCE_TUNER) return;
+  const panel = document.createElement('div');
+  panel.id = 'balanceTuner';
+  panel.style.cssText = `
+    position: fixed; right: 12px; bottom: 12px; z-index: 10000;
+    background: rgba(20,20,20,0.9); color: #eee; padding: 10px; border-radius: 12px;
+    width: 280px; font: 12px/1.3 system-ui, sans-serif;
+  `;
+  panel.innerHTML = `<strong>Balance Tuner</strong>
+    <div id="bt-sliders" style="max-height: 260px; overflow:auto; margin-top:8px;"></div>
+    <div style="display:flex; gap:8px; margin-top:8px;">
+      <button id="bt-reset">Reset</button>
+      <button id="bt-close" style="margin-left:auto;">Close</button>
+    </div>`;
+
+  document.body.appendChild(panel);
+  const sliders = panel.querySelector('#bt-sliders');
+  const data = getAllTunables();
+
+  for (const [key, val] of Object.entries(data)) {
+    const row = document.createElement('div');
+    row.style.marginBottom = '6px';
+    row.innerHTML = `
+      <label style="display:block; margin-bottom:2px;">${key} <span data-k="${key}" style="opacity:.8">${val.toFixed(2)}</span></label>
+      <input type="range" min="0.25" max="4" step="0.01" value="${val}" data-key="${key}" />
+    `;
+    sliders.appendChild(row);
+  }
+
+  sliders.addEventListener('input', (ev) => {
+    const el = ev.target;
+    if (el.tagName !== 'INPUT') return;
+    const k = el.getAttribute('data-key');
+    const v = parseFloat(el.value);
+    setTunable(k, v);
+    const label = panel.querySelector(`span[data-k="${k}"]`);
+    if (label) label.textContent = v.toFixed(2);
+  });
+
+  panel.querySelector('#bt-reset').onclick = () => {
+    resetTunables();
+    panel.remove();
+    mountBalanceTuner();
+  };
+  panel.querySelector('#bt-close').onclick = () => panel.remove();
+}


### PR DESCRIPTION
## Summary
- add central tunables registry and telemetry helpers
- optional Balance Tuner UI for live multiplier tweaks
- validate balance contracts with new script and weapon/proficiency checks

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68ab3c95337c8326842a5c4c44330efe