### PR TITLE
feat: expand stun-related stats

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -296,7 +296,8 @@ way-of-ascension/
 │   │   └── utils/
 │   │       ├── dom.js
 │   │       ├── hp.js
-│   │       └── number.js
+│   │       ├── number.js
+│   │       └── stats.js
 │   └── ui/
 │       ├── app.js
 │       ├── dev/
@@ -409,6 +410,9 @@ Contains `initHp()` to create `{ hp, hpMax }` objects from a maximum value.
 
 #### `utils/number.js` - Number Formatting Helpers
 Formats large numbers with shorthand suffixes (k, m, b, t).
+
+#### `utils/stats.js` - Stat Utilities
+Merges base stats with modifier objects.
 
 #### `src/features/progression/logic.js` - Game Calculations
 **Purpose**: Core progression mechanics and calculations

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -346,10 +346,9 @@ export function updateAdventureCombat() {
         if (enemyBar) {
           showFloatingText({ targetEl: enemyBar, result: isCrit ? 'crit' : 'hit', amount: dealt });
         }
-        const enemyState = { stunBar: S.adventure.enemyStunBar, hpMax: S.adventure.enemyMaxHP }; // STATUS-REFORM
-        const mainKey = typeof S.equipment?.mainhand === 'string' ? S.equipment.mainhand : S.equipment?.mainhand?.key;
-        performAttack(S, enemyState, { attackIsPhysical: true, physDamageDealt: dealt, usingPalm: mainKey === 'palm' }, S); // STATUS-REFORM
-        S.adventure.enemyStunBar = enemyState.stunBar; // STATUS-REFORM
+          const enemyState = { stunBar: S.adventure.enemyStunBar, hpMax: S.adventure.enemyMaxHP }; // STATUS-REFORM
+          performAttack(S, enemyState, { attackIsPhysical: true, physDamageDealt: dealt, weapon }, S); // STATUS-REFORM
+          S.adventure.enemyStunBar = enemyState.stunBar; // STATUS-REFORM
         const pos = getCombatPositions();
         if (pos) {
           setFxTint(pos.svg, weapon.animations?.tint || 'auto');

--- a/src/features/combat/attack.js
+++ b/src/features/combat/attack.js
@@ -1,15 +1,19 @@
 import { STATUSES_BY_ELEMENT } from './data/statusesByElement.js';
 import { applyStatus } from './mutators.js';
+import { mergeStats } from '../../shared/utils/stats.js';
 
 export function performAttack(attacker, target, options = {}, state) { // STATUS-REFORM
-  const { ability, attackElement, attackIsPhysical, physDamageDealt = 0, isCrit = false, usingPalm = false } = options;
+  const { ability, attackElement, attackIsPhysical, physDamageDealt = 0, isCrit = false, weapon } = options;
+
+  const attackerStats = mergeStats(attacker?.stats, weapon?.stats);
+  const targetStats = target?.stats || {};
 
   if (ability && ability.status) { // STATUS-REFORM
     const { key, power } = ability.status;
     const chance = isCrit ? 1 : power;
     if (Math.random() < chance) {
       console.log(`[status] ${key} applied ${isCrit ? '(crit)' : '(roll)'}`); // STATUS-REFORM
-      applyStatus(target, key, power, state); // STATUS-REFORM
+      applyStatus(target, key, power, state, { attackerStats, targetStats }); // STATUS-REFORM
     } else {
       console.log(`[status] ${key} failed (roll)`); // STATUS-REFORM
     }
@@ -18,24 +22,30 @@ export function performAttack(attacker, target, options = {}, state) { // STATUS
     const chance = isCrit ? 1 : power;
     if (Math.random() < chance) {
       console.log(`[status] ${key} applied ${isCrit ? '(crit)' : '(roll)'}`); // STATUS-REFORM
-      applyStatus(target, key, power, state); // STATUS-REFORM
+      applyStatus(target, key, power, state, { attackerStats, targetStats }); // STATUS-REFORM
     } else {
       console.log(`[status] ${key} failed (roll)`); // STATUS-REFORM
     }
   }
 
   if (attackIsPhysical) { // STATUS-REFORM
-    const modifier = usingPalm ? 1.3 : 1; // STATUS-REFORM
-    const gain = (physDamageDealt / target.hpMax) * 100 * modifier; // STATUS-REFORM
+    const baseGain = (physDamageDealt / target.hpMax) * 100;
+    const buildMult = 1 + (attackerStats.stunBuildMult || 0);
+    const takenMult = 1 - (targetStats.stunBuildTakenReduction || 0);
+    const gain = baseGain * buildMult * takenMult;
     const before = target.stunBar || 0; // STATUS-REFORM
     target.stunBar = Math.min(100, before + gain); // STATUS-REFORM
     console.log(`[stun] bar=${Math.round(before)} → ${Math.round(target.stunBar)} (damage=${physDamageDealt})`); // STATUS-REFORM
     if (target.stunBar >= 100) { // STATUS-REFORM
-      console.log('[stun] threshold reached → stunned'); // STATUS-REFORM
-      applyStatus(target, 'stun', 1, state); // STATUS-REFORM
+      if (Math.random() >= (targetStats.stunResist || 0)) {
+        console.log('[stun] threshold reached → stunned'); // STATUS-REFORM
+        applyStatus(target, 'stun', 1, state, { attackerStats, targetStats }); // STATUS-REFORM
+      } else {
+        console.log('[stun] resisted'); // STATUS-REFORM
+      }
       target.stunBar = 0; // STATUS-REFORM
     }
-    applyStatus(target, 'interrupt', 0.05, state); // STATUS-REFORM
+    applyStatus(target, 'interrupt', 0.05, state, { attackerStats, targetStats }); // STATUS-REFORM
   }
 }
 

--- a/src/features/combat/mutators.js
+++ b/src/features/combat/mutators.js
@@ -47,6 +47,6 @@ export function processAttack(damage, options = {}, state = S) {
   return dealt;
 }
 
-export function applyStatus(target, key, power, state = S) {
-  return applyStatusBase(target, key, power, state);
+export function applyStatus(target, key, power, state = S, options) {
+  return applyStatusBase(target, key, power, state, options);
 }

--- a/src/features/combat/statusEngine.js
+++ b/src/features/combat/statusEngine.js
@@ -1,11 +1,18 @@
 import { STATUSES } from './data/status.js';
 
-export function applyStatus(target, key, power, state) { // STATUS-REFORM
+export function applyStatus(target, key, power, state, options = {}) { // STATUS-REFORM
   const def = STATUSES[key];
   if (!def) return;
+  const { attackerStats = {}, targetStats = {} } = options;
   if (!target.statuses) target.statuses = {};
   const current = target.statuses[key] || { stacks: 0, duration: 0 };
   current.stacks = Math.min(def.maxStacks ?? Infinity, current.stacks + 1);
-  current.duration = def.duration;
+  let duration = def.duration;
+  if (key === 'stun') {
+    duration *= 1 + (attackerStats.stunDurationMult || 0);
+    duration *= 1 - (targetStats.stunResist || 0);
+  }
+  duration *= 1 - (targetStats.ccResist || 0);
+  current.duration = duration;
   target.statuses[key] = current;
 }

--- a/src/features/weaponGeneration/data/weapons.js
+++ b/src/features/weaponGeneration/data/weapons.js
@@ -61,8 +61,19 @@ const FIST = {
   animations: defaultAnimationsForType('fist'),
 };
 
+const PALM = {
+  ...FIST,
+  key: 'palm',
+  displayName: 'Palm',
+  stats: {
+    stunBuildMult: 0.3,
+    stunDurationMult: 0.1,
+  },
+};
+
 export const WEAPONS = {
   fist: FIST,
+  palm: PALM,
   ironSword: toLegacy('ironSword', generateWeapon({ typeKey: 'sword', materialKey: 'iron' })),
   bronzeHammer: toLegacy('bronzeHammer', generateWeapon({ typeKey: 'hammer', materialKey: 'bronze' })),
   elderWand: toLegacy('elderWand', generateWeapon({ typeKey: 'wand', materialKey: 'spiritwood' })),

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -47,7 +47,12 @@ export const defaultState = () => {
     adventureSpeed: 1.0, // Adventure/exploration speed multiplier
     armor: 0,           // Total armor from gear and bonuses
     accuracy: ACCURACY_BASE,        // Chance to hit with attacks
-    dodge: DODGE_BASE           // Chance to avoid attacks
+    dodge: DODGE_BASE,          // Chance to avoid attacks
+    stunBuildMult: 0,           // Bonus stun build applied by attacker
+    stunDurationMult: 0,        // Bonus stun duration applied by attacker
+    stunResist: 0,              // Resistance to stun effects
+    ccResist: 0,                // Resistance to crowd control duration
+    stunBuildTakenReduction: 0  // Reduction to stun build taken
   },
   disciples:1,
   gather:{herbs:0, ore:0, wood:0},

--- a/src/shared/utils/stats.js
+++ b/src/shared/utils/stats.js
@@ -1,0 +1,11 @@
+export function mergeStats(base = {}, ...mods) {
+  const out = { ...base };
+  for (const mod of mods) {
+    if (!mod) continue;
+    for (const [k, v] of Object.entries(mod)) {
+      if (typeof v !== 'number') continue;
+      out[k] = (out[k] || 0) + v;
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- replace engine actor helper with shared stat merging utility
- merge attacker weapon stats (e.g., palm) into attack calculations for stun
- document new stat helper and register palm weapon bonuses

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3d9fd1a483269d8843bed7f19629