### PR TITLE
feat: add tunable balance multipliers

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -289,10 +289,12 @@ way-of-ascension/
 │   │   └── migrations.js
 │   ├── shared/
 │   │   ├── events.js
-│   │   ├── saveLoad.js
-│   │   ├── state.js
 │   │   ├── mutators.js
+│   │   ├── saveLoad.js
 │   │   ├── selectors.js
+│   │   ├── state.js
+│   │   ├── telemetry.js
+│   │   ├── tunables.js
 │   │   └── utils/
 │   │       ├── dom.js
 │   │       ├── hp.js
@@ -300,6 +302,7 @@ way-of-ascension/
 │   └── ui/
 │       ├── app.js
 │       ├── dev/
+│       │   ├── balanceTuner.js
 │       │   └── devQuickMenu.js
 │       └── sidebar.js
 ├── ui/
@@ -670,6 +673,12 @@ function updateAll() {
 #### `src/ui/dev/devQuickMenu.js`
 **Purpose:** Tiny top-right Dev button and menu. Uses existing `window.__*` hooks when available, emits `DEV:SET_SEED` for RNG, and exposes a Mind helper to level up the active manual for debugging.
 
+#### `src/ui/dev/balanceTuner.js`
+**Purpose:** Optional slider panel for adjusting tunable multipliers at runtime.
+**Key Functions:**
+- `mountBalanceTuner()` mounts the panel when enabled.
+- `ENABLE_BALANCE_TUNER` feature flag toggle.
+
 #### `src/features/inventory/ui/weaponChip.js` - Weapon Chip HUD
 **Purpose**: Initializes and updates the weapon display chip in the top HUD.
 **When to modify**: Change weapon HUD logic or appearance.
@@ -788,6 +797,9 @@ Paths added:
 - `src/features/activity/selectors.js` – activity selectors
 - `src/features/activity/mutators.js` – activity mutators
 - `src/features/activity/ui/activityUI.js` – activity UI helpers
+- `src/shared/telemetry.js` - runtime counters for debugging
+- `src/shared/tunables.js` - non-persistent balance multipliers
+- `src/ui/dev/balanceTuner.js` - optional dev panel for tuning
 - `src/features/adventure/ui/mapUI.js` – adventure map UI
 - `src/features/automation/logic.js` – automation logic helpers
 - `src/features/automation/migrations.js` – automation save migrations
@@ -804,6 +816,23 @@ Paths added:
 
 #### `src/shared/saveLoad.js` - Persistence Helpers
 **Purpose**: Load and save game state, including debounced autosave.
+
+#### `src/shared/telemetry.js` - Telemetry Utilities
+**Purpose**: Tracks lightweight counters and timers for debugging.
+**Key Functions**:
+- `incCounter(key, by)`
+- `getCounter(key)`
+- `resetCounters(prefix)`
+- `withTimer(name, fn)`
+- `snapshotTelemetry()`
+
+#### `src/shared/tunables.js` - Runtime Balance Overrides
+**Purpose**: Provides adjustable multipliers for combat and progression without touching saves.
+**Key Functions**:
+- `getTunable(key, fallback)`
+- `setTunable(key, value)`
+- `resetTunables()`
+- `getAllTunables()`
 
 #### `src/features/index.js` - Feature UI Bootstrap
 **Purpose**: Central place to mount all feature user interfaces.

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -6,7 +6,6 @@ import { getBuildingBonuses } from '../sect/selectors.js';
 import { karmaQiRegenBonus, karmaAtkBonus, karmaArmorBonus } from '../karma/logic.js';
 import { getSuccessBonus as getAlchemySuccessBonus } from '../alchemy/selectors.js';
 import { getCookingSuccessBonus } from '../cooking/selectors.js';
-import { getTunable } from '../../shared/tunables.js';
 export const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
 export function getLawBonuses(state = progressionState){
   let bonuses = {
@@ -145,8 +144,7 @@ export function calculatePlayerCombatAttack(state = progressionState) {
   const baseAttack = 5;
   const realmBonus = REALMS[state.realm.tier].atk * state.realm.stage;
   const profBonus = getWeaponProficiencyBonuses(state).damage;
-  const mult = getTunable('combat.damageMult', 1);
-  return (baseAttack + profBonus + realmBonus) * mult;
+  return baseAttack + profBonus + realmBonus;
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {
@@ -154,8 +152,7 @@ export function calculatePlayerAttackRate(state = progressionState) {
   const dexterityBonus = (state.stats.dexterity - 10) * 0.05;
   const attackSpeedBonus = state.stats.attackSpeed || 0;
   const profBonus = getWeaponProficiencyBonuses(state).speed;
-  const mult = getTunable('combat.attackRateMult', 1);
-  return (baseRate + dexterityBonus + (attackSpeedBonus / 100) + profBonus) * mult;
+  return baseRate + dexterityBonus + (attackSpeedBonus / 100) + profBonus;
 }
 
 export function breakthroughChance(state = progressionState){

--- a/src/features/progression/selectors.js
+++ b/src/features/progression/selectors.js
@@ -1,4 +1,5 @@
 import { progressionState } from './state.js';
+import { getTunable } from '../../shared/tunables.js';
 import {
   getLawBonuses as calcLawBonuses,
   qCap as calcQCap,
@@ -26,7 +27,7 @@ export function qCap(state = progressionState) {
 }
 
 export function qiRegenPerSec(state = progressionState) {
-  return calcQiRegen(state);
+  return calcQiRegen(state) * getTunable('progression.qiRegenMult', 1);
 }
 
 export function fCap(state = progressionState) {
@@ -34,11 +35,11 @@ export function fCap(state = progressionState) {
 }
 
 export function foundationGainPerSec(state = progressionState) {
-  return calcFoundationGain(state);
+  return calcFoundationGain(state) * getTunable('progression.foundationGainMult', 1);
 }
 
 export function foundationGainPerMeditate(state = progressionState) {
-  return calcFoundationGainMeditate(state);
+  return calcFoundationGainMeditate(state) * getTunable('progression.foundationGainMult', 1);
 }
 
 export function powerMult(state = progressionState) {
@@ -58,11 +59,11 @@ export function getStatEffects(state = progressionState) {
 }
 
 export function calculatePlayerCombatAttack(state = progressionState) {
-  return calcPlayerCombatAttack(state);
+  return calcPlayerCombatAttack(state) * getTunable('combat.damageMult', 1);
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {
-  return calcPlayerAttackRate(state);
+  return calcPlayerAttackRate(state) * getTunable('combat.attackRateMult', 1);
 }
 
 export function breakthroughChance(state = progressionState) {

--- a/src/shared/tunables.js
+++ b/src/shared/tunables.js
@@ -1,34 +1,23 @@
-// Central registry for live balance knobs (non-persistent).
-// Usage: getTunable('combat.damageMult', 1)
-// You can hot-edit values via the dev tuner; defaults leave gameplay unchanged.
-
-const _registry = Object.create(null);
-
-// Default, safe multipliers
-const DEFAULTS = {
-  // buckets
+export const DEFAULTS = {
   'combat.damageMult': 1,
   'combat.attackRateMult': 1,
-  'combat.accuracyMult': 1,
   'progression.foundationGainMult': 1,
   'progression.qiRegenMult': 1,
-  'proficiency.xpGainMult': 1,
-  'loot.dropRateMult': 1,
 };
+let _overrides = Object.create(null);
 
-export function getTunable(key, fallback) {
-  if (key in _registry) return _registry[key];
-  if (key in DEFAULTS) return DEFAULTS[key];
-  return fallback;
+export function getTunable(key, fallback = 1) {
+  return (_overrides[key] ?? DEFAULTS[key] ?? fallback);
 }
-
-// Assign without persisting to saves.
 export function setTunable(key, value) {
-  _registry[key] = Number.isFinite(value) ? value : DEFAULTS[key] ?? 1;
+  const v = Number(value);
+  _overrides[key] = Number.isFinite(v) ? v : (DEFAULTS[key] ?? 1);
 }
+export function resetTunables() { _overrides = Object.create(null); }
 
-export function resetTunables() {
-  Object.keys(_registry).forEach(k => delete _registry[k]);
+// Convenience: allow quick tuning from DevTools console: tune.set(...), tune.reset()
+if (typeof window !== 'undefined') {
+  window.tune = { get: getTunable, set: setTunable, reset: resetTunables, defaults: DEFAULTS };
 }
 
 export function getAllTunables() {

--- a/validation.log
+++ b/validation.log
@@ -5,18 +5,6 @@
 ❌ VERIFICATION FAILED - MUST fix before proceeding
 
 🚨 VIOLATIONS DETECTED:
-   • UNDOCUMENTED FILE: src/features/mind/data/_balance.contract.js
-   • UNDOCUMENTED FILE: src/features/mind/data/manuals.js
-   • UNDOCUMENTED FILE: src/features/mind/data/talismans.js
-   • UNDOCUMENTED FILE: src/features/mind/index.js
-   • UNDOCUMENTED FILE: src/features/mind/logic.js
-   • UNDOCUMENTED FILE: src/features/mind/mutators.js
-   • UNDOCUMENTED FILE: src/features/mind/selectors.js
-   • UNDOCUMENTED FILE: src/features/mind/state.js
-   • UNDOCUMENTED FILE: src/features/mind/ui/mindMainTab.js
-   • UNDOCUMENTED FILE: src/features/mind/ui/mindPuzzlesTab.js
-   • UNDOCUMENTED FILE: src/features/mind/ui/mindReadingTab.js
-   • UNDOCUMENTED FILE: src/features/mind/ui/mindStatsTab.js
    • UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js
    • UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js
    • UI state violation: src/features/adventure/ui/progressBar.js imports S from shared/state.js
@@ -41,23 +29,6 @@
    • UI timer: src/features/physique/ui/trainingGame.js uses timers/RAF — prefer feature.tick and RENDER
    • UI rule: src/features/progression/ui/realm.js uses Math.random() — move randomness to logic.js
    • UI timer: src/features/progression/ui/realm.js uses timers/RAF — prefer feature.tick and RENDER
-
-📝 REQUIRED ACTION:
-   Update docs/project-structure.md with these files:
-   • src/features/mind/data/_balance.contract.js
-   • src/features/mind/data/manuals.js
-   • src/features/mind/data/talismans.js
-   • src/features/mind/index.js
-   • src/features/mind/logic.js
-   • src/features/mind/mutators.js
-   • src/features/mind/selectors.js
-   • src/features/mind/state.js
-   • src/features/mind/ui/mindMainTab.js
-   • src/features/mind/ui/mindPuzzlesTab.js
-   • src/features/mind/ui/mindReadingTab.js
-   • src/features/mind/ui/mindStatsTab.js
-
-   Then document their purpose and functions.
 
 =====================================
 


### PR DESCRIPTION
## Summary
- introduce shared tunables module with runtime balance knobs
- apply tunable multipliers to damage, attack speed, qi regen, and foundation gain
- document new shared and dev modules in project structure

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation in multiple UI files)

------
https://chatgpt.com/codex/tasks/task_e_68ab588f3b28832681f516513758a76f