### PR TITLE
Fix cultivation silhouette missing on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -4272,7 +4272,11 @@ tr:last-child td {
   .cards .card{width:100%;box-sizing:border-box;}
   .cards .card h4{font-size:1rem;}
   .cards .btn{font-size:0.9rem;}
-  .cultivation-layout{gap:12px;}
+  .cultivation-layout{
+    flex-direction:column;
+    align-items:stretch;
+    gap:12px;
+  }
   .cultivation-visualization-container{height:300px;min-height:200px;}
   .cultivation-controls-card{font-size:0.85rem;}
   .cultivation-buttons{gap:6px;}


### PR DESCRIPTION
## Summary
- Ensure cultivation layout stacks vertically on small screens so silhouette card is visible

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement errors)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68aca470fdc4832683d61432d5986f1b