### PR TITLE
Fix cultivation silhouette missing on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -4272,8 +4272,17 @@ tr:last-child td {
   .cards .card{width:100%;box-sizing:border-box;}
   .cards .card h4{font-size:1rem;}
   .cards .btn{font-size:0.9rem;}
-  .cultivation-layout{gap:12px;}
-  .cultivation-visualization-container{height:300px;min-height:200px;}
+  .cultivation-layout{
+    flex-direction:column;
+    align-items:stretch;
+    gap:12px;
+  }
+  .cultivation-visualization-container{
+    flex: none;
+    width: 100%;
+    height:300px;
+    min-height:200px;
+  }
   .cultivation-controls-card{font-size:0.85rem;}
   .cultivation-buttons{gap:6px;}
   .cultivation-btn{font-size:0.85rem;padding:6px 8px;}


### PR DESCRIPTION
## Summary
- Prevent cultivation visualization from collapsing on small screens so silhouette card appears

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement errors)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68aca470fdc4832683d61432d5986f1b