### PR TITLE
Add enemy stun gauge UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,6 +530,10 @@
                     <div class="health-fill" id="enemyHealthFill"></div>
                     <span class="health-text" id="enemyHealthText">--/--</span>
                   </div>
+                  <div class="stun-bar" id="enemyStunBar" title="Gauge: 0\nThreshold: 100\nDecay: 6/s">
+                    <div class="stun-fill" id="enemyStunFill"></div>
+                    <span class="stun-text" id="enemyStunText">0/100</span>
+                  </div>
                   <div class="qi-bar">
                     <div class="qi-fill" id="enemyQiFill"></div>
                     <span class="qi-text" id="enemyQiText">--</span>

--- a/src/engine/combat/stun.js
+++ b/src/engine/combat/stun.js
@@ -7,9 +7,9 @@
  * @property {(key: string) => boolean} [hasStatus]
  */
 
-const STUN_THRESHOLD = 100;
+export const STUN_THRESHOLD = 100;
 const MAX_STUN_PER_HIT = 40; // per-hit cap in percent
-const DECAY_PER_SECOND = 6; // stun bar decays this % each second
+export const DECAY_PER_SECOND = 6; // stun bar decays this % each second
 const BASE_STUN_DURATION_MS = 2000;
 
 /** Initialize and attach a stun state to a target. */

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -10,7 +10,7 @@ import { rollGearDropForZone } from '../gearGeneration/selectors.js';
 import { addToInventory } from '../inventory/mutators.js';
 import { ABILITIES } from '../ability/data/abilities.js';
 import { performAttack } from '../combat/attack.js'; // STATUS-REFORM
-import { tickStunDecay, initStun } from '../../engine/combat/stun.js';
+import { tickStunDecay, initStun, STUN_THRESHOLD, DECAY_PER_SECOND } from '../../engine/combat/stun.js';
 import { chanceToHit, DODGE_BASE } from '../combat/hit.js';
 import { tryCastAbility, processAbilityQueue } from '../ability/mutators.js';
 import { ENEMY_DATA } from './data/enemies.js';
@@ -218,6 +218,29 @@ export function updateBattleDisplay() {
       const enemyHealthPct = (enemyHP / enemyMaxHP) * 100;
       enemyHealthFill.style.width = `${enemyHealthPct}%`;
     }
+    const stunFill = document.getElementById('enemyStunFill');
+    const stunBarEl = document.getElementById('enemyStunBar');
+    const stunGauge = S.adventure.enemyStunBar || 0;
+    if (stunFill) {
+      const pct = stunGauge / STUN_THRESHOLD;
+      stunFill.style.width = `${pct * 100}%`;
+      const hue = 39 * (1 - pct);
+      stunFill.style.backgroundColor = `hsl(${hue}, 100%, 50%)`;
+    }
+    if (stunBarEl) {
+      stunBarEl.classList.toggle('stun-flash', stunGauge >= STUN_THRESHOLD * 0.9 && stunGauge < STUN_THRESHOLD);
+      stunBarEl.classList.toggle('stun-shake', stunGauge >= STUN_THRESHOLD);
+      const statuses = enemy.statuses || {};
+      const info = [
+        `Gauge: ${Math.round(stunGauge)}`,
+        `Threshold: ${STUN_THRESHOLD}`,
+        `Decay: ${DECAY_PER_SECOND}/s`
+      ];
+      if (statuses.stunWeakened) info.push('stunWeakened active');
+      if (statuses.stunImmune) info.push('stunImmune active');
+      stunBarEl.title = info.join('\n');
+    }
+    setText('enemyStunText', `${Math.round(stunGauge)}/${STUN_THRESHOLD}`);
   } else {
     setText('enemyName', 'Select an area to begin');
     setText('enemyHealthText', '--/--');
@@ -230,6 +253,17 @@ export function updateBattleDisplay() {
     if (enemyQiFill) enemyQiFill.style.width = '0%';
     const affixEl = document.getElementById('enemyAffixes');
     if (affixEl) affixEl.innerHTML = '';
+    const enemyStunFill = document.getElementById('enemyStunFill');
+    if (enemyStunFill) {
+      enemyStunFill.style.width = '0%';
+      enemyStunFill.style.backgroundColor = 'hsl(39, 100%, 50%)';
+    }
+    setText('enemyStunText', `0/${STUN_THRESHOLD}`);
+    const enemyStunBar = document.getElementById('enemyStunBar');
+    if (enemyStunBar) {
+      enemyStunBar.classList.remove('stun-flash', 'stun-shake');
+      enemyStunBar.title = `Gauge: 0\nThreshold: ${STUN_THRESHOLD}\nDecay: ${DECAY_PER_SECOND}/s`;
+    }
   }
   const combatLog = document.getElementById('combatLog');
   if (combatLog && S.adventure.combatLog) {

--- a/style.css
+++ b/style.css
@@ -3206,6 +3206,52 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
 }
 
+.stun-bar {
+  position: relative;
+  width: 100%;
+  height: 12px;
+  background: rgba(251, 191, 36, 0.3);
+  border-radius: 8px;
+  margin: 4px 0;
+  overflow: hidden;
+}
+
+.stun-fill {
+  height: 100%;
+  width: 0%;
+  background: hsl(39, 100%, 50%);
+  transition: width 0.2s ease, background-color 0.2s ease;
+}
+
+.stun-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #000;
+  font-weight: bold;
+  font-size: 0.75em;
+}
+
+@keyframes stunFlash {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes stunShake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  75% { transform: translateX(2px); }
+}
+
+.stun-bar.stun-flash .stun-fill {
+  animation: stunFlash 0.5s infinite;
+}
+
+.stun-bar.stun-shake {
+  animation: stunShake 0.3s infinite;
+}
+
 .qi-bar {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- Add stun gauge bar under enemy HP with color shift and effects
- Export stun constants and update adventure logic to drive bar and tooltip
- Style new bar with flashing and shaking animations

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: AI verification enforcement violations)


------
https://chatgpt.com/codex/tasks/task_e_68acb0e10780832690ce03653c59f96d