### PR TITLE
Fix mobile scrolling by allowing body vertical overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -121,7 +121,8 @@ body{
   margin:0;
   font-family: 'IM Fell English', serif;
   color: #000;
-  overflow:hidden;
+  overflow-x:hidden;
+  overflow-y:auto;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- Allow body vertical scrolling on mobile by removing `overflow:hidden`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: UI state violation in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68acb13484e48326a37fb698bcd6745b