### PR TITLE
feat: add Flowing Palm ability and manual

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -16,6 +16,16 @@ export const ABILITIES = {
     tags: ['weapon-skill', 'physical'],
     requiresWeaponType: 'sword',
   },
+  flowingPalm: {
+    key: 'flowingPalm',
+    displayName: 'Flowing Palm',
+    icon: 'game-icons:open-palm',
+    costQi: 0,
+    cooldownMs: 5_000,
+    castTimeMs: 0,
+    tags: ['martial', 'physical'],
+    requiresWeaponType: 'palm',
+  },
   seventyFive: {
     key: 'seventyFive',
     displayName: '75%',

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -4,11 +4,22 @@ export function resolveAbilityHit(abilityKey, state) {
   switch (abilityKey) {
     case 'powerSlash':
       return resolvePowerSlash(state);
+    case 'flowingPalm':
+      return resolveFlowingPalm(state);
     case 'seventyFive':
       return resolveSeventyFive();
     default:
       return null;
   }
+}
+
+function resolveFlowingPalm(state) {
+  const weapon = getEquippedWeapon(state);
+  const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
+  return {
+    attack: { amount: roll, type: 'physical', target: state.adventure.currentEnemy },
+    stun: { mult: 2 },
+  };
 }
 
 function resolvePowerSlash(state) {

--- a/src/features/mind/data/manuals.js
+++ b/src/features/mind/data/manuals.js
@@ -177,6 +177,27 @@ export const MANUALS = {
       { qiShieldCapacityPct: 24 },
       { qiShieldCapacityPct: 30 }
     ]
+  },
+
+  flowingPalmManual: {
+    id: 'flowingPalmManual',
+    name: 'Flowing Palm Manual',
+    category: 'Combat',
+    xpRate: 0.31,
+    reqLevel: 1,
+    maxLevel: 5,
+    baseTimeSec: 15 * 60,
+    statWeights: { mind: 0.7, agility: 0.6, physique: 0.4 },
+    maxSpeedBoostPct: 400,
+    levelTimeMult: [1, 6, 30, 180, 1800],
+    grantsAbility: 'flowingPalm',
+    effects: [
+      { abilityMods: { flowingPalm: { damagePct: 8, stunPct: 20 } } },
+      { abilityMods: { flowingPalm: { damagePct: 8, stunPct: 20 } } },
+      { abilityMods: { flowingPalm: { damagePct: 10, stunPct: 25 } } },
+      { abilityMods: { flowingPalm: { damagePct: 12, stunPct: 30 } } },
+      { abilityMods: { flowingPalm: { damagePct: 15, stunPct: 40 } } },
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- introduce Flowing Palm ability and resolution logic with stun effect
- apply manual-based damage and stun modifiers through Flowing Palm Manual
- support ability-specific stun via applyStatus hook

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation)*

------
https://chatgpt.com/codex/tasks/task_e_68acb0c7f3188326b477546e10977761