### PR TITLE
Add enemy stun gauge UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,6 +526,10 @@
                 <div class="combatant enemy">
                   <div class="enemy-affixes" id="enemyAffixes"></div>
                   <div class="combatant-name" id="enemyName">Select an area to begin</div>
+                  <div class="stun-bar" id="enemyStunBar" title="Gauge: 0\nThreshold: 100\nDecay: 6/s">
+                    <div class="stun-fill" id="enemyStunFill"></div>
+                    <span class="stun-text" id="enemyStunText">0/100</span>
+                  </div>
                   <div class="health-bar">
                     <div class="health-fill" id="enemyHealthFill"></div>
                     <span class="health-text" id="enemyHealthText">--/--</span>

--- a/src/engine/combat/stun.js
+++ b/src/engine/combat/stun.js
@@ -7,9 +7,9 @@
  * @property {(key: string) => boolean} [hasStatus]
  */
 
-const STUN_THRESHOLD = 100;
+export const STUN_THRESHOLD = 100;
 const MAX_STUN_PER_HIT = 40; // per-hit cap in percent
-const DECAY_PER_SECOND = 6; // stun bar decays this % each second
+export const DECAY_PER_SECOND = 6; // stun bar decays this % each second
 const BASE_STUN_DURATION_MS = 2000;
 
 /** Initialize and attach a stun state to a target. */

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -104,55 +104,76 @@ export function powerMult(state = progressionState){
 }
 
 export function calcAtk(state = progressionState){
-  const realm = REALMS[state.realm.tier];
-  const baseAtk = realm.atk;
-  const stageBonus = Math.floor(baseAtk * (state.realm.stage - 1) * 0.08);
+  const tier = state?.realm?.tier ?? 0;
+  const stage = state?.realm?.stage ?? 1;
+  const realm = REALMS[tier] || {};
+  const baseAtk = Number(realm.atk) || 0;
+  const stageBonus = Math.floor(baseAtk * (stage - 1) * 0.08);
   const lawBonuses = getLawBonuses(state);
-  const profBonus = getWeaponProficiencyBonuses(state).damage;
-  const building = getBuildingBonuses(state).atkBase || 0;
-  return Math.floor((state.atkBase + building + profBonus + state.tempAtk + baseAtk + stageBonus + karmaAtkBonus(state)) * lawBonuses.atk);
+  const profBonus = Number(getWeaponProficiencyBonuses(state).damage) || 0;
+  const building = Number(getBuildingBonuses(state).atkBase) || 0;
+  const base = Number(state.atkBase) || 0;
+  const temp = Number(state.tempAtk) || 0;
+  const karma = Number(karmaAtkBonus(state)) || 0;
+  return Math.floor((base + building + profBonus + temp + baseAtk + stageBonus + karma) * (lawBonuses.atk || 1));
 }
 
 export function calcArmor(state = progressionState){
-  const realm = REALMS[state.realm.tier];
-  const baseArmor = realm.armor;
-  const stageBonus = Math.floor(baseArmor * (state.realm.stage - 1) * 0.08);
+  const tier = state?.realm?.tier ?? 0;
+  const stage = state?.realm?.stage ?? 1;
+  const realm = REALMS[tier] || {};
+  const baseArmor = Number(realm.armor) || 0;
+  const stageBonus = Math.floor(baseArmor * (stage - 1) * 0.08);
   const lawBonuses = getLawBonuses(state);
-  const building = getBuildingBonuses(state).armorBase || 0;
-  return Math.floor((state.armorBase + building + state.tempArmor + baseArmor + stageBonus + karmaArmorBonus(state)) * lawBonuses.armor);
+  const building = Number(getBuildingBonuses(state).armorBase) || 0;
+  const base = Number(state.armorBase) || 0;
+  const temp = Number(state.tempArmor) || 0;
+  const karma = Number(karmaArmorBonus(state)) || 0;
+  return Math.floor((base + building + temp + baseArmor + stageBonus + karma) * (lawBonuses.armor || 1));
 }
 
 export function getStatEffects(state = progressionState) {
+  const stats = state.stats || {};
+  const mind = Number(stats.mind) || 10;
+  const dex = Number(stats.dexterity) || 10;
+  const comp = Number(stats.comprehension) || 10;
+  const crit = Number(stats.criticalChance) || 0;
+  const atkSpd = Number(stats.attackSpeed) || 0;
+  const cdRed = Number(stats.cooldownReduction) || 0;
+  const advSpd = Number(stats.adventureSpeed) || 0;
   return {
-    spellPowerMult: 1 + (state.stats.mind - 10) * 0.06,
-    alchemySuccessMult: 1 + (state.stats.mind - 10) * 0.04,
-    learningSpeedMult: 1 + (state.stats.mind - 10) * 0.05,
-    attackSpeedMult: 1 + (state.stats.dexterity - 10) * 0.04,
-    cooldownReductionBonus: (state.stats.dexterity - 10) * 0.02,
-    craftingSpeedMult: 1 + (state.stats.dexterity - 10) * 0.03,
-    adventureSpeedMult: 1 + (state.stats.dexterity - 10) * 0.03,
-    foundationGainMult: 1 + (state.stats.comprehension - 10) * 0.05,
-    learningSpeedMult2: 1 + (state.stats.comprehension - 10) * 0.04,
-    totalCritChance: state.stats.criticalChance + (state.stats.dexterity - 10) * 0.005,
-    totalAttackSpeed: state.stats.attackSpeed * (1 + (state.stats.dexterity - 10) * 0.04),
-    totalCooldownReduction: state.stats.cooldownReduction + (state.stats.dexterity - 10) * 0.02,
-    totalAdventureSpeed: state.stats.adventureSpeed * (1 + (state.stats.dexterity - 10) * 0.03)
+    spellPowerMult: 1 + (mind - 10) * 0.06,
+    alchemySuccessMult: 1 + (mind - 10) * 0.04,
+    learningSpeedMult: 1 + (mind - 10) * 0.05,
+    attackSpeedMult: 1 + (dex - 10) * 0.04,
+    cooldownReductionBonus: (dex - 10) * 0.02,
+    craftingSpeedMult: 1 + (dex - 10) * 0.03,
+    adventureSpeedMult: 1 + (dex - 10) * 0.03,
+    foundationGainMult: 1 + (comp - 10) * 0.05,
+    learningSpeedMult2: 1 + (comp - 10) * 0.04,
+    totalCritChance: crit + (dex - 10) * 0.005,
+    totalAttackSpeed: atkSpd * (1 + (dex - 10) * 0.04),
+    totalCooldownReduction: cdRed + (dex - 10) * 0.02,
+    totalAdventureSpeed: advSpd * (1 + (dex - 10) * 0.03)
   };
 }
 
 export function calculatePlayerCombatAttack(state = progressionState) {
   const baseAttack = 5;
-  const realmBonus = REALMS[state.realm.tier].atk * state.realm.stage;
-  const profBonus = getWeaponProficiencyBonuses(state).damage;
-  return baseAttack + profBonus + realmBonus;
+  const tier = state?.realm?.tier ?? 0;
+  const stage = Number(state?.realm?.stage) || 0;
+  const realmAtk = Number(REALMS[tier]?.atk) || 0;
+  const profBonus = Number(getWeaponProficiencyBonuses(state).damage) || 0;
+  return baseAttack + profBonus + realmAtk * stage;
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {
   const baseRate = 1.0;
-  const dexterityBonus = (state.stats.dexterity - 10) * 0.05;
-  const attackSpeedBonus = state.stats.attackSpeed || 0;
-  const profBonus = getWeaponProficiencyBonuses(state).speed;
-  return baseRate + dexterityBonus + (attackSpeedBonus / 100) + profBonus;
+  const dex = Number(state.stats?.dexterity) || 10;
+  const attackSpeedBonus = Number(state.stats?.attackSpeed) || 0;
+  const profBonus = Number(getWeaponProficiencyBonuses(state).speed) || 0;
+  const dexterityBonus = (dex - 10) * 0.05;
+  return baseRate + dexterityBonus + attackSpeedBonus / 100 + profBonus;
 }
 
 export function breakthroughChance(state = progressionState){

--- a/style.css
+++ b/style.css
@@ -3206,6 +3206,52 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
 }
 
+.stun-bar {
+  position: relative;
+  width: 100%;
+  height: 12px;
+  background: rgba(251, 191, 36, 0.3);
+  border-radius: 8px;
+  margin: 4px 0;
+  overflow: hidden;
+}
+
+.stun-fill {
+  height: 100%;
+  width: 0%;
+  background: hsl(39, 100%, 50%);
+  transition: width 0.2s ease, background-color 0.2s ease;
+}
+
+.stun-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #000;
+  font-weight: bold;
+  font-size: 0.75em;
+}
+
+@keyframes stunFlash {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes stunShake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  75% { transform: translateX(2px); }
+}
+
+.stun-bar.stun-flash .stun-fill {
+  animation: stunFlash 0.5s infinite;
+}
+
+.stun-bar.stun-shake {
+  animation: stunShake 0.3s infinite;
+}
+
 .qi-bar {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- Add stun gauge bar under enemy HP with color shift and effects
- Export stun constants and update adventure logic to drive bar and tooltip
- Style new bar with flashing and shaking animations
- Move stun gauge above HP bar and guard combat attack calculations to prevent NaN damage
- Default progression stats to numeric values to avoid NaN in combat calculations

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68acb0e10780832690ce03653c59f96d