### PR TITLE
Add palm wraps starting weapon and palm strike ability

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -16,6 +16,16 @@ export const ABILITIES = {
     tags: ['weapon-skill', 'physical'],
     requiresWeaponType: 'sword',
   },
+  palmStrike: {
+    key: 'palmStrike',
+    displayName: 'Palm Strike',
+    icon: 'ph:hand-palm-thin',
+    costQi: 0,
+    cooldownMs: 0,
+    castTimeMs: 0,
+    tags: ['weapon-skill', 'physical'],
+    requiresWeaponType: 'palm',
+  },
   seventyFive: {
     key: 'seventyFive',
     displayName: '75%',

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -4,6 +4,8 @@ export function resolveAbilityHit(abilityKey, state) {
   switch (abilityKey) {
     case 'powerSlash':
       return resolvePowerSlash(state);
+    case 'palmStrike':
+      return resolvePalmStrike(state);
     case 'seventyFive':
       return resolveSeventyFive();
     default:
@@ -18,6 +20,15 @@ function resolvePowerSlash(state) {
   return {
     attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
     healOnHit: 5,
+  };
+}
+
+function resolvePalmStrike(state) {
+  const weapon = getEquippedWeapon(state);
+  const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
+  const raw = Math.round(roll);
+  return {
+    attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
   };
 }
 

--- a/src/features/inventory/migrations.js
+++ b/src/features/inventory/migrations.js
@@ -54,5 +54,13 @@ export const migrations = [
     if (!save.shield) save.shield = { current: 0, max: 0 };
     if (typeof save.autoFillShieldFromQi === 'undefined') save.autoFillShieldFromQi = true;
     if (save.shield.current > save.shield.max) save.shield.current = save.shield.max;
+  },
+  save => {
+    if (!Array.isArray(save.inventory)) save.inventory = [];
+    const hasPalmWraps = save.inventory.some(it => (typeof it === 'string' ? it === 'palmWraps' : it.key === 'palmWraps'));
+    const equippedPalm = typeof save.equipment?.mainhand === 'object' && save.equipment.mainhand?.key === 'palmWraps';
+    if (!hasPalmWraps && !equippedPalm) {
+      save.inventory.push({ id: Date.now() + Math.random(), key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' });
+    }
   }
 ];

--- a/src/features/inventory/state.js
+++ b/src/features/inventory/state.js
@@ -1,4 +1,4 @@
 export const inventoryState = {
-  inventory: [],
+  inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
   equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, food: null },
 };

--- a/src/features/weaponGeneration/data/weapons.js
+++ b/src/features/weaponGeneration/data/weapons.js
@@ -19,6 +19,8 @@ function defaultAnimationsForType(typeKey) {
     case 'focus':
       // Focus has special defensive FX handled in adventure.js
       return { fx: [], tint: '#9ed2ff' };
+    case 'palm':
+      return { fx: ['palmStrike'], tint: 'auto' };
     case 'fist':
       // Placeholder: use palm-like thrust for jabs
       return { fx: ['palmStrike'], tint: 'auto' };
@@ -61,19 +63,23 @@ const FIST = {
   animations: defaultAnimationsForType('fist'),
 };
 
-const PALM = {
+const PALM_WRAPS = {
   ...FIST,
-  key: 'palm',
-  displayName: 'Palm',
+  key: 'palmWraps',
+  displayName: 'Palm Wraps',
+  typeKey: 'palm',
+  proficiencyKey: 'palm',
+  abilityKeys: ['palmStrike'],
   stats: {
     stunBuildMult: 0.3,
     stunDurationMult: 0.1,
   },
+  animations: defaultAnimationsForType('palm'),
 };
 
 export const WEAPONS = {
   fist: FIST,
-  palm: PALM,
+  palmWraps: PALM_WRAPS,
   ironSword: toLegacy('ironSword', generateWeapon({ typeKey: 'sword', materialKey: 'iron' })),
   bronzeHammer: toLegacy('bronzeHammer', generateWeapon({ typeKey: 'hammer', materialKey: 'bronze' })),
   elderWand: toLegacy('elderWand', generateWeapon({ typeKey: 'wand', materialKey: 'spiritwood' })),

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -122,7 +122,7 @@ export const defaultState = () => {
   proficiency: {},
 
   equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, food: null }, // EQUIP-CHAR-UI
-  inventory: [],
+  inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
   sessionLoot: [], // EQUIP-CHAR-UI
   flags: { weaponsEnabled: true },
   cultivation: {


### PR DESCRIPTION
## Summary
- Add Palm Strike ability and Palm Wraps weapon
- Include Palm Wraps in starting inventory and migrations

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation)


------
https://chatgpt.com/codex/tasks/task_e_68acb4f45a90832682e0dc837af3008b