### PR TITLE
Fix NaN when applying stun

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -696,7 +696,9 @@ export function startBossCombat() {
     attack: Math.round(h.eAtk),
     armor: Math.round(h.eArmor),
     regen: h.regen,
-    affixes: h.affixes
+    affixes: h.affixes,
+    hpMax: h.enemyMax,
+    hp: h.enemyHP
   };
   initStun(S.adventure.currentEnemy);
   S.adventure.enemyStunBar = S.adventure.currentEnemy.stun.value;
@@ -738,7 +740,9 @@ export function startAdventureCombat() {
     attack: Math.round(h.eAtk),
     armor: Math.round(h.eArmor),
     regen: h.regen,
-    affixes: h.affixes
+    affixes: h.affixes,
+    hpMax: h.enemyMax,
+    hp: h.enemyHP
   };
   initStun(S.adventure.currentEnemy);
   S.adventure.enemyStunBar = S.adventure.currentEnemy.stun.value;

--- a/src/features/combat/attack.js
+++ b/src/features/combat/attack.js
@@ -29,23 +29,9 @@ export function performAttack(attacker, target, options = {}, state) { // STATUS
   }
 
   if (attackIsPhysical) { // STATUS-REFORM
-    const baseGain = (physDamageDealt / target.hpMax) * 100;
-    const buildMult = 1 + (attackerStats.stunBuildMult || 0);
-    const takenMult = 1 - (targetStats.stunBuildTakenReduction || 0);
-    const gain = baseGain * buildMult * takenMult;
-    const before = target.stunBar || 0; // STATUS-REFORM
-    target.stunBar = Math.min(100, before + gain); // STATUS-REFORM
-    console.log(`[stun] bar=${Math.round(before)} → ${Math.round(target.stunBar)} (damage=${physDamageDealt})`); // STATUS-REFORM
-    if (target.stunBar >= 100) { // STATUS-REFORM
-      if (Math.random() >= (targetStats.stunResist || 0)) {
-        console.log('[stun] threshold reached → stunned'); // STATUS-REFORM
-        applyStatus(target, 'stun', 1, state, { attackerStats, targetStats }); // STATUS-REFORM
-      } else {
-        console.log('[stun] resisted'); // STATUS-REFORM
-      }
-      target.stunBar = 0; // STATUS-REFORM
-    }
-    applyStatus(target, 'interrupt', 0.05, state, { attackerStats, targetStats }); // STATUS-REFORM
+    // Stun accumulation is now handled by processAttack/onPhysicalHit.
+    // Keep only interrupt application here to avoid NaN when hpMax is missing.
+    applyStatus(target, 'interrupt', 0.05, state, { attackerStats, targetStats });
   }
 }
 


### PR DESCRIPTION
## Summary
- remove outdated stun-bar calculations from `performAttack`
- ensure enemies track `hp`/`hpMax` so stun math has valid denominators

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68accb588f7483268d052b4d60d691cf