### PR TITLE
feat: add fireball ability and manual

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -35,5 +35,14 @@ export const ABILITIES = {
     castTimeMs: 0,
     tags: ['special']
   },
+  fireball: {
+    key: 'fireball',
+    displayName: 'Fireball',
+    icon: 'game-icons:fireball',
+    costQi: 50,
+    cooldownMs: 0,
+    castTimeMs: 3_000,
+    tags: ['spell', 'fire']
+  },
   // Leave other abilities out until you define them.
 };

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -1,4 +1,5 @@
 import { getEquippedWeapon } from '../inventory/selectors.js';
+import { S } from '../../shared/state.js';
 
 export function resolveAbilityHit(abilityKey, state) {
   switch (abilityKey) {
@@ -6,6 +7,8 @@ export function resolveAbilityHit(abilityKey, state) {
       return resolvePowerSlash(state);
     case 'flowingPalm':
       return resolveFlowingPalm(state);
+    case 'fireball':
+      return resolveFireball(state);
     case 'seventyFive':
       return resolveSeventyFive();
     default:
@@ -29,6 +32,14 @@ function resolvePowerSlash(state) {
   return {
     attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
     healOnHit: 5,
+  };
+}
+
+function resolveFireball(state) {
+  const level = S.mind?.manualProgress?.fireballManual?.level || 0;
+  const damage = 40 + level * 20;
+  return {
+    attack: { amount: damage, type: 'fire', target: state.adventure.currentEnemy },
   };
 }
 

--- a/src/features/mind/data/manuals.js
+++ b/src/features/mind/data/manuals.js
@@ -198,6 +198,27 @@ export const MANUALS = {
       { abilityMods: { flowingPalm: { damagePct: 12, stunPct: 30 } } },
       { abilityMods: { flowingPalm: { damagePct: 15, stunPct: 40 } } },
     ]
+  },
+
+  fireballManual: {
+    id: 'fireballManual',
+    name: 'Fireball Manual',
+    category: 'Casting',
+    xpRate: 0.32,
+    reqLevel: 1,
+    maxLevel: 5,
+    baseTimeSec: 15 * 60,
+    statWeights: { mind: 0.9, agility: 0.6, physique: 0.3 },
+    maxSpeedBoostPct: 400,
+    levelTimeMult: [1, 6, 30, 180, 1800],
+    grantsAbility: 'fireball',
+    effects: [
+      { abilityMods: { fireball: { damagePct: 10, castTimePct: -5 } } },
+      { abilityMods: { fireball: { damagePct: 10, castTimePct: -5 } } },
+      { abilityMods: { fireball: { damagePct: 13, castTimePct: -7 } } },
+      { abilityMods: { fireball: { damagePct: 16, castTimePct: -9 } } },
+      { abilityMods: { fireball: { damagePct: 20, castTimePct: -12 } } },
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- add Fireball ability definition with Qi cost and cast time
- implement resolveFireball using manual level for scaling fire damage
- include Fireball Manual that unlocks the spell and boosts damage while cutting cast time

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68acb546d8488326951eef3058b7fc5e