### PR TITLE
feat: add Lightning Step ability and manual

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -37,6 +37,15 @@ export const ABILITIES = {
     tags: ['martial', 'physical'],
     requiresWeaponType: 'palm',
   },
+  lightningStep: {
+    key: 'lightningStep',
+    displayName: 'Lightning Step',
+    icon: 'game-icons:lightning-dissipation',
+    costQi: 30,
+    cooldownMs: 10_000,
+    castTimeMs: 500,
+    tags: ['lightning', 'buff'],
+  },
   seventyFive: {
     key: 'seventyFive',
     displayName: '75%',

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -8,6 +8,8 @@ export function resolveAbilityHit(abilityKey, state) {
       return resolvePalmStrike(state);
     case 'flowingPalm':
       return resolveFlowingPalm(state);
+    case 'lightningStep':
+      return resolveLightningStep(state);
     case 'seventyFive':
       return resolveSeventyFive();
     default:
@@ -40,6 +42,15 @@ function resolvePalmStrike(state) {
   const raw = Math.round(roll);
   return {
     attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
+  };
+}
+
+function resolveLightningStep(state) {
+  const mods = state.abilityMods?.lightningStep || {};
+  const damagePct = 10 + (mods.damagePct || 0);
+  const dodgePct = 20 + (mods.dodgePct || 0);
+  return {
+    buff: { damagePct, dodgePct, durationMs: 10_000 },
   };
 }
 

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -76,6 +76,24 @@ function applyAbilityResult(abilityKey, res, state) {
       emit('ABILITY:HEAL', { amount: healed });
     }
   }
+  if (res.buff) {
+    const { damagePct = 0, dodgePct = 0, durationMs = 0 } = res.buff;
+    if (damagePct) {
+      const deltaAtk = Math.round((state.atkBase || 0) * damagePct / 100);
+      state.tempAtk = (state.tempAtk || 0) + deltaAtk;
+      setTimeout(() => {
+        state.tempAtk = (state.tempAtk || 0) - deltaAtk;
+      }, durationMs);
+    }
+    if (dodgePct) {
+      const deltaDodge = dodgePct / 100;
+      state.stats.dodge = (state.stats.dodge || 0) + deltaDodge;
+      setTimeout(() => {
+        state.stats.dodge = (state.stats.dodge || 0) - deltaDodge;
+      }, durationMs);
+    }
+    logs?.push(`You are shrouded in lightning, boosting dodge and attack.`);
+  }
   if (res.defeatEnemy) {
     const before = state.adventure.enemyHP || 0;
     state.adventure.enemyHP = 0;

--- a/src/features/mind/data/manuals.js
+++ b/src/features/mind/data/manuals.js
@@ -198,6 +198,27 @@ export const MANUALS = {
       { abilityMods: { flowingPalm: { damagePct: 12, stunPct: 30 } } },
       { abilityMods: { flowingPalm: { damagePct: 15, stunPct: 40 } } },
     ]
+  },
+
+  lightningStepManual: {
+    id: 'lightningStepManual',
+    name: 'Lightning Step Manual',
+    category: 'Movement',
+    xpRate: 0.32,
+    reqLevel: 1,
+    maxLevel: 5,
+    baseTimeSec: 15 * 60,
+    statWeights: { mind: 0.7, agility: 0.9, physique: 0.5 },
+    maxSpeedBoostPct: 400,
+    levelTimeMult: [1, 6, 30, 180, 1800],
+    grantsAbility: 'lightningStep',
+    effects: [
+      { unlockAbility: 'lightningStep', abilityMods: { lightningStep: { damagePct: 10, cooldownPct: -5, dodgePct: -2 } } },
+      { abilityMods: { lightningStep: { damagePct: 10, cooldownPct: -5, dodgePct: -2 } } },
+      { abilityMods: { lightningStep: { damagePct: 12, cooldownPct: -6, dodgePct: -3 } } },
+      { abilityMods: { lightningStep: { damagePct: 15, cooldownPct: -7, dodgePct: -4 } } },
+      { abilityMods: { lightningStep: { damagePct: 18, cooldownPct: -8, dodgePct: -5 } } },
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- add Lightning Step ability that grants a brief dodge and attack buff
- introduce Lightning Step Manual to unlock and scale the ability
- handle ability buff effects and manual-based scaling

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)*

------
https://chatgpt.com/codex/tasks/task_e_68acded3d6c4832690b1c6369f1886c9