### PR TITLE
Add fireball ability visual effect

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -62,6 +62,7 @@ function applyAbilityResult(abilityKey, res, state) {
     const { amount, type, target } = res.attack;
     const dealt = processAttack(amount, { target, type, attacker: state, nowMs: Date.now() }, state);
     logs?.push(`You used ${ability.displayName} for ${dealt} ${type === 'physical' ? 'Physical ' : ''}damage.`);
+    emit('ABILITY:CAST', { abilityKey });
     if (res.stun) {
       const mult = (res.stun.mult || 0) * (1 + (mods?.stunPct || 0) / 100);
       const attackerStats = { ...(state.stats || {}), stunDurationMult: (state.stats?.stunDurationMult || 0) + (mult - 1) };

--- a/src/features/ability/ui.js
+++ b/src/features/ability/ui.js
@@ -1,8 +1,18 @@
 import { on } from '../../shared/events.js';
+import { playFireball, setFxTint } from '../combat/ui/index.js';
 
 export function setupAbilityUI() {
   on('ABILITY:HEAL', ({ amount }) => {
     showHeal(amount);
+  });
+  on('ABILITY:CAST', ({ abilityKey }) => {
+    if (abilityKey === 'fireball') {
+      const pos = getCombatPositions();
+      if (pos) {
+        setFxTint(pos.svg, 'red');
+        playFireball(pos.svg, pos.from, pos.to);
+      }
+    }
   });
 }
 
@@ -17,4 +27,25 @@ function showHeal(amount) {
   note.style.top = rect.top - 20 + 'px';
   document.body.appendChild(note);
   setTimeout(() => note.remove(), 1000);
+}
+
+function getCombatPositions() {
+  const svg = document.getElementById('combatFx');
+  const playerEl = document.querySelector('.combatant.player');
+  const enemyEl = document.querySelector('.combatant.enemy');
+  if (!svg || !playerEl || !enemyEl) return null;
+  const rect = svg.getBoundingClientRect();
+  if (!rect || rect.width === 0 || rect.height === 0) return null;
+  const pRect = playerEl.getBoundingClientRect();
+  const eRect = enemyEl.getBoundingClientRect();
+  const from = {
+    x: ((pRect.right - rect.left) / rect.width) * 100,
+    y: ((pRect.top + pRect.height / 2 - rect.top) / rect.height) * 50,
+  };
+  const to = {
+    x: ((eRect.left - rect.left) / rect.width) * 100,
+    y: ((eRect.top + eRect.height / 2 - rect.top) / rect.height) * 50,
+  };
+  if (!Number.isFinite(from.x) || !Number.isFinite(from.y) || !Number.isFinite(to.x) || !Number.isFinite(to.y)) return null;
+  return { svg, from, to };
 }

--- a/src/features/combat/ui/fx.js
+++ b/src/features/combat/ui/fx.js
@@ -64,13 +64,16 @@ export function playThrustLine(svg, from, to) {
   spawn(svg, line, 300);
 }
 
-export function playRingShockwave(svg, center, radius = 20) {
+export function playRingShockwave(svg, center, radius = 20, gradientId) {
   const circle = document.createElementNS(NS, 'circle');
   circle.setAttribute('cx', center.x);
   circle.setAttribute('cy', center.y);
   circle.setAttribute('r', 0);
   circle.style.setProperty('--fx-radius', radius);
   circle.classList.add('fx-ring');
+  if (gradientId) {
+    circle.style.stroke = `url(#${gradientId})`;
+  }
   spawn(svg, circle, 600);
 }
 
@@ -126,6 +129,11 @@ export function playChakram(svg, from, to) {
   } else if (svg.contains(g)) {
     svg.removeChild(g);
   }
+}
+
+export function playFireball(svg, from, to) {
+  playBeam(svg, from, to);
+  setTimeout(() => playRingShockwave(svg, to, 8, 'elem-fire'), 350);
 }
 
 export function playShieldDome(svg, center, radius = 25) {


### PR DESCRIPTION
## Summary
- add `playFireball` SVG effect for combat visuals with fire-colored impact ring
- emit ability cast events from mutators
- trigger fireball FX when casting Fireball ability

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation, DOM usage)


------
https://chatgpt.com/codex/tasks/task_e_68addfaadf2c832695884aca5ba72392