### PR TITLE
Add Lightning Step ability and scaling manual

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -55,5 +55,14 @@ export const ABILITIES = {
     castTimeMs: 3_000,
     tags: ['spell', 'fire']
   },
+  lightningStep: {
+    key: 'lightningStep',
+    displayName: 'Lightning Step',
+    icon: 'game-icons:lightning',
+    costQi: 30,
+    cooldownMs: 30_000,
+    castTimeMs: 500,
+    tags: ['buff', 'metal']
+  },
   // Leave other abilities out until you define them.
 };

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -11,6 +11,8 @@ export function resolveAbilityHit(abilityKey, state) {
       return resolveFlowingPalm(state);
     case 'fireball':
       return resolveFireball(state);
+    case 'lightningStep':
+      return resolveLightningStep(state);
     case 'seventyFive':
       return resolveSeventyFive();
     default:
@@ -53,6 +55,18 @@ function resolvePalmStrike(state) {
   return {
     attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
   };
+}
+
+function resolveLightningStep(state) {
+  const level = S.mind?.manualProgress?.lightningStepManual?.level || 0;
+  const durationMs = 10_000 + level * 1_000;
+  const damageMult = 1.3 + level * 0.05;
+  state.lightningStep = {
+    attackSpeedMult: 1.2,
+    damageMult,
+    expiresAt: Date.now() + durationMs,
+  };
+  return {};
 }
 
 function resolveSeventyFive() {

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -118,4 +118,7 @@ function applyAbilityResult(abilityKey, res, state) {
       state.qi = state.qiMax || state.qi || 0;
     }
   }
+  if (abilityKey === 'lightningStep') {
+    emit('ABILITY:FX', { abilityKey });
+  }
 }

--- a/src/features/mind/data/manuals.js
+++ b/src/features/mind/data/manuals.js
@@ -219,6 +219,27 @@ export const MANUALS = {
       { abilityMods: { fireball: { damagePct: 16, castTimePct: -9 } } },
       { abilityMods: { fireball: { damagePct: 20, castTimePct: -12 } } },
     ]
+  },
+
+  lightningStepManual: {
+    id: 'lightningStepManual',
+    name: 'Lightning Step Manual',
+    category: 'Combat',
+    xpRate: 0.33,
+    reqLevel: 1,
+    maxLevel: 5,
+    baseTimeSec: 15 * 60,
+    statWeights: { mind: 0.7, agility: 0.7, physique: 0.4 },
+    maxSpeedBoostPct: 400,
+    levelTimeMult: [1, 6, 30, 180, 1800],
+    grantsAbility: 'lightningStep',
+    effects: [
+      { unlockAbility: 'lightningStep' },
+      {},
+      {},
+      {},
+      {}
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- introduce Lightning Step ability with buffed attack speed and metal damage
- add Lightning Step Manual to unlock and scale the new ability
- hook ability into combat, cooldown, and special FX system

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI verification protocol violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ade5c813848326a033dc9ce6522ee3