### PR TITLE
feat: redesign manuals tab

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,6 +23,10 @@
   --tabs-h: 48px;
   --safe-bottom: env(safe-area-inset-bottom,0px);
   --float-pad: 0px;
+  --card-pad: 12px;
+  --card-gap: 8px;
+  --dot-size: 8px;
+  --row-h: 48px;
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
   --mortal-primary: #a66c4c; /* lighter saddle brown */
@@ -4389,6 +4393,51 @@ tr:last-child td {
   .combat-controls{gap:8px;}
   .combat-controls .btn{flex:1;font-size:0.85rem;padding:6px 8px;min-width:0;}
 }
+
+/* Queue bar and manual cards */
+.queue-bar{
+  position:sticky;
+  top:0;
+  z-index:50;
+  display:flex;
+  align-items:center;
+  gap:var(--card-gap);
+  padding:var(--card-pad);
+  background:var(--panel);
+  overflow-x:auto;
+}
+.queue-bar .queue-chips{display:flex;gap:var(--card-gap);flex:1;}
+.queue-chip{
+  display:flex;
+  align-items:center;
+  gap:4px;
+  padding:4px 8px;
+  border:none;
+  border-radius:999px;
+  background:var(--accent-2);
+  color:#000;
+  white-space:nowrap;
+  cursor:pointer;
+}
+.queue-chip iconify-icon{font-size:1rem;}
+.manuals-list{display:flex;flex-direction:column;gap:var(--card-gap);}
+.manual-card{background:var(--panel);border:1px solid rgba(45,37,32,0.35);border-radius:12px;overflow:hidden;}
+.manual-card-header{
+  display:flex;align-items:center;width:100%;
+  padding:var(--card-pad);gap:var(--card-gap);
+  background:none;border:none;text-align:left;cursor:pointer;
+  min-height:var(--row-h);
+}
+.manual-card-header:focus{outline:2px solid var(--accent);}
+.manual-card-header .name{flex:1;}
+.level-info{display:flex;flex-direction:column;align-items:flex-end;gap:2px;}
+.level-dots{display:flex;gap:2px;}
+.level-dots .dot{width:var(--dot-size);height:var(--dot-size);border-radius:50%;background:var(--muted);}
+.level-dots .dot.filled{background:var(--accent);}
+.progress-pill{width:48px;height:4px;background:rgba(0,0,0,0.2);border-radius:2px;overflow:hidden;}
+.progress-pill>div{height:100%;background:var(--accent);}
+ .manual-card-body{padding:var(--card-pad);border-top:1px solid rgba(45,37,32,0.2);display:flex;flex-direction:column;gap:8px;}
+ .manual-card-body .manual-actions{display:flex;gap:8px;margin-top:4px;}
 @media (prefers-reduced-motion:reduce){
   #sidebar{transition:none;}
   .drawer-scrim{transition:none;}


### PR DESCRIPTION
## Summary
- add sticky queue bar summarizing active manual reading
- render manuals as compact collapsible cards with level dots and progress pills
- expose add-to-queue action and custom CSS variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ade83889b88326867e13ec5fed5bf2