### PR TITLE
Show ability damage on cards

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -3,7 +3,7 @@ import { calculatePlayerCombatAttack, calculatePlayerAttackRate, qCap } from '..
 import { initializeFight, processAttack } from '../combat/mutators.js';
 import { refillShieldFromQi, ARMOR_K, ARMOR_CAP } from '../combat/logic.js';
 import { getEquippedWeapon } from '../inventory/selectors.js';
-import { getAbilitySlots } from '../ability/selectors.js';
+import { getAbilitySlots, getAbilityDamage } from '../ability/selectors.js';
 import { rollLoot, toLootTableKey } from '../loot/logic.js'; // WEAPONS-INTEGRATION
 import { WEAPONS } from '../weaponGeneration/data/weapons.js'; // WEAPONS-INTEGRATION
 import { rollGearDropForZone } from '../gearGeneration/selectors.js';
@@ -289,8 +289,13 @@ export function updateAbilityBar() {
     card.dataset.slot = i + 1;
     if (slot.abilityKey) {
       const def = ABILITIES[slot.abilityKey];
+      const dmg = getAbilityDamage(slot.abilityKey, S);
+      const dmgLine = dmg !== null ? `<div class="ability-damage">${dmg}</div>` : '';
       card.innerHTML = `
-        <div class="ability-name">${def.displayName}</div>
+        <div class="ability-title">
+          <div class="ability-name">${def.displayName}</div>
+          ${dmgLine}
+        </div>
         <div class="ability-icon">${iconMap[def.icon] || def.icon}</div>
         <div class="qi-badge">${def.costQi} Qi</div>
         <div class="keybind">[${i + 1}]</div>

--- a/style.css
+++ b/style.css
@@ -4258,6 +4258,8 @@ tr:last-child td {
 .ability-bar { display:flex; gap:4px; }
 .ability-card { width:60px; height:90px; background:var(--panel); border:1px solid var(--ink-light); border-radius:4px; position:relative; padding:2px; display:flex; flex-direction:column; align-items:center; justify-content:space-between; }
 .ability-card .ability-name { font-size:10px; text-align:center; }
+.ability-card .ability-title { display:flex; flex-direction:column; align-items:center; }
+.ability-card .ability-damage { font-size:10px; }
 .ability-card .ability-icon { font-size:24px; }
 .ability-card .qi-badge { position:absolute; bottom:12px; right:2px; font-size:10px; background:var(--panel); padding:1px 3px; border-radius:3px; }
 .ability-card .keybind { font-size:10px; }


### PR DESCRIPTION
## Summary
- compute current ability damage and expose via selector
- render ability damage under name on ability cards
- style ability cards to include damage display

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: validation enforcement)*

------
https://chatgpt.com/codex/tasks/task_e_68ade6120b608326bdcd29106c84f841