### PR TITLE
Ensure cultivation stage updates after breakthrough

### DIFF
--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -11,7 +11,7 @@ import {
   powerMult,
   breakthroughChance
 } from '../selectors.js';
-import { advanceRealm, checkLawUnlocks, awardLawPoints } from '../mutators.js';
+import { advanceRealm } from '../mutators.js';
 import { qs, setText, log } from '../../../shared/utils/dom.js';
 
 export function getRealmName(tier) {
@@ -428,7 +428,7 @@ export function updateBreakthrough() {
     if(Math.random() < ch) {
       S.qi = 0;
       S.foundation = 0;
-      const info = advanceRealm();
+      const info = advanceRealm(S);
       log('Breakthrough succeeded! Realm advanced.', 'good');
       showBreakthroughResult(true, info);
     } else {


### PR DESCRIPTION
## Summary
- Fix breakthrough handler to advance the realm using global state so the cultivation stage updates correctly
- Clean up unused imports in realm UI

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68ade689bd908326b57b971be96340a6