### PR TITLE
Display manual details in popup

### DIFF
--- a/src/features/mind/ui/mindReadingTab.js
+++ b/src/features/mind/ui/mindReadingTab.js
@@ -59,27 +59,33 @@ function levelDots(current, max) {
   return html;
 }
 
-function isMobile() {
-  return window.matchMedia('(max-width: 767px)').matches;
-}
+function showManualPopup(manual, S) {
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  overlay.innerHTML = `
+    <div class="modal-backdrop"></div>
+    <div class="modal-content card">
+      <div class="card-header">
+        <h4>${manual.name}</h4>
+        <button class="btn small ghost close-btn">×</button>
+      </div>
+      <div class="manual-meta">${manual.category} • Req Level ${manual.reqLevel}</div>
+      ${renderSpeedInfo(manual, S.stats)}
+      ${renderEffects(manual)}
+      <div class="manual-actions">
+        <button class="btn small add-btn">Add to Queue</button>
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
 
-let expandedCard = null;
-
-function expandCard(card) {
-  const header = card.querySelector('.manual-card-header');
-  const body = card.querySelector('.manual-card-body');
-  const expanded = header.getAttribute('aria-expanded') === 'true';
-  if (isMobile() && !expanded) {
-    if (expandedCard && expandedCard !== card) {
-      const h = expandedCard.querySelector('.manual-card-header');
-      const b = expandedCard.querySelector('.manual-card-body');
-      h.setAttribute('aria-expanded', 'false');
-      b.hidden = true;
-    }
-    expandedCard = card;
-  }
-  header.setAttribute('aria-expanded', String(!expanded));
-  body.hidden = expanded;
+  const close = () => overlay.remove();
+  overlay.querySelector('.close-btn').addEventListener('click', close);
+  overlay.querySelector('.modal-backdrop').addEventListener('click', close);
+  overlay.querySelector('.add-btn').addEventListener('click', e => {
+    e.stopPropagation();
+    emit('mind/manuals/startReading', { root: S, manualId: manual.id });
+    close();
+  });
 }
 
 function createManualCard(manual, S) {
@@ -89,43 +95,19 @@ function createManualCard(manual, S) {
   const needed = manual.baseTimeSec * manual.levelTimeMult[level] * manual.xpRate;
   const ratio = maxed ? 1 : Math.min(rec.xp / needed, 1);
 
-  const card = document.createElement('div');
+  const card = document.createElement('button');
   card.className = 'manual-card';
   card.id = `manual-${manual.id}`;
-
-  const header = document.createElement('button');
-  header.className = 'manual-card-header';
-  header.setAttribute('aria-expanded', 'false');
-  header.setAttribute('aria-controls', `body-${manual.id}`);
-  header.innerHTML = `
-    <iconify-icon icon="iconoir:book" aria-hidden="true"></iconify-icon>
-    <span class="name">${manual.name}</span>
-    <span class="level-info">
+  card.innerHTML = `
+    <div class="manual-card-header">
+      <iconify-icon icon="iconoir:book" aria-hidden="true"></iconify-icon>
+      <span class="name">${manual.name}</span>
+    </div>
+    <div class="manual-card-level">
       <span class="level-dots">${levelDots(level, manual.maxLevel)}</span>
       <span class="progress-pill"><div style="width:${(ratio * 100).toFixed(1)}%"></div></span>
-    </span>`;
-  card.appendChild(header);
-
-  const body = document.createElement('div');
-  body.className = 'manual-card-body';
-  body.id = `body-${manual.id}`;
-  body.hidden = true;
-  body.innerHTML = `
-    <div class="manual-meta">${manual.category} • Req Level ${manual.reqLevel}</div>
-    ${renderSpeedInfo(manual, S.stats)}
-    ${renderEffects(manual)}
-    <div class="manual-actions">
-      <button class="btn small add-btn">Add to Queue</button>
     </div>`;
-  card.appendChild(body);
-
-  header.addEventListener('click', () => expandCard(card));
-
-  const addBtn = body.querySelector('.add-btn');
-  addBtn.addEventListener('click', e => {
-    e.stopPropagation();
-    emit('mind/manuals/startReading', { root: S, manualId: manual.id });
-  });
+  card.addEventListener('click', () => showManualPopup(manual, S));
 
   return card;
 }
@@ -190,13 +172,12 @@ export function renderMindReadingTab(rootEl, S) {
   if (!rootEl) return;
   rootEl.innerHTML = '';
 
-  const cardMap = new Map();
+  const manualMap = new Map();
 
   function focusManual(id) {
-    const card = cardMap.get(id);
-    if (card) {
-      expandCard(card);
-      card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const manual = manualMap.get(id);
+    if (manual) {
+      showManualPopup(manual, S);
     }
   }
 
@@ -209,7 +190,7 @@ export function renderMindReadingTab(rootEl, S) {
   for (const m of listManuals()) {
     const card = createManualCard(m, S);
     list.appendChild(card);
-    cardMap.set(m.id, card);
+    manualMap.set(m.id, m);
   }
 
   rootEl.appendChild(list);

--- a/style.css
+++ b/style.css
@@ -4420,17 +4420,16 @@ tr:last-child td {
   cursor:pointer;
 }
 .queue-chip iconify-icon{font-size:1rem;}
-.manuals-list{display:flex;flex-direction:column;gap:var(--card-gap);}
-.manual-card{background:var(--panel);border:1px solid rgba(45,37,32,0.35);border-radius:12px;overflow:hidden;}
+.manuals-list{display:flex;flex-wrap:wrap;gap:var(--card-gap);}
+.manual-card{background:var(--panel);border:1px solid rgba(45,37,32,0.35);border-radius:12px;overflow:hidden;flex:0 0 calc(25% - var(--card-gap));max-width:calc(25% - var(--card-gap));display:flex;flex-direction:column;justify-content:space-between;height:120px;font-size:.5rem;padding:0;cursor:pointer;}
+.manual-card iconify-icon{font-size:1rem;}
 .manual-card-header{
   display:flex;align-items:center;width:100%;
   padding:var(--card-pad);gap:var(--card-gap);
-  background:none;border:none;text-align:left;cursor:pointer;
-  min-height:var(--row-h);
+  background:none;border:none;text-align:left;
 }
-.manual-card-header:focus{outline:2px solid var(--accent);}
-.manual-card-header .name{flex:1;}
-.level-info{display:flex;flex-direction:column;align-items:flex-end;gap:2px;}
+.manual-card-header .name{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
+.manual-card-level{padding:var(--card-pad);display:flex;flex-direction:column;gap:2px;}
 .level-dots{display:flex;gap:2px;}
 .level-dots .dot{width:var(--dot-size);height:var(--dot-size);border-radius:50%;background:var(--muted);}
 .level-dots .dot.filled{background:var(--accent);}


### PR DESCRIPTION
## Summary
- Show manual info in a modal when clicking a manual card
- Arrange manual cards in a compact grid with smaller widths
- Shrink manual card text and move level indicators to the bottom for uniform cards

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2607643083269e61134a433f6d92