### PR TITLE
feat: color-coded manual categories

### DIFF
--- a/src/features/mind/data/manuals.js
+++ b/src/features/mind/data/manuals.js
@@ -22,7 +22,7 @@ export const MANUALS = {
   footworkFundamentals: {
     id: 'footworkFundamentals',
     name: 'Footwork Fundamentals',
-    category: 'Movement',
+    category: 'Agility',
     xpRate: 0.32,
     reqLevel: 1,
     maxLevel: 5,
@@ -42,7 +42,7 @@ export const MANUALS = {
   focusedChannelingI: {
     id: 'focusedChannelingI',
     name: 'Focused Channeling I',
-    category: 'Casting',
+    category: 'Spells',
     xpRate: 0.30,
     reqLevel: 1,
     maxLevel: 5,
@@ -142,7 +142,7 @@ export const MANUALS = {
   ironFistTreatiseI: {
     id: 'ironFistTreatiseI',
     name: 'Iron Fist Treatise I',
-    category: 'Combat',
+    category: 'Physique',
     xpRate: 0.32,
     reqLevel: 1,
     maxLevel: 5,
@@ -182,7 +182,7 @@ export const MANUALS = {
   flowingPalmManual: {
     id: 'flowingPalmManual',
     name: 'Flowing Palm Manual',
-    category: 'Combat',
+    category: 'Agility',
     xpRate: 0.31,
     reqLevel: 1,
     maxLevel: 5,
@@ -203,7 +203,7 @@ export const MANUALS = {
   fireballManual: {
     id: 'fireballManual',
     name: 'Fireball Manual',
-    category: 'Casting',
+    category: 'Spells',
     xpRate: 0.32,
     reqLevel: 1,
     maxLevel: 5,
@@ -224,7 +224,7 @@ export const MANUALS = {
   lightningStepManual: {
     id: 'lightningStepManual',
     name: 'Lightning Step Manual',
-    category: 'Combat',
+    category: 'Agility',
     xpRate: 0.33,
     reqLevel: 1,
     maxLevel: 5,

--- a/src/features/mind/ui/mindReadingTab.js
+++ b/src/features/mind/ui/mindReadingTab.js
@@ -13,6 +13,17 @@ const EFFECT_LABELS = {
   qiCostPct: 'Qi Cost',
 };
 
+const CATEGORY_INFO = {
+  Cultivation: { color: '#399e34', icon: 'solar:meditation-round-linear' },
+  Qi: { color: '#0ea5e9', icon: 'arcticons:meditation-timer-and-log' },
+  Spells: { color: '#7c3aed', icon: 'game-icons:fire-spell-cast' },
+  Defense: { color: '#6b7280', icon: 'stash:shield-duotone' },
+  Mind: { color: '#3b82f6', icon: 'mdi:brain' },
+  Agility: { color: '#16a34a', icon: 'icon-park-outline:foot' },
+  Physique: { color: '#dc2626', icon: 'hugeicons:body-part-muscle' },
+  'Life Skills': { color: '#8b7f75', icon: 'mdi:heart-outline' },
+};
+
 function cap(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
@@ -96,11 +107,13 @@ function createManualCard(manual, S) {
   const ratio = maxed ? 1 : Math.min(rec.xp / needed, 1);
 
   const card = document.createElement('button');
+  const info = CATEGORY_INFO[manual.category] || {};
   card.className = 'manual-card';
   card.id = `manual-${manual.id}`;
+  card.style.setProperty('--cat-color', info.color || '#8b7f75');
   card.innerHTML = `
     <div class="manual-card-header">
-      <iconify-icon icon="iconoir:book" aria-hidden="true"></iconify-icon>
+      <iconify-icon icon="${info.icon || 'iconoir:book'}" aria-hidden="true"></iconify-icon>
       <span class="name">${manual.name}</span>
     </div>
     <div class="manual-card-level">

--- a/style.css
+++ b/style.css
@@ -4423,8 +4423,8 @@ tr:last-child td {
 }
 .queue-chip iconify-icon{font-size:1rem;}
 .manuals-list{display:flex;flex-wrap:wrap;gap:var(--card-gap);}
-.manual-card{background:var(--panel);border:1px solid rgba(45,37,32,0.35);border-radius:12px;overflow:hidden;flex:0 0 calc(25% - var(--card-gap));max-width:calc(25% - var(--card-gap));display:flex;flex-direction:column;justify-content:space-between;height:120px;font-size:.5rem;padding:0;cursor:pointer;}
-.manual-card iconify-icon{font-size:1rem;}
+.manual-card{background:var(--panel);border:1px solid rgba(45,37,32,0.35);border-left:4px solid var(--cat-color,rgba(45,37,32,0.35));border-radius:12px;overflow:hidden;flex:0 0 calc(25% - var(--card-gap));max-width:calc(25% - var(--card-gap));display:flex;flex-direction:column;justify-content:space-between;height:120px;font-size:.5rem;padding:0;cursor:pointer;}
+.manual-card iconify-icon{font-size:1rem;color:var(--cat-color,inherit);}
 .manual-card-header{
   display:flex;align-items:center;width:100%;
   padding:var(--card-pad);gap:var(--card-gap);


### PR DESCRIPTION
## Summary
- standardize manual categories and update existing manual data
- show manual category icons and colors on manual cards
- style manual cards with category-specific borders and icon colors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ae38313cd0832680e4dfa355a9bf4e