### PR TITLE
feat: show palm icon for palm attack

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -31,6 +31,7 @@ import {
   playChakram,
   playShieldDome,
   playSparkBurst,
+  playPalmHit,
   setFxTint,
   showFloatingText
 } from '../combat/ui/index.js';
@@ -433,8 +434,10 @@ export function updateAdventureCombat() {
                 playSlashArc(pos.svg, pos.from, pos.to);
                 break;
               case 'pierceThrust':
-              case 'palmStrike':
                 playThrustLine(pos.svg, pos.from, pos.to);
+                break;
+              case 'palmStrike':
+                playPalmHit(pos.svg, pos.to);
                 break;
               case 'smash':
                 playRingShockwave(pos.svg, pos.to, 20);

--- a/src/features/combat/ui/fx.js
+++ b/src/features/combat/ui/fx.js
@@ -64,6 +64,23 @@ export function playThrustLine(svg, from, to) {
   spawn(svg, line, 300);
 }
 
+export function playPalmHit(svg, at) {
+  // Display a palm emoji at the target location
+  const valid = (
+    svg && at &&
+    Number.isFinite(at.x) && Number.isFinite(at.y)
+  );
+  if (!valid) return;
+  const text = document.createElementNS(NS, 'text');
+  text.setAttribute('x', String(at.x));
+  text.setAttribute('y', String(at.y));
+  text.setAttribute('text-anchor', 'middle');
+  text.setAttribute('dominant-baseline', 'middle');
+  text.textContent = '🖐️';
+  text.classList.add('fx-palm');
+  spawn(svg, text, 300);
+}
+
 export function playRingShockwave(svg, center, radius = 20) {
   const circle = document.createElementNS(NS, 'circle');
   circle.setAttribute('cx', center.x);

--- a/style.css
+++ b/style.css
@@ -4187,6 +4187,7 @@ tr:last-child td {
 .fx-stroke{stroke-width:2;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .35s linear forwards}
 .fx-thrust{stroke-width:2;stroke-dasharray:60;stroke-dashoffset:60;animation:fx-draw .25s linear forwards}
 .fx-beam{stroke-width:3;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .4s linear forwards}
+.fx-palm{font-size:10px;transform-box:fill-box;transform-origin:center;animation:fx-palm .3s ease-out forwards}
 .fx-ring{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-width:4;animation:fx-ring .5s ease-out forwards}
 .fx-shield{fill:rgba(255,255,255,.15);stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-width:2;animation:fx-shield .6s ease-out forwards}
 .fx-rotate{animation:fx-rotate .6s linear}
@@ -4195,6 +4196,7 @@ tr:last-child td {
 @keyframes fx-ring{to{r:var(--fx-radius);opacity:0}}
 @keyframes fx-shield{from{r:0;opacity:.6}to{r:var(--fx-radius);opacity:0}}
 @keyframes fx-rotate{to{transform:rotate(360deg)}}
+@keyframes fx-palm{to{opacity:0;transform:scale(1.5)}}
 /* Debug console */
 .debug-console {
   position: fixed;


### PR DESCRIPTION
## Summary
- add palm emoji hit effect for palm-style attacks
- wire palm strike attacks to use the palm hit effect
- style palm hit animation

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation messages)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68ae38dd6cb883269eb4a250944f8d6d