### PR TITLE
feat: show palm icon effect

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -26,6 +26,7 @@ import { updateLootTab } from '../loot/ui/lootTab.js';
 import {
   playSlashArc,
   playThrustLine,
+  playPalmHit,
   playRingShockwave,
   playBeam,
   playChakram,
@@ -449,8 +450,10 @@ export function updateAdventureCombat() {
                 playSlashArc(pos.svg, pos.from, pos.to);
                 break;
               case 'pierceThrust':
-              case 'palmStrike':
                 playThrustLine(pos.svg, pos.from, pos.to);
+                break;
+              case 'palmStrike':
+                playPalmHit(pos.svg, pos.to);
                 break;
               case 'smash':
                 playRingShockwave(pos.svg, pos.to, 20);

--- a/src/features/combat/ui/fx.js
+++ b/src/features/combat/ui/fx.js
@@ -64,6 +64,23 @@ export function playThrustLine(svg, from, to) {
   spawn(svg, line, 300);
 }
 
+export function playPalmHit(svg, at) {
+  const valid = svg && at && Number.isFinite(at.x) && Number.isFinite(at.y);
+  if (!valid) return;
+  const parent = svg.parentNode;
+  if (!parent || reduceMotion || active >= MAX_FX) return;
+  const icon = document.createElement('iconify-icon');
+  icon.setAttribute('icon', 'ph:hand-palm-fill');
+  icon.setAttribute('aria-hidden', 'true');
+  icon.classList.add('fx-palm-hit');
+  icon.style.left = `calc(${at.x}% - 12px)`;
+  icon.style.top = `calc(${at.y}% - 12px)`;
+  icon.style.fontSize = '24px';
+  const color = getComputedStyle(svg).getPropertyValue('--fx-b');
+  if (color) icon.style.color = color;
+  spawn(parent, icon, 400);
+}
+
 export function playRingShockwave(svg, center, radius = 20) {
   const circle = document.createElementNS(NS, 'circle');
   circle.setAttribute('cx', center.x);

--- a/style.css
+++ b/style.css
@@ -4191,11 +4191,13 @@ tr:last-child td {
 .fx-shield{fill:rgba(255,255,255,.15);stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-width:2;animation:fx-shield .6s ease-out forwards}
 .fx-rotate{animation:fx-rotate .6s linear}
 .fx-fireball{fill:url(#elem-fire);filter:url(#soft-glow)}
+.fx-palm-hit{position:absolute;pointer-events:none;color:var(--fx-b);filter:url(#soft-glow);animation:fx-palm-hit .4s ease-out forwards}
 
 @keyframes fx-draw{to{stroke-dashoffset:0;opacity:0}}
 @keyframes fx-ring{to{r:var(--fx-radius);opacity:0}}
 @keyframes fx-shield{from{r:0;opacity:.6}to{r:var(--fx-radius);opacity:0}}
 @keyframes fx-rotate{to{transform:rotate(360deg)}}
+@keyframes fx-palm-hit{to{transform:scale(1.5);opacity:0}}
 /* Debug console */
 .debug-console {
   position: fixed;


### PR DESCRIPTION
## Summary
- replace palm attack effect with palm icon hit using Iconify
- add palm hit combat FX and animation styling
- handle palm strike FX in adventure logic

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation and AI changes blocked)*
- `npm run lint:balance`

------
https://chatgpt.com/codex/tasks/task_e_68ae53c762bc8326ae3973822c812303