### PR TITLE
feat: add sprite stage battle layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -458,39 +458,9 @@
             
             <div class="battle-area" id="battleArea">
               <div class="area-background" id="areaBackground"></div>
-
-              <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
-                <defs>
-                  <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
-                    <feGaussianBlur stdDeviation="2" result="blur" />
-                    <feMerge>
-                      <feMergeNode in="blur" />
-                      <feMergeNode in="SourceGraphic" />
-                    </feMerge>
-                  </filter>
-                  <linearGradient id="fx-gradient" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="var(--fx-a, #fff)" />
-                    <stop offset="100%" stop-color="var(--fx-b, #fff)" />
-                  </linearGradient>
-                  <linearGradient id="elem-fire" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="#ff9a00" />
-                    <stop offset="100%" stop-color="#ff0000" />
-                  </linearGradient>
-                  <linearGradient id="elem-ice" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="#00c6ff" />
-                    <stop offset="100%" stop-color="#0072ff" />
-                  </linearGradient>
-                  <symbol id="rune-circle" viewBox="0 0 100 100">
-                    <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="6" />
-                  </symbol>
-                  <symbol id="shockwave-ring" viewBox="0 0 100 100">
-                    <circle cx="50" cy="50" r="45" fill="none" stroke="currentColor" stroke-width="10" />
-                  </symbol>
-                </defs>
-              </svg>
-
-              <div class="combat-display">
-                <div class="combatant player">
+              <!-- Compact HUD Bars -->
+              <div class="compact-hud">
+                <div class="hud player">
                   <div class="combatant-name">You</div>
                   <div class="health-bar">
                     <div class="health-fill" id="playerHealthFill"></div>
@@ -514,16 +484,8 @@
                     <div class="qi-fill" id="playerQiFill"></div>
                     <span class="qi-text" id="playerQiText">0/0</span>
                   </div>
-                  <div class="combat-stats">
-                    <span>ATK: <span id="playerAttack">10</span></span>
-                    <span>Rate: <span id="playerAttackRate">1.0/s</span></span>
-                    <span title="Physical mitigation versus the strongest enemy in this zone">Mit: <span id="playerMitigation">0%</span></span>
-                  </div>
                 </div>
-                
-                <div class="combat-vs">VS</div>
-                
-                <div class="combatant enemy">
+                <div class="hud enemy">
                   <div class="enemy-affixes" id="enemyAffixes"></div>
                   <div class="combatant-name" id="enemyName">Select an area to begin</div>
                   <div class="stun-bar" id="enemyStunBar" title="Gauge: 0\nThreshold: 100\nDecay: 6/s">
@@ -538,11 +500,42 @@
                     <div class="qi-fill" id="enemyQiFill"></div>
                     <span class="qi-text" id="enemyQiText">--</span>
                   </div>
-                  <div class="combat-stats">
-                    <span>ATK: <span id="enemyAttack">--</span></span>
-                    <span>Rate: <span id="enemyAttackRate">--/s</span></span>
-                  </div>
                 </div>
+              </div>
+
+              <!-- Sprite Stage -->
+              <div class="sprite-stage" id="spriteStage">
+                <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
+                  <defs>
+                    <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
+                      <feGaussianBlur stdDeviation="2" result="blur" />
+                      <feMerge>
+                        <feMergeNode in="blur" />
+                        <feMergeNode in="SourceGraphic" />
+                      </feMerge>
+                    </filter>
+                    <linearGradient id="fx-gradient" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="var(--fx-a, #fff)" />
+                      <stop offset="100%" stop-color="var(--fx-b, #fff)" />
+                    </linearGradient>
+                    <linearGradient id="elem-fire" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="#ff9a00" />
+                      <stop offset="100%" stop-color="#ff0000" />
+                    </linearGradient>
+                    <linearGradient id="elem-ice" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="#00c6ff" />
+                      <stop offset="100%" stop-color="#0072ff" />
+                    </linearGradient>
+                    <symbol id="rune-circle" viewBox="0 0 100 100">
+                      <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="6" />
+                    </symbol>
+                    <symbol id="shockwave-ring" viewBox="0 0 100 100">
+                      <circle cx="50" cy="50" r="45" fill="none" stroke="currentColor" stroke-width="10" />
+                    </symbol>
+                  </defs>
+                </svg>
+                <div class="player-sprite" id="playerSprite" aria-label="Player"></div>
+                <div class="enemy-sprite" id="enemySprite" aria-label="Enemy"></div>
               </div>
 
               <!-- Combat Actions -->

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -52,8 +52,8 @@ function logEnemyResists(enemy) {
 
 function getCombatPositions() {
   const svg = document.getElementById('combatFx');
-  const playerEl = document.querySelector('.combatant.player');
-  const enemyEl = document.querySelector('.combatant.enemy');
+  const playerEl = document.querySelector('.player-sprite');
+  const enemyEl = document.querySelector('.enemy-sprite');
   if (!svg || !playerEl || !enemyEl) return null;
   const rect = svg.getBoundingClientRect();
   // If SVG hasn't been laid out yet, its rect can be 0x0 which would cause NaN (0/0)
@@ -86,9 +86,9 @@ on('ABILITY:FX', ({ abilityKey }) => {
     const pos = getCombatPositions();
     if (pos) {
       const svgRect = pos.svg.getBoundingClientRect();
-      const hpBar = document.querySelector('.combatant.enemy .health-bar');
-      if (hpBar) {
-        const hpRect = hpBar.getBoundingClientRect();
+      const enemySprite = document.querySelector('.enemy-sprite');
+      if (enemySprite) {
+        const hpRect = enemySprite.getBoundingClientRect();
         const to = {
           x: ((hpRect.left + hpRect.width / 2 - svgRect.left) / svgRect.width) * 100,
           y: ((hpRect.top + hpRect.height / 2 - svgRect.top) / svgRect.height) * 50,
@@ -102,7 +102,7 @@ on('ABILITY:FX', ({ abilityKey }) => {
 
 // Subtle red-and-break visual on death
 function triggerDeathBreak(target) {
-  const sel = target === 'enemy' ? '.combatant.enemy' : '.combatant.player';
+  const sel = target === 'enemy' ? '.enemy-sprite' : '.player-sprite';
   const el = document.querySelector(sel);
   if (!el) return;
   el.classList.add('death-break');
@@ -435,9 +435,9 @@ export function updateAdventureCombat() {
         gainProficiencyFromEnemy(weapon.proficiencyKey, S.adventure.enemyMaxHP, S); // WEAPONS-INTEGRATION
         S.adventure.combatLog = S.adventure.combatLog || [];
         S.adventure.combatLog.push(`You deal ${dealt} damage to ${S.adventure.currentEnemy.name}`);
-        const enemyBar = document.querySelector('.combatant.enemy .health-bar');
-        if (enemyBar) {
-          showFloatingText({ targetEl: enemyBar, result: isCrit ? 'crit' : 'hit', amount: dealt });
+        const enemySprite = document.querySelector('.enemy-sprite');
+        if (enemySprite) {
+          showFloatingText({ targetEl: enemySprite, result: isCrit ? 'crit' : 'hit', amount: dealt });
         }
           S.adventure.enemyStunBar = S.adventure.currentEnemy.stun?.value || 0; // STATUS-REFORM
           performAttack(S, S.adventure.currentEnemy, { weapon }, S); // STATUS-REFORM
@@ -483,9 +483,9 @@ export function updateAdventureCombat() {
       } else {
         S.adventure.combatLog = S.adventure.combatLog || [];
         S.adventure.combatLog.push('You miss!');
-        const enemyBar = document.querySelector('.combatant.enemy .health-bar');
-        if (enemyBar) {
-          showFloatingText({ targetEl: enemyBar, result: 'miss' });
+        const enemySprite = document.querySelector('.enemy-sprite');
+        if (enemySprite) {
+          showFloatingText({ targetEl: enemySprite, result: 'miss' });
         }
       }
     }
@@ -507,9 +507,9 @@ export function updateAdventureCombat() {
             S
           );
           S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${taken} damage to you`);
-          const playerBar = document.querySelector('.combatant.player .health-bar');
-          if (playerBar) {
-            showFloatingText({ targetEl: playerBar, result: isCrit ? 'crit' : 'hit', amount: taken });
+          const playerSprite = document.querySelector('.player-sprite');
+          if (playerSprite) {
+            showFloatingText({ targetEl: playerSprite, result: isCrit ? 'crit' : 'hit', amount: taken });
           }
           performAttack(S.adventure.currentEnemy, S, {}, S); // STATUS-REFORM
           if (weapon.typeKey === 'focus') {
@@ -546,9 +546,9 @@ export function updateAdventureCombat() {
           }
         } else {
           S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} misses you`);
-          const playerBar = document.querySelector('.combatant.player .health-bar');
-          if (playerBar) {
-            showFloatingText({ targetEl: playerBar, result: 'miss' });
+          const playerSprite = document.querySelector('.player-sprite');
+          if (playerSprite) {
+            showFloatingText({ targetEl: playerSprite, result: 'miss' });
           }
         }
       }

--- a/style.css
+++ b/style.css
@@ -3182,6 +3182,74 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 }
 
 /* Adventure Combat System */
+.compact-hud {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 8px;
+}
+.compact-hud .hud {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.compact-hud .combatant-name {
+  font-size: 0.9em;
+  margin-bottom: 2px;
+}
+.compact-hud .hud.enemy .combatant-name {
+  text-align: right;
+}
+.compact-hud .health-bar,
+.compact-hud .qi-bar,
+.compact-hud .stun-bar {
+  height: 12px;
+}
+
+.sprite-stage {
+  position: relative;
+  height: 160px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 16px;
+}
+.sprite-stage svg.fx-layer {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.player-sprite,
+.enemy-sprite {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.15);
+  box-shadow: 0 0 8px rgba(0,0,0,0.4);
+}
+.enemy-sprite {
+  background: rgba(0, 0, 0, 0.25);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .player-sprite,
+  .enemy-sprite {
+    animation: sprite-bob 3s ease-in-out infinite;
+  }
+}
+@keyframes sprite-bob {
+  0%,100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+@media (max-width: 600px) {
+  .sprite-stage {
+    height: 40vh;
+  }
+}
+
 .combat-display {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Compact HUD bars display player and enemy health/qi at top of battle area
- Central sprite stage anchors combat FX and floating text
- Logic updated to target sprite elements for FX positions and damage text

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: verification violations)


------
https://chatgpt.com/codex/tasks/task_e_68ae739d14308326a91c9e89efa10ff8