### PR TITLE
feat: refactor battle arena with sprite stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,89 +459,99 @@
             <div class="battle-area" id="battleArea">
               <div class="area-background" id="areaBackground"></div>
 
-              <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
-                <defs>
-                  <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
-                    <feGaussianBlur stdDeviation="2" result="blur" />
-                    <feMerge>
-                      <feMergeNode in="blur" />
-                      <feMergeNode in="SourceGraphic" />
-                    </feMerge>
-                  </filter>
-                  <linearGradient id="fx-gradient" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="var(--fx-a, #fff)" />
-                    <stop offset="100%" stop-color="var(--fx-b, #fff)" />
-                  </linearGradient>
-                  <linearGradient id="elem-fire" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="#ff9a00" />
-                    <stop offset="100%" stop-color="#ff0000" />
-                  </linearGradient>
-                  <linearGradient id="elem-ice" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="#00c6ff" />
-                    <stop offset="100%" stop-color="#0072ff" />
-                  </linearGradient>
-                  <symbol id="rune-circle" viewBox="0 0 100 100">
-                    <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="6" />
-                  </symbol>
-                  <symbol id="shockwave-ring" viewBox="0 0 100 100">
-                    <circle cx="50" cy="50" r="45" fill="none" stroke="currentColor" stroke-width="10" />
-                  </symbol>
-                </defs>
-              </svg>
-
-              <div class="combat-display">
-                <div class="combatant player">
-                  <div class="combatant-name">You</div>
-                  <div class="health-bar">
-                    <div class="health-fill" id="playerHealthFill"></div>
-                    <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">
-                      <defs>
-                        <linearGradient id="advShieldGradient">
-                          <stop offset="0%" stop-color="rgba(255,255,255,0)" />
-                          <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
-                          <stop offset="100%" stop-color="rgba(255,255,255,0)" />
-                        </linearGradient>
-                      </defs>
-                      <mask id="advHpMask">
-                        <rect id="advHpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
-                      </mask>
-                      <rect id="advShieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#advHpMask)" />
-                      <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#advHpMask)" fill="url(#advShieldGradient)" />
-                    </svg>
-                    <span class="health-text" id="playerHealthText">100/100</span>
+              <div class="combat-hud">
+                <div class="hud player">
+                  <div class="bar-group">
+                    <div class="health-bar">
+                      <div class="health-fill" id="playerHealthFill"></div>
+                      <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">
+                        <defs>
+                          <linearGradient id="advShieldGradient">
+                            <stop offset="0%" stop-color="rgba(255,255,255,0)" />
+                            <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
+                            <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+                          </linearGradient>
+                        </defs>
+                        <mask id="advHpMask">
+                          <rect id="advHpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
+                        </mask>
+                        <rect id="advShieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#advHpMask)" />
+                        <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#advHpMask)" fill="url(#advShieldGradient)" />
+                      </svg>
+                      <span class="health-text" id="playerHealthText">100/100</span>
+                    </div>
+                    <div class="qi-bar">
+                      <div class="qi-fill" id="playerQiFill"></div>
+                      <span class="qi-text" id="playerQiText">0/0</span>
+                    </div>
                   </div>
-                  <div class="qi-bar">
-                    <div class="qi-fill" id="playerQiFill"></div>
-                    <span class="qi-text" id="playerQiText">0/0</span>
-                  </div>
-                  <div class="combat-stats">
-                    <span>ATK: <span id="playerAttack">10</span></span>
-                    <span>Rate: <span id="playerAttackRate">1.0/s</span></span>
-                    <span title="Physical mitigation versus the strongest enemy in this zone">Mit: <span id="playerMitigation">0%</span></span>
+                  <div class="stat-icons">
+                    <span class="icon" id="playerAttack" title="ATK">⚔️</span>
+                    <span class="icon" id="playerAttackRate" title="Rate">⏱️</span>
+                    <span class="icon" id="playerMitigation" title="Mit">🛡️</span>
                   </div>
                 </div>
-                
-                <div class="combat-vs">VS</div>
-                
+
+                <div class="hud enemy">
+                  <div class="bar-group">
+                    <div class="enemy-name" id="enemyName">Select an area to begin</div>
+                    <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
+                      <div class="stun-fill" id="enemyStunFill"></div>
+                      <span class="stun-text" id="enemyStunText">0/100</span>
+                    </div>
+                    <div class="health-bar">
+                      <div class="health-fill" id="enemyHealthFill"></div>
+                      <span class="health-text" id="enemyHealthText">--/--</span>
+                    </div>
+                    <div class="qi-bar">
+                      <div class="qi-fill" id="enemyQiFill"></div>
+                      <span class="qi-text" id="enemyQiText">--</span>
+                    </div>
+                    <div class="enemy-affixes" id="enemyAffixes"></div>
+                  </div>
+                  <div class="stat-icons">
+                    <span class="icon" id="enemyAttack" title="ATK">⚔️</span>
+                    <span class="icon" id="enemyAttackRate" title="Rate">⏱️</span>
+                    <span class="icon" id="enemyMitigation" title="Mit">🛡️</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="sprite-stage">
+                <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
+                  <defs>
+                    <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
+                      <feGaussianBlur stdDeviation="2" result="blur" />
+                      <feMerge>
+                        <feMergeNode in="blur" />
+                        <feMergeNode in="SourceGraphic" />
+                      </feMerge>
+                    </filter>
+                    <linearGradient id="fx-gradient" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="var(--fx-a, #fff)" />
+                      <stop offset="100%" stop-color="var(--fx-b, #fff)" />
+                    </linearGradient>
+                    <linearGradient id="elem-fire" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="#ff9a00" />
+                      <stop offset="100%" stop-color="#ff0000" />
+                    </linearGradient>
+                    <linearGradient id="elem-ice" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="#00c6ff" />
+                      <stop offset="100%" stop-color="#0072ff" />
+                    </linearGradient>
+                    <symbol id="rune-circle" viewBox="0 0 100 100">
+                      <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="6" />
+                    </symbol>
+                    <symbol id="shockwave-ring" viewBox="0 0 100 100">
+                      <circle cx="50" cy="50" r="45" fill="none" stroke="currentColor" stroke-width="10" />
+                    </symbol>
+                  </defs>
+                </svg>
+                <div class="combatant player">
+                  <div class="sprite player-sprite"></div>
+                </div>
                 <div class="combatant enemy">
-                  <div class="enemy-affixes" id="enemyAffixes"></div>
-                  <div class="combatant-name" id="enemyName">Select an area to begin</div>
-                  <div class="stun-bar" id="enemyStunBar" title="Gauge: 0\nThreshold: 100\nDecay: 6/s">
-                    <div class="stun-fill" id="enemyStunFill"></div>
-                    <span class="stun-text" id="enemyStunText">0/100</span>
-                  </div>
-                  <div class="health-bar">
-                    <div class="health-fill" id="enemyHealthFill"></div>
-                    <span class="health-text" id="enemyHealthText">--/--</span>
-                  </div>
-                  <div class="qi-bar">
-                    <div class="qi-fill" id="enemyQiFill"></div>
-                    <span class="qi-text" id="enemyQiText">--</span>
-                  </div>
-                  <div class="combat-stats">
-                    <span>ATK: <span id="enemyAttack">--</span></span>
-                    <span>Rate: <span id="enemyAttackRate">--/s</span></span>
-                  </div>
+                  <div class="sprite enemy-sprite"></div>
                 </div>
               </div>
 

--- a/style.css
+++ b/style.css
@@ -3386,7 +3386,7 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   background: var(--panel);
   border-radius: 6px;
   padding: 12px;
-  margin: 12px 0;
+  margin: 20px 0 0;
   font-family: monospace;
   font-size: 0.9em;
 }
@@ -4181,7 +4181,26 @@ tr:last-child td {
 .hint{border-bottom:1px dotted #475569; cursor:help}
 
 /* Combat FX Layer */
-.battle-area{position:relative;overflow:hidden}
+.battle-area{position:relative;overflow:hidden;display:flex;flex-direction:column;gap:8px}
+.combat-hud{display:flex;justify-content:space-between;align-items:flex-start;padding:4px 8px;gap:8px}
+.combat-hud .hud{display:flex;flex-direction:column;gap:4px;align-items:center;flex:0 0 45%}
+.combat-hud .bar-group{display:flex;flex-direction:column;gap:2px}
+.combat-hud .health-bar{height:12px;margin:0}
+.combat-hud .qi-bar{height:8px;margin:0}
+.combat-hud .health-text,.combat-hud .qi-text{font-size:.65rem}
+.combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
+.combat-hud .stat-icons .icon{cursor:help}
+.combat-hud .hud.enemy{text-align:right}
+.combat-hud .enemy-name{font-size:.75rem;font-weight:600}
+.sprite-stage{position:relative;flex:1;min-height:160px;display:flex;align-items:flex-end;justify-content:space-between;padding:8px}
+.sprite-stage .combatant{flex:0 0 45%;display:flex;align-items:flex-end;justify-content:center;position:relative}
+.sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
+.sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
+.sprite-stage .player-sprite{background-color:hsl(200,50%,60%)}
+.sprite-stage .enemy-sprite{background-color:hsl(0,50%,60%)}
+@keyframes sprite-bob{from{transform:translateY(0)}to{transform:translateY(-4px)}}
+@media (prefers-reduced-motion:reduce){.sprite-stage .sprite{animation:none}}
+html.reduce-motion .sprite-stage .sprite{animation:none}
 .fx-layer{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;--fx-a:#fff;--fx-b:#fff}
 .fx-stroke,.fx-thrust,.fx-beam{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-linecap:round}
 .fx-stroke{stroke-width:2;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .35s linear forwards}


### PR DESCRIPTION
## Summary
- compress battle HUD into equal-width health/qi bars with aligned stat icons
- center player and enemy sprites with expanded bars and closer spacing
- move combat log down to keep controls visible

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation and AI changes blocked)


------
https://chatgpt.com/codex/tasks/task_e_68ae739d14308326a91c9e89efa10ff8