### PR TITLE
feat: refactor battle arena with sprite stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,89 +459,99 @@
             <div class="battle-area" id="battleArea">
               <div class="area-background" id="areaBackground"></div>
 
-              <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
-                <defs>
-                  <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
-                    <feGaussianBlur stdDeviation="2" result="blur" />
-                    <feMerge>
-                      <feMergeNode in="blur" />
-                      <feMergeNode in="SourceGraphic" />
-                    </feMerge>
-                  </filter>
-                  <linearGradient id="fx-gradient" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="var(--fx-a, #fff)" />
-                    <stop offset="100%" stop-color="var(--fx-b, #fff)" />
-                  </linearGradient>
-                  <linearGradient id="elem-fire" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="#ff9a00" />
-                    <stop offset="100%" stop-color="#ff0000" />
-                  </linearGradient>
-                  <linearGradient id="elem-ice" x1="0" y1="0" x2="1" y2="1">
-                    <stop offset="0%" stop-color="#00c6ff" />
-                    <stop offset="100%" stop-color="#0072ff" />
-                  </linearGradient>
-                  <symbol id="rune-circle" viewBox="0 0 100 100">
-                    <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="6" />
-                  </symbol>
-                  <symbol id="shockwave-ring" viewBox="0 0 100 100">
-                    <circle cx="50" cy="50" r="45" fill="none" stroke="currentColor" stroke-width="10" />
-                  </symbol>
-                </defs>
-              </svg>
-
-              <div class="combat-display">
-                <div class="combatant player">
-                  <div class="combatant-name">You</div>
-                  <div class="health-bar">
-                    <div class="health-fill" id="playerHealthFill"></div>
-                    <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">
-                      <defs>
-                        <linearGradient id="advShieldGradient">
-                          <stop offset="0%" stop-color="rgba(255,255,255,0)" />
-                          <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
-                          <stop offset="100%" stop-color="rgba(255,255,255,0)" />
-                        </linearGradient>
-                      </defs>
-                      <mask id="advHpMask">
-                        <rect id="advHpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
-                      </mask>
-                      <rect id="advShieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#advHpMask)" />
-                      <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#advHpMask)" fill="url(#advShieldGradient)" />
-                    </svg>
-                    <span class="health-text" id="playerHealthText">100/100</span>
+              <div class="combat-hud">
+                <div class="hud player">
+                  <div class="bar-group">
+                    <div class="health-bar">
+                      <div class="health-fill" id="playerHealthFill"></div>
+                      <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">
+                        <defs>
+                          <linearGradient id="advShieldGradient">
+                            <stop offset="0%" stop-color="rgba(255,255,255,0)" />
+                            <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
+                            <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+                          </linearGradient>
+                        </defs>
+                        <mask id="advHpMask">
+                          <rect id="advHpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
+                        </mask>
+                        <rect id="advShieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#advHpMask)" />
+                        <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#advHpMask)" fill="url(#advShieldGradient)" />
+                      </svg>
+                      <span class="health-text" id="playerHealthText">100/100</span>
+                    </div>
+                    <div class="qi-bar">
+                      <div class="qi-fill" id="playerQiFill"></div>
+                      <span class="qi-text" id="playerQiText">0/0</span>
+                    </div>
                   </div>
-                  <div class="qi-bar">
-                    <div class="qi-fill" id="playerQiFill"></div>
-                    <span class="qi-text" id="playerQiText">0/0</span>
-                  </div>
-                  <div class="combat-stats">
-                    <span>ATK: <span id="playerAttack">10</span></span>
-                    <span>Rate: <span id="playerAttackRate">1.0/s</span></span>
-                    <span title="Physical mitigation versus the strongest enemy in this zone">Mit: <span id="playerMitigation">0%</span></span>
+                  <div class="stat-icons">
+                    <span class="icon" id="playerAttack" title="ATK">⚔️</span>
+                    <span class="icon" id="playerAttackRate" title="Rate">⏱️</span>
+                    <span class="icon" id="playerMitigation" title="Mit">🛡️</span>
                   </div>
                 </div>
-                
-                <div class="combat-vs">VS</div>
-                
+
+                <div class="hud enemy">
+                  <div class="bar-group">
+                    <div class="enemy-name" id="enemyName">Select an area to begin</div>
+                    <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
+                      <div class="stun-fill" id="enemyStunFill"></div>
+                      <span class="stun-text" id="enemyStunText">0/100</span>
+                    </div>
+                    <div class="health-bar">
+                      <div class="health-fill" id="enemyHealthFill"></div>
+                      <span class="health-text" id="enemyHealthText">--/--</span>
+                    </div>
+                    <div class="qi-bar">
+                      <div class="qi-fill" id="enemyQiFill"></div>
+                      <span class="qi-text" id="enemyQiText">--</span>
+                    </div>
+                    <div class="enemy-affixes" id="enemyAffixes"></div>
+                  </div>
+                  <div class="stat-icons">
+                    <span class="icon" id="enemyAttack" title="ATK">⚔️</span>
+                    <span class="icon" id="enemyAttackRate" title="Rate">⏱️</span>
+                    <span class="icon" id="enemyMitigation" title="Mit">🛡️</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="sprite-stage">
+                <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
+                  <defs>
+                    <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
+                      <feGaussianBlur stdDeviation="2" result="blur" />
+                      <feMerge>
+                        <feMergeNode in="blur" />
+                        <feMergeNode in="SourceGraphic" />
+                      </feMerge>
+                    </filter>
+                    <linearGradient id="fx-gradient" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="var(--fx-a, #fff)" />
+                      <stop offset="100%" stop-color="var(--fx-b, #fff)" />
+                    </linearGradient>
+                    <linearGradient id="elem-fire" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="#ff9a00" />
+                      <stop offset="100%" stop-color="#ff0000" />
+                    </linearGradient>
+                    <linearGradient id="elem-ice" x1="0" y1="0" x2="1" y2="1">
+                      <stop offset="0%" stop-color="#00c6ff" />
+                      <stop offset="100%" stop-color="#0072ff" />
+                    </linearGradient>
+                    <symbol id="rune-circle" viewBox="0 0 100 100">
+                      <circle cx="50" cy="50" r="40" fill="none" stroke="currentColor" stroke-width="6" />
+                    </symbol>
+                    <symbol id="shockwave-ring" viewBox="0 0 100 100">
+                      <circle cx="50" cy="50" r="45" fill="none" stroke="currentColor" stroke-width="10" />
+                    </symbol>
+                  </defs>
+                </svg>
+                <div class="combatant player">
+                  <div class="sprite player-sprite"></div>
+                </div>
                 <div class="combatant enemy">
-                  <div class="enemy-affixes" id="enemyAffixes"></div>
-                  <div class="combatant-name" id="enemyName">Select an area to begin</div>
-                  <div class="stun-bar" id="enemyStunBar" title="Gauge: 0\nThreshold: 100\nDecay: 6/s">
-                    <div class="stun-fill" id="enemyStunFill"></div>
-                    <span class="stun-text" id="enemyStunText">0/100</span>
-                  </div>
-                  <div class="health-bar">
-                    <div class="health-fill" id="enemyHealthFill"></div>
-                    <span class="health-text" id="enemyHealthText">--/--</span>
-                  </div>
-                  <div class="qi-bar">
-                    <div class="qi-fill" id="enemyQiFill"></div>
-                    <span class="qi-text" id="enemyQiText">--</span>
-                  </div>
-                  <div class="combat-stats">
-                    <span>ATK: <span id="enemyAttack">--</span></span>
-                    <span>Rate: <span id="enemyAttackRate">--/s</span></span>
-                  </div>
+                  <div class="sprite enemy-sprite"></div>
                 </div>
               </div>
 

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -86,12 +86,12 @@ on('ABILITY:FX', ({ abilityKey }) => {
     const pos = getCombatPositions();
     if (pos) {
       const svgRect = pos.svg.getBoundingClientRect();
-      const hpBar = document.querySelector('.combatant.enemy .health-bar');
-      if (hpBar) {
-        const hpRect = hpBar.getBoundingClientRect();
+      const enemyEl = document.querySelector('.combatant.enemy');
+      if (enemyEl) {
+        const eRect = enemyEl.getBoundingClientRect();
         const to = {
-          x: ((hpRect.left + hpRect.width / 2 - svgRect.left) / svgRect.width) * 100,
-          y: ((hpRect.top + hpRect.height / 2 - svgRect.top) / svgRect.height) * 50,
+          x: ((eRect.left + eRect.width / 2 - svgRect.left) / svgRect.width) * 100,
+          y: ((eRect.top + eRect.height / 2 - svgRect.top) / svgRect.height) * 50,
         };
         setFxTint(pos.svg, 'red');
         playFireball(pos.svg, pos.from, to);
@@ -191,8 +191,10 @@ export function updateBattleDisplay() {
   if (S.lightningStep) {
     playerAttackRate *= S.lightningStep.attackSpeedMult;
   }
-  setText('playerAttack', Math.round(playerAttack));
-  setText('playerAttackRate', `${playerAttackRate.toFixed(1)}/s`);
+  const atkEl = document.getElementById('playerAttack');
+  if (atkEl) atkEl.title = `ATK: ${Math.round(playerAttack)}`;
+  const rateEl = document.getElementById('playerAttackRate');
+  if (rateEl) rateEl.title = `Rate: ${playerAttackRate.toFixed(1)}/s`;
   setText('combatAttackRate', `${playerAttackRate.toFixed(1)}/s`);
   setText('qiShield', `${S.shield?.current || 0}/${S.shield?.max || 0}`);
 
@@ -210,15 +212,27 @@ export function updateBattleDisplay() {
       mitPct = Math.min(ARMOR_CAP, armor / (armor + ARMOR_K * maxEnemyAtk));
     }
   }
-  setText('playerMitigation', `${Math.round(mitPct * 100)}%`);
+  const mitEl = document.getElementById('playerMitigation');
+  if (mitEl) mitEl.title = `Mit: ${Math.round(mitPct * 100)}%`;
   if (S.adventure.inCombat && S.adventure.currentEnemy) {
     const enemy = S.adventure.currentEnemy;
     const enemyHP = S.adventure.enemyHP || 0;
     const enemyMaxHP = S.adventure.enemyMaxHP || 0;
     setText('enemyName', enemy.name || 'Unknown Enemy');
     setText('enemyHealthText', `${Math.round(enemyHP)}/${Math.round(enemyMaxHP)}`);
-    setText('enemyAttack', Math.round(enemy.attack || 0));
-    setText('enemyAttackRate', `${(enemy.attackRate || 1.0).toFixed(1)}/s`);
+    const enemyAtkEl = document.getElementById('enemyAttack');
+    if (enemyAtkEl) enemyAtkEl.title = `ATK: ${Math.round(enemy.attack || 0)}`;
+    const enemyRateEl = document.getElementById('enemyAttackRate');
+    if (enemyRateEl) enemyRateEl.title = `Rate: ${(enemy.attackRate || 1.0).toFixed(1)}/s`;
+    const enemyMitEl = document.getElementById('enemyMitigation');
+    if (enemyMitEl) {
+      let eMitPct = 0;
+      const eArmor = enemy.armor || 0;
+      if (eArmor > 0 && playerAttack > 0) {
+        eMitPct = Math.min(ARMOR_CAP, eArmor / (eArmor + ARMOR_K * playerAttack));
+      }
+      enemyMitEl.title = `Mit: ${Math.round(eMitPct * 100)}%`;
+    }
     const enemyQiFill = document.getElementById('enemyQiFill');
     if (enemy.qiMax) {
       const enemyQi = S.adventure.enemyQi || 0;
@@ -275,8 +289,12 @@ export function updateBattleDisplay() {
   } else {
     setText('enemyName', 'Select an area to begin');
     setText('enemyHealthText', '--/--');
-    setText('enemyAttack', '--');
-    setText('enemyAttackRate', '--/s');
+    const enemyAtkEl = document.getElementById('enemyAttack');
+    if (enemyAtkEl) enemyAtkEl.title = 'ATK: --';
+    const enemyRateEl = document.getElementById('enemyAttackRate');
+    if (enemyRateEl) enemyRateEl.title = 'Rate: --/s';
+    const enemyMitEl = document.getElementById('enemyMitigation');
+    if (enemyMitEl) enemyMitEl.title = 'Mit: --';
     const enemyHealthFill = document.getElementById('enemyHealthFill');
     if (enemyHealthFill) enemyHealthFill.style.width = '0%';
     const enemyQiFill = document.getElementById('enemyQiFill');
@@ -435,9 +453,9 @@ export function updateAdventureCombat() {
         gainProficiencyFromEnemy(weapon.proficiencyKey, S.adventure.enemyMaxHP, S); // WEAPONS-INTEGRATION
         S.adventure.combatLog = S.adventure.combatLog || [];
         S.adventure.combatLog.push(`You deal ${dealt} damage to ${S.adventure.currentEnemy.name}`);
-        const enemyBar = document.querySelector('.combatant.enemy .health-bar');
-        if (enemyBar) {
-          showFloatingText({ targetEl: enemyBar, result: isCrit ? 'crit' : 'hit', amount: dealt });
+        const enemyEl = document.querySelector('.combatant.enemy');
+        if (enemyEl) {
+          showFloatingText({ targetEl: enemyEl, result: isCrit ? 'crit' : 'hit', amount: dealt });
         }
           S.adventure.enemyStunBar = S.adventure.currentEnemy.stun?.value || 0; // STATUS-REFORM
           performAttack(S, S.adventure.currentEnemy, { weapon }, S); // STATUS-REFORM
@@ -483,9 +501,9 @@ export function updateAdventureCombat() {
       } else {
         S.adventure.combatLog = S.adventure.combatLog || [];
         S.adventure.combatLog.push('You miss!');
-        const enemyBar = document.querySelector('.combatant.enemy .health-bar');
-        if (enemyBar) {
-          showFloatingText({ targetEl: enemyBar, result: 'miss' });
+        const enemyEl = document.querySelector('.combatant.enemy');
+        if (enemyEl) {
+          showFloatingText({ targetEl: enemyEl, result: 'miss' });
         }
       }
     }
@@ -507,9 +525,9 @@ export function updateAdventureCombat() {
             S
           );
           S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${taken} damage to you`);
-          const playerBar = document.querySelector('.combatant.player .health-bar');
-          if (playerBar) {
-            showFloatingText({ targetEl: playerBar, result: isCrit ? 'crit' : 'hit', amount: taken });
+          const playerEl = document.querySelector('.combatant.player');
+          if (playerEl) {
+            showFloatingText({ targetEl: playerEl, result: isCrit ? 'crit' : 'hit', amount: taken });
           }
           performAttack(S.adventure.currentEnemy, S, {}, S); // STATUS-REFORM
           if (weapon.typeKey === 'focus') {
@@ -546,9 +564,9 @@ export function updateAdventureCombat() {
           }
         } else {
           S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} misses you`);
-          const playerBar = document.querySelector('.combatant.player .health-bar');
-          if (playerBar) {
-            showFloatingText({ targetEl: playerBar, result: 'miss' });
+          const playerEl = document.querySelector('.combatant.player');
+          if (playerEl) {
+            showFloatingText({ targetEl: playerEl, result: 'miss' });
           }
         }
       }

--- a/style.css
+++ b/style.css
@@ -3386,7 +3386,7 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   background: var(--panel);
   border-radius: 6px;
   padding: 12px;
-  margin: 12px 0;
+  margin: 24px 0;
   font-family: monospace;
   font-size: 0.9em;
 }
@@ -4181,7 +4181,25 @@ tr:last-child td {
 .hint{border-bottom:1px dotted #475569; cursor:help}
 
 /* Combat FX Layer */
-.battle-area{position:relative;overflow:hidden}
+.battle-area{position:relative;overflow:hidden;display:flex;flex-direction:column;gap:8px}
+.combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
+.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
+.combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}
+.combat-hud .health-bar{height:12px;margin:0}
+.combat-hud .qi-bar{height:8px;margin:0}
+.combat-hud .health-text,.combat-hud .qi-text{font-size:.65rem}
+.combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
+.combat-hud .stat-icons .icon{cursor:help}
+.combat-hud .enemy-name{font-size:.75rem;font-weight:600}
+.sprite-stage{position:relative;flex:1;min-height:160px;display:flex;align-items:flex-end;justify-content:center;gap:24px;padding:8px}
+.sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
+.sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
+.sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
+.sprite-stage .player-sprite{background-color:hsl(200,50%,60%)}
+.sprite-stage .enemy-sprite{background-color:hsl(0,50%,60%)}
+@keyframes sprite-bob{from{transform:translateY(0)}to{transform:translateY(-4px)}}
+@media (prefers-reduced-motion:reduce){.sprite-stage .sprite{animation:none}}
+html.reduce-motion .sprite-stage .sprite{animation:none}
 .fx-layer{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;--fx-a:#fff;--fx-b:#fff}
 .fx-stroke,.fx-thrust,.fx-beam{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-linecap:round}
 .fx-stroke{stroke-width:2;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .35s linear forwards}


### PR DESCRIPTION
## Summary
- compress battle HUD into micro health/qi bars with stat icons
- add sprite stage for player and enemy with FX overlays and floating damage numbers
- target ability FX and floating combat text at sprites
- align combat HUD bars over sprites and space combatants closer

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI changes blocked until validation passes)


------
https://chatgpt.com/codex/tasks/task_e_68ae739d14308326a91c9e89efa10ff8