### PR TITLE
Refine battle layout for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -458,13 +458,13 @@
             
             <div class="battle-area" id="battleArea">
               <div class="area-background" id="areaBackground"></div>
-
-              <div class="combat-hud">
-                <div class="hud player">
-                  <div class="bar-group">
-                    <div class="health-bar">
-                      <div class="health-fill" id="playerHealthFill"></div>
-                      <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">
+              <div class="combatant-container">
+                <div class="combat-hud">
+                  <div class="hud player">
+                    <div class="bar-group">
+                      <div class="health-bar">
+                        <div class="health-fill" id="playerHealthFill"></div>
+                        <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">
                         <defs>
                           <linearGradient id="advShieldGradient">
                             <stop offset="0%" stop-color="rgba(255,255,255,0)" />
@@ -490,38 +490,38 @@
                     <span class="icon" id="playerAttackRate" title="Rate">⏱️</span>
                     <span class="icon" id="playerMitigation" title="Mit">🛡️</span>
                   </div>
+                  </div>
+
+                  <div class="hud enemy">
+                    <div class="bar-group">
+                      <div class="enemy-name" id="enemyName">Select an area to begin</div>
+                      <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
+                        <div class="stun-fill" id="enemyStunFill"></div>
+                        <span class="stun-text" id="enemyStunText">0/100</span>
+                      </div>
+                      <div class="health-bar">
+                        <div class="health-fill" id="enemyHealthFill"></div>
+                        <span class="health-text" id="enemyHealthText">--/--</span>
+                      </div>
+                      <div class="qi-bar">
+                        <div class="qi-fill" id="enemyQiFill"></div>
+                        <span class="qi-text" id="enemyQiText">--</span>
+                      </div>
+                      <div class="enemy-affixes" id="enemyAffixes"></div>
+                    </div>
+                    <div class="stat-icons">
+                      <span class="icon" id="enemyAttack" title="ATK">⚔️</span>
+                      <span class="icon" id="enemyAttackRate" title="Rate">⏱️</span>
+                      <span class="icon" id="enemyMitigation" title="Mit">🛡️</span>
+                    </div>
+                  </div>
                 </div>
 
-                <div class="hud enemy">
-                  <div class="bar-group">
-                    <div class="enemy-name" id="enemyName">Select an area to begin</div>
-                    <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
-                      <div class="stun-fill" id="enemyStunFill"></div>
-                      <span class="stun-text" id="enemyStunText">0/100</span>
-                    </div>
-                    <div class="health-bar">
-                      <div class="health-fill" id="enemyHealthFill"></div>
-                      <span class="health-text" id="enemyHealthText">--/--</span>
-                    </div>
-                    <div class="qi-bar">
-                      <div class="qi-fill" id="enemyQiFill"></div>
-                      <span class="qi-text" id="enemyQiText">--</span>
-                    </div>
-                    <div class="enemy-affixes" id="enemyAffixes"></div>
-                  </div>
-                  <div class="stat-icons">
-                    <span class="icon" id="enemyAttack" title="ATK">⚔️</span>
-                    <span class="icon" id="enemyAttackRate" title="Rate">⏱️</span>
-                    <span class="icon" id="enemyMitigation" title="Mit">🛡️</span>
-                  </div>
-                </div>
-              </div>
-
-              <div class="sprite-stage">
-                <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
-                  <defs>
-                    <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
-                      <feGaussianBlur stdDeviation="2" result="blur" />
+                <div class="sprite-stage">
+                  <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
+                    <defs>
+                      <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
+                        <feGaussianBlur stdDeviation="2" result="blur" />
                       <feMerge>
                         <feMergeNode in="blur" />
                         <feMergeNode in="SourceGraphic" />
@@ -553,6 +553,12 @@
                 <div class="combatant enemy">
                   <div class="sprite enemy-sprite"></div>
                 </div>
+
+                <!-- Ability Bar -->
+                <div class="ability-bar-container">
+                  <span class="ability-label">Ability Bar:</span>
+                  <div class="ability-bar" id="abilityBar"></div>
+                </div>
               </div>
 
               <!-- Combat Actions -->
@@ -560,12 +566,6 @@
                 <button class="btn primary" id="startBattleButton">Start Battle</button>
                 <button class="btn success" id="progressButton" disabled>Clear Area</button>
                 <button class="btn danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
-              </div>
-
-              <!-- Ability Bar -->
-              <div class="ability-bar-container">
-                <span class="ability-label">Ability Bar:</span>
-                <div class="ability-bar" id="abilityBar"></div>
               </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -3348,13 +3348,13 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 .ability-bar-container {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 16px;
+  gap: 4px;
+  margin-top: 8px;
 }
 
 .ability-bar {
   display: flex;
-  gap: 8px;
+  gap: 4px;
 }
 
 .ability-slot {
@@ -3411,9 +3411,14 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 
 .combat-controls {
   display: flex;
-  gap: 12px;
-  justify-content: center;
-  margin-top: 16px;
+  gap: 8px;
+  justify-content: flex-start;
+  margin-top: 8px;
+}
+.combat-controls .btn{
+  padding:6px 8px;
+  font-size:.9rem;
+  min-width:0;
 }
 
 .adventure-zones {
@@ -4182,8 +4187,9 @@ tr:last-child td {
 
 /* Combat FX Layer */
 .battle-area{position:relative;overflow:hidden;display:flex;flex-direction:column;gap:8px}
-.combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
-.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
+.combatant-container{background:rgba(0,0,0,.05);border-radius:8px;padding:8px;display:flex;flex-direction:column;gap:8px}
+.combat-hud{display:flex;justify-content:flex-start;align-items:flex-start;padding:4px 8px;gap:16px}
+.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:140px;align-items:center;text-align:center}
 .combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}
 .combat-hud .health-bar{height:12px;margin:0}
 .combat-hud .qi-bar{height:8px;margin:0}
@@ -4191,7 +4197,7 @@ tr:last-child td {
 .combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
-.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
+.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:flex-start;gap:16px;padding:8px}
 .sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
 .sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
@@ -4413,8 +4419,8 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   .cultivation-btn{font-size:0.85rem;padding:6px 8px;}
   .adventure-cards{grid-template-columns:1fr;}
   .combat-display{gap:10px;}
-  .combat-controls{gap:8px;}
-  .combat-controls .btn{flex:1;font-size:0.85rem;padding:6px 8px;min-width:0;}
+  .combat-controls{gap:6px;}
+  .combat-controls .btn{flex:1;font-size:0.8rem;padding:4px 6px;min-width:0;}
 }
 
 /* Queue bar and manual cards */


### PR DESCRIPTION
## Summary
- Wrap combat HUD, sprites, and abilities in a shaded container
- Align combatants, sprites, and control buttons to the left and shrink button spacing
- Relocate ability bar below combatants for full visibility

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation and other checks)


------
https://chatgpt.com/codex/tasks/task_e_68aeeda4ab088326bdd506e48cd6010a