### PR TITLE
Improve battle layout for smaller screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,6 +459,7 @@
             <div class="battle-area" id="battleArea">
               <div class="area-background" id="areaBackground"></div>
 
+              <div class="combat-container">
               <div class="combat-hud">
                 <div class="hud player">
                   <div class="bar-group">
@@ -555,17 +556,18 @@
                 </div>
               </div>
 
-              <!-- Combat Actions -->
-              <div class="combat-controls">
-                <button class="btn primary" id="startBattleButton">Start Battle</button>
-                <button class="btn success" id="progressButton" disabled>Clear Area</button>
-                <button class="btn danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
-              </div>
-
               <!-- Ability Bar -->
               <div class="ability-bar-container">
                 <span class="ability-label">Ability Bar:</span>
                 <div class="ability-bar" id="abilityBar"></div>
+              </div>
+              </div>
+
+              <!-- Combat Actions -->
+              <div class="combat-controls">
+                <button class="btn small primary" id="startBattleButton">Start Battle</button>
+                <button class="btn small success" id="progressButton" disabled>Clear Area</button>
+                <button class="btn small danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
               </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -3347,14 +3347,17 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 
 .ability-bar-container {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 16px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  margin-top: 8px;
 }
 
 .ability-bar {
   display: flex;
-  gap: 8px;
+  gap: 4px;
+  width: 100%;
+  flex-wrap: wrap;
 }
 
 .ability-slot {
@@ -3411,9 +3414,14 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 
 .combat-controls {
   display: flex;
-  gap: 12px;
-  justify-content: center;
+  gap: 8px;
+  justify-content: flex-start;
   margin-top: 16px;
+}
+
+.combat-controls .btn{
+  flex:0 0 auto;
+  min-width:0;
 }
 
 .adventure-zones {
@@ -4182,7 +4190,8 @@ tr:last-child td {
 
 /* Combat FX Layer */
 .battle-area{position:relative;overflow:hidden;display:flex;flex-direction:column;gap:8px}
-.combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
+.combat-container{background:rgba(0,0,0,.05);padding:8px;border-radius:6px;display:flex;flex-direction:column;gap:8px;align-items:flex-start}
+.combat-hud{display:flex;justify-content:flex-start;align-items:flex-start;padding:4px 8px;gap:24px}
 .combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
 .combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}
 .combat-hud .health-bar{height:12px;margin:0}
@@ -4191,7 +4200,7 @@ tr:last-child td {
 .combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
-.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
+.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:flex-start;gap:24px;padding:8px}
 .sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
 .sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
@@ -4280,7 +4289,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 }
 
 /* Ability bar */
-.ability-bar { display:flex; gap:4px; }
+.ability-bar { display:flex; gap:4px; flex-wrap:wrap; width:100%; }
 .ability-card { width:60px; height:90px; background:var(--panel); border:1px solid var(--ink-light); border-radius:4px; position:relative; padding:2px; display:flex; flex-direction:column; align-items:center; justify-content:space-between; }
 .ability-card .ability-name { font-size:10px; text-align:center; }
 .ability-card .ability-title { display:flex; flex-direction:column; align-items:center; }
@@ -4414,7 +4423,6 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   .adventure-cards{grid-template-columns:1fr;}
   .combat-display{gap:10px;}
   .combat-controls{gap:8px;}
-  .combat-controls .btn{flex:1;font-size:0.85rem;padding:6px 8px;min-width:0;}
 }
 
 /* Queue bar and manual cards */


### PR DESCRIPTION
## Summary
- Wrap combat HUD, sprites, and ability bar in a shaded container to tighten battle card
- Reposition combat elements and ability bar to the left for better visibility
- Compact and left-align battle controls

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68aeeda4ab088326bdd506e48cd6010a