### PR TITLE
Refine battle layout for adventure mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -459,9 +459,10 @@
             <div class="battle-area" id="battleArea">
               <div class="area-background" id="areaBackground"></div>
 
-              <div class="combat-hud">
-                <div class="hud player">
-                  <div class="bar-group">
+              <div class="combat-container">
+                <div class="combat-hud">
+                  <div class="hud player">
+                    <div class="bar-group">
                     <div class="health-bar">
                       <div class="health-fill" id="playerHealthFill"></div>
                       <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">
@@ -515,10 +516,9 @@
                     <span class="icon" id="enemyMitigation" title="Mit">🛡️</span>
                   </div>
                 </div>
-              </div>
 
-              <div class="sprite-stage">
-                <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
+                <div class="sprite-stage">
+                  <svg class="fx-layer" id="combatFx" viewBox="0 0 100 50" preserveAspectRatio="none">
                   <defs>
                     <filter id="soft-glow" x="-50%" y="-50%" width="200%" height="200%">
                       <feGaussianBlur stdDeviation="2" result="blur" />
@@ -555,17 +555,18 @@
                 </div>
               </div>
 
-              <!-- Combat Actions -->
-              <div class="combat-controls">
-                <button class="btn primary" id="startBattleButton">Start Battle</button>
-                <button class="btn success" id="progressButton" disabled>Clear Area</button>
-                <button class="btn danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
-              </div>
-
               <!-- Ability Bar -->
               <div class="ability-bar-container">
                 <span class="ability-label">Ability Bar:</span>
                 <div class="ability-bar" id="abilityBar"></div>
+              </div>
+              </div>
+
+              <!-- Combat Actions -->
+              <div class="combat-controls">
+                <button class="btn small primary" id="startBattleButton">Start Battle</button>
+                <button class="btn small success" id="progressButton" disabled>Clear Area</button>
+                <button class="btn small danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
               </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -3349,12 +3349,12 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-top: 16px;
+  margin-top: 0;
 }
 
 .ability-bar {
   display: flex;
-  gap: 8px;
+  gap: 4px;
 }
 
 .ability-slot {
@@ -3411,10 +3411,11 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 
 .combat-controls {
   display: flex;
-  gap: 12px;
-  justify-content: center;
-  margin-top: 16px;
+  gap: 8px;
+  justify-content: flex-start;
+  margin-top: 8px;
 }
+.combat-controls .btn{flex:0 0 auto;}
 
 .adventure-zones {
   margin-top: 12px;
@@ -4182,8 +4183,9 @@ tr:last-child td {
 
 /* Combat FX Layer */
 .battle-area{position:relative;overflow:hidden;display:flex;flex-direction:column;gap:8px}
-.combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
-.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
+.combat-container{background:rgba(0,0,0,.05);padding:8px;border-radius:8px;display:flex;flex-direction:column;gap:8px;align-items:flex-start}
+.combat-hud{display:flex;justify-content:flex-start;align-items:flex-start;padding:4px 8px;gap:12px}
+.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:140px;align-items:flex-start;text-align:left}
 .combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}
 .combat-hud .health-bar{height:12px;margin:0}
 .combat-hud .qi-bar{height:8px;margin:0}
@@ -4191,7 +4193,7 @@ tr:last-child td {
 .combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
-.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
+.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:flex-start;gap:12px;padding:8px 0}
 .sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
 .sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
@@ -4413,8 +4415,8 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   .cultivation-btn{font-size:0.85rem;padding:6px 8px;}
   .adventure-cards{grid-template-columns:1fr;}
   .combat-display{gap:10px;}
-  .combat-controls{gap:8px;}
-  .combat-controls .btn{flex:1;font-size:0.85rem;padding:6px 8px;min-width:0;}
+  .combat-controls{gap:8px;justify-content:flex-start;}
+  .combat-controls .btn{flex:0 0 auto;font-size:0.85rem;padding:4px 6px;min-width:0;}
 }
 
 /* Queue bar and manual cards */


### PR DESCRIPTION
## Summary
- Wrap combat HUD, sprites and abilities in a shaded container
- Left-align combatants and ability bar, move ability bar below sprites
- Compact battle action buttons and shift them to the left

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI verification protocol violations)


------
https://chatgpt.com/codex/tasks/task_e_68aeeda4ab088326bdd506e48cd6010a