### PR TITLE
Ensure ability bar and controls fit in adventure battles

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,17 +555,17 @@
                 </div>
               </div>
 
+              <!-- Ability Bar -->
+              <div class="ability-bar-container">
+                <span class="ability-label">Ability Bar:</span>
+                <div class="ability-bar" id="abilityBar"></div>
+              </div>
+
               <!-- Combat Actions -->
               <div class="combat-controls">
                 <button class="btn primary" id="startBattleButton">Start Battle</button>
                 <button class="btn success" id="progressButton" disabled>Clear Area</button>
                 <button class="btn danger" id="challengeBossButton" disabled style="display: none;">👹 Challenge Boss</button>
-              </div>
-
-              <!-- Ability Bar -->
-              <div class="ability-bar-container">
-                <span class="ability-label">Ability Bar:</span>
-                <div class="ability-bar" id="abilityBar"></div>
               </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -3386,7 +3386,7 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   background: var(--panel);
   border-radius: 6px;
   padding: 12px;
-  margin: 40px 0 0;
+  margin: 80px 0 0;
   font-family: monospace;
   font-size: 0.9em;
 }
@@ -4181,7 +4181,7 @@ tr:last-child td {
 .hint{border-bottom:1px dotted #475569; cursor:help}
 
 /* Combat FX Layer */
-.battle-area{position:relative;overflow:hidden;display:flex;flex-direction:column;gap:8px}
+.battle-area{position:relative;overflow:visible;display:flex;flex-direction:column;gap:8px}
 .combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
 .combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
 .combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}


### PR DESCRIPTION
## Summary
- Reorder ability bar above combat controls so both remain visible
- Allow battle area overflow and push combat log down for extra space

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation: src/features/loot/ui/lootTab.js imports S from shared/state.js, UI state violation: src/features/mining/ui/miningDisplay.js imports S from shared/state.js, UI state violation: src/features/proficiency/ui/weaponProficiencyDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/lawDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiOrb.js imports S from shared/state.js, UI state violation: src/features/progression/ui/realm.js imports S from shared/state.js, DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js)


------
https://chatgpt.com/codex/tasks/task_e_68aeeda4ab088326bdd506e48cd6010a