### PR TITLE
Refactor battle layout for mobile HUD

### DIFF
--- a/style.css
+++ b/style.css
@@ -4182,8 +4182,8 @@ tr:last-child td {
 
 /* Combat FX Layer */
 .battle-area{position:relative;overflow:visible;display:flex;flex-direction:column;gap:8px}
-.combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
-.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
+.combat-hud{display:flex;justify-content:space-between;align-items:flex-start;padding:4px 8px;gap:8px}
+.combat-hud .hud{display:flex;flex-direction:column;gap:4px;max-width:160px;width:45%;align-items:flex-start;text-align:left}
 .combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}
 .combat-hud .health-bar{height:12px;margin:0}
 .combat-hud .qi-bar{height:8px;margin:0}
@@ -4191,12 +4191,13 @@ tr:last-child td {
 .combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
-.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
-.sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
+.sprite-stage{position:relative;flex:0 0 auto;min-height:40vh;display:flex;align-items:flex-start;justify-content:space-between;gap:8px;padding:8px}
+.sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative;max-width:160px;width:45%}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
 .sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
 .sprite-stage .player-sprite{background-color:hsl(200,50%,60%)}
 .sprite-stage .enemy-sprite{background-color:hsl(0,50%,60%)}
+@media (min-width:768px){.combat-hud{justify-content:center;gap:24px}.combat-hud .hud{width:160px;align-items:center;text-align:center}.sprite-stage{min-height:120px;justify-content:center;gap:24px}.sprite-stage .combatant{width:160px}}
 @keyframes sprite-bob{from{transform:translateY(0)}to{transform:translateY(-4px)}}
 @media (prefers-reduced-motion:reduce){.sprite-stage .sprite{animation:none}}
 html.reduce-motion .sprite-stage .sprite{animation:none}


### PR DESCRIPTION
## Summary
- Make battle HUD mobile-first with left-aligned compact bars for player and enemy
- Align sprite stage beneath HUD and add responsive min-height
- Preserve desktop layout via breakpoint

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68af7eeebcc88326b6201d9c0c986f03