### PR TITLE
Refactor: responsive battle hud

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,11 +494,6 @@
 
                 <div class="hud enemy">
                   <div class="bar-group">
-                    <div class="enemy-name" id="enemyName">Select an area to begin</div>
-                    <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
-                      <div class="stun-fill" id="enemyStunFill"></div>
-                      <span class="stun-text" id="enemyStunText">0/100</span>
-                    </div>
                     <div class="health-bar">
                       <div class="health-fill" id="enemyHealthFill"></div>
                       <span class="health-text" id="enemyHealthText">--/--</span>
@@ -507,8 +502,13 @@
                       <div class="qi-fill" id="enemyQiFill"></div>
                       <span class="qi-text" id="enemyQiText">--</span>
                     </div>
-                    <div class="enemy-affixes" id="enemyAffixes"></div>
                   </div>
+                  <div class="enemy-name" id="enemyName">Select an area to begin</div>
+                  <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
+                    <div class="stun-fill" id="enemyStunFill"></div>
+                    <span class="stun-text" id="enemyStunText">0/100</span>
+                  </div>
+                  <div class="enemy-affixes" id="enemyAffixes"></div>
                   <div class="stat-icons">
                     <span class="icon" id="enemyAttack" title="ATK">⚔️</span>
                     <span class="icon" id="enemyAttackRate" title="Rate">⏱️</span>

--- a/style.css
+++ b/style.css
@@ -4182,17 +4182,18 @@ tr:last-child td {
 
 /* Combat FX Layer */
 .battle-area{position:relative;overflow:visible;display:flex;flex-direction:column;gap:8px}
-.combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
-.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
-.combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}
-.combat-hud .health-bar{height:12px;margin:0}
-.combat-hud .qi-bar{height:8px;margin:0}
+.combat-hud{display:grid;grid-template-columns:1fr 1fr;align-items:flex-start;justify-items:start;padding:4px 8px;gap:8px;width:100%}
+.combat-hud .hud{display:flex;flex-direction:column;gap:4px;align-items:flex-start;text-align:left}
+.combat-hud .bar-group{display:flex;flex-direction:row;gap:4px}
+.combat-hud .health-bar,.combat-hud .qi-bar{margin:0;width:150px}
+.combat-hud .health-bar{height:12px}
+.combat-hud .qi-bar{height:8px}
 .combat-hud .health-text,.combat-hud .qi-text{font-size:.65rem}
 .combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
-.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
-.sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
+.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:grid;grid-template-columns:1fr 1fr;align-items:flex-end;justify-items:center;padding:8px}
+.sprite-stage .combatant{display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
 .sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
 .sprite-stage .player-sprite{background-color:hsl(200,50%,60%)}
@@ -4201,6 +4202,16 @@ tr:last-child td {
 @media (prefers-reduced-motion:reduce){.sprite-stage .sprite{animation:none}}
 html.reduce-motion .sprite-stage .sprite{animation:none}
 .fx-layer{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;--fx-a:#fff;--fx-b:#fff}
+
+@media (max-width:600px){
+  .combat-hud{gap:4px}
+  .combat-hud .health-bar,.combat-hud .qi-bar{width:120px}
+  .combat-hud .stat-icons,
+  .combat-hud .enemy-name,
+  .combat-hud .stun-bar,
+  .combat-hud .enemy-affixes{display:none}
+  .sprite-stage{min-height:40vh}
+}
 .fx-stroke,.fx-thrust,.fx-beam{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-linecap:round}
 .fx-stroke{stroke-width:2;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .35s linear forwards}
 .fx-thrust{stroke-width:2;stroke-dasharray:60;stroke-dashoffset:60;animation:fx-draw .25s linear forwards}


### PR DESCRIPTION
## Summary
- Align player and enemy HP/Qi bars in a single row and center sprites beneath each side
- Use grid-based battle HUD with compact bars and responsive mobile styling
- Enforce mobile-first layout that hides extra UI elements and guarantees a 40vh sprite stage

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f6865a48326b620500328ed5d5c