### PR TITLE
Refactor combat HUD for mobile layout

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -66,6 +66,7 @@ way-of-ascension/
 │   ├── ai-verification-protocol.md
 │   ├── balance-protocol.md
 │   ├── cultivation-ui-style.md
+│   ├── game-state-and-mechanics.md
 │   ├── proficiency.md
 │   ├── parameters-and-formulas.md
 │   ├── project-structure.md
@@ -349,6 +350,7 @@ way-of-ascension/
 - `docs/To-dos/ui-improvements.md` – Planned UI improvements and enhancements.
 - `docs/To-dos/Balance.md` – Balance system notes and parameter guidelines.
 - `docs/To-dos/Palms-and-fists.md` – Concept notes for palm and fist weapon styles.
+- `docs/game-state-and-mechanics.md` – Overview of core game state and combat/resource mechanics.
 - `parameters-and-formulas.md` – Base stats, cultivation stats, activity starting stats, damage formulas, and skill XP scaling reference.
 - `To-dos/Balance.md` – Notes on planned balance adjustments.
 
@@ -855,6 +857,9 @@ Paths added:
 
 #### `docs/ARCHITECTURE.md` - Architecture Overview
 **Purpose**: Documents the controller, events bus and bootstrap pattern.
+
+#### `docs/game-state-and-mechanics.md` - Game State and Mechanics
+**Purpose**: Describes the overall game state layout and the core combat and resource mechanics.
 
 #### `docs/To-dos/stats-to-implement.md` - Stats Roadmap
 **Purpose**: Lists game stats that still need implementation.

--- a/style.css
+++ b/style.css
@@ -4182,17 +4182,21 @@ tr:last-child td {
 
 /* Combat FX Layer */
 .battle-area{position:relative;overflow:visible;display:flex;flex-direction:column;gap:8px}
-.combat-hud{display:flex;justify-content:center;align-items:flex-start;padding:4px 8px;gap:24px}
-.combat-hud .hud{display:flex;flex-direction:column;gap:4px;width:160px;align-items:center;text-align:center}
-.combat-hud .bar-group{display:flex;flex-direction:column;gap:2px;width:100%}
-.combat-hud .health-bar{height:12px;margin:0}
-.combat-hud .qi-bar{height:8px;margin:0}
+/* Combat HUD arranged in two equal columns for player and enemy */
+.combat-hud{display:grid;grid-template-columns:1fr 1fr;align-items:start;justify-items:start;padding:4px 8px;gap:8px;width:100%}
+.combat-hud .hud{display:flex;flex-direction:column;gap:4px;align-items:flex-start;text-align:left;width:100%;max-width:160px}
+/* HP and Qi bars inline within each column */
+.combat-hud .bar-group{display:flex;flex-direction:row;flex-wrap:wrap;gap:4px;width:100%;max-width:160px}
+.combat-hud .health-bar{flex:1;height:12px;margin:0}
+.combat-hud .qi-bar{flex:1;height:8px;margin:0}
+.combat-hud .enemy-name,.combat-hud .stun-bar,.combat-hud .enemy-affixes{flex-basis:100%}
 .combat-hud .health-text,.combat-hud .qi-text{font-size:.65rem}
 .combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
-.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
-.sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
+/* Sprite stage split into left/right halves */
+.sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:grid;grid-template-columns:1fr 1fr;align-items:flex-end;justify-items:center;padding:8px}
+.sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative;width:100%}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}
 .sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
 .sprite-stage .player-sprite{background-color:hsl(200,50%,60%)}
@@ -4200,6 +4204,16 @@ tr:last-child td {
 @keyframes sprite-bob{from{transform:translateY(0)}to{transform:translateY(-4px)}}
 @media (prefers-reduced-motion:reduce){.sprite-stage .sprite{animation:none}}
 html.reduce-motion .sprite-stage .sprite{animation:none}
+
+/* Mobile adjustments for slim HUD and larger stage */
+@media (max-width:600px){
+  .combat-hud{gap:4px}
+  .combat-hud .stat-icons,
+  .combat-hud .enemy-name,
+  .combat-hud .stun-bar,
+  .combat-hud .enemy-affixes{display:none}
+  .sprite-stage{min-height:40vh}
+}
 .fx-layer{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;--fx-a:#fff;--fx-b:#fff}
 .fx-stroke,.fx-thrust,.fx-beam{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-linecap:round}
 .fx-stroke{stroke-width:2;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .35s linear forwards}


### PR DESCRIPTION
## Summary
- Rework combat HUD into a two-column grid so both combatants' HP and Qi bars sit inline, left-aligned, and compact.
- Center player and enemy sprites beneath their respective bars and expand stage height on small screens.
- Document game-state-and-mechanics file in project structure docs.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations in multiple UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68b03f6865a48326b620500328ed5d5c