### PR TITLE
feat: add astral skill tree

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -66,6 +66,7 @@ way-of-ascension/
 │   ├── ai-verification-protocol.md
 │   ├── balance-protocol.md
 │   ├── cultivation-ui-style.md
+│   ├── game-state-and-mechanics.md
 │   ├── proficiency.md
 │   ├── parameters-and-formulas.md
 │   ├── project-structure.md
@@ -202,7 +203,8 @@ way-of-ascension/
 │   │   │       ├── lawsHUD.js
 │   │   │       ├── qiDisplay.js
 │   │   │       ├── qiOrb.js
-│   │   │       └── realm.js
+│   │   │       ├── realm.js
+│   │   │       └── astralTree.js
 │   │   ├── sect/
 │   │   │   ├── data/
 │   │   │   │   ├── _balance.contract.js
@@ -749,6 +751,9 @@ function updateAll() {
 
 #### `src/features/progression/ui/lawsHUD.js` - Active Laws HUD
 **Purpose**: Displays learned laws and bonuses in the HUD.
+
+#### `src/features/progression/ui/astralTree.js` - Astral Skill Tree UI
+**Purpose**: Renders the astral skill tree overlay and handles open/close interactions.
 
 ### UI Effects (`src/features/combat/ui/`)
 

--- a/index.html
+++ b/index.html
@@ -146,8 +146,9 @@
 
         <div id="cultivationSubTab" class="cultivation-tab-content tab-content active">
           <div class="cultivation-layout">
-            <div class="cultivation-visualization-container">
+          <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
+                <button id="openAstralTree" class="astral-tree-btn">Astral Tree</button>
                 
                 <!-- Misty fog layers behind silhouette -->
                 <div class="misty-fog">
@@ -231,10 +232,10 @@
                     <div class="qi-stream stream-1"></div>
                     <div class="qi-stream stream-2"></div>
                     <div class="qi-stream stream-3"></div>
-                    <div class="qi-mist"></div>
-                  </div>
+                  <div class="qi-mist"></div>
+                </div>
                   
-                  <!-- Yin-Yang in chest area -->
+                <!-- Yin-Yang in chest area -->
                   <div class="chest-area">
                     <div class="yin-yang-container" id="yinYangContainer">
                       <svg class="yin-yang-svg" id="cultivationYinYang" viewBox="0 0 512 512" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false">
@@ -965,6 +966,11 @@
     </div>
   </div>
 
+  <div id="astralSkillTreeOverlay" class="astral-skill-tree">
+    <div class="starfield"></div>
+    <button id="closeAstralTree" class="astral-tree-close">Close</button>
+    <svg id="astralTreeSvg"></svg>
+  </div>
 
   <script type="module" src="ui/index.js"></script>
   <script type="module">

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -10,6 +10,7 @@ import { mountLawDisplay } from "./progression/ui/lawDisplay.js";
 import { mountMiningUI } from "./mining/ui/miningDisplay.js";
 import { mountPhysiqueUI } from "./physique/ui/physiqueDisplay.js";
 import { mountMindReadingUI } from "./mind/ui/mindReadingTab.js";
+import { mountAstralTreeUI } from "./progression/ui/astralTree.js";
 
 
 // Example placeholder for later:
@@ -25,6 +26,7 @@ export function mountAllFeatureUIs(state) {
   mountPhysiqueUI(state);
   mountLawDisplay(state);
   mountMindReadingUI(state);
+  mountAstralTreeUI(state);
 
   // mountWeaponGenUI?.(state);
 }

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -1,0 +1,109 @@
+export function mountAstralTreeUI() {
+  const openBtn = document.getElementById('openAstralTree');
+  const overlay = document.getElementById('astralSkillTreeOverlay');
+  const closeBtn = document.getElementById('closeAstralTree');
+  if (!openBtn || !overlay || !closeBtn) return;
+
+  openBtn.addEventListener('click', () => {
+    overlay.style.display = 'block';
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.style.display = 'none';
+  });
+
+  buildTree();
+}
+
+function buildTree() {
+  const svg = document.getElementById('astralTreeSvg');
+  if (!svg) return;
+
+  const width = 1000;
+  const height = 1000;
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+  const nodes = [];
+  const edges = [];
+
+  const center = { id: 'hub', x: width / 2, y: height / 2, type: 'hub' };
+  nodes.push(center);
+
+  const elements = [
+    { name: 'Wood', cls: 'wood', angle: -90 },
+    { name: 'Fire', cls: 'fire', angle: -18 },
+    { name: 'Earth', cls: 'earth', angle: 54 },
+    { name: 'Metal', cls: 'metal', angle: 126 },
+    { name: 'Water', cls: 'water', angle: 198 }
+  ];
+
+  const startNodes = [];
+
+  elements.forEach(el => {
+    const rad = (el.angle * Math.PI) / 180;
+    const sx = center.x + Math.cos(rad) * 100;
+    const sy = center.y + Math.sin(rad) * 100;
+    const startId = `${el.name.toLowerCase()}-start`;
+    nodes.push({ id: startId, x: sx, y: sy, type: 'start', element: el.cls });
+    edges.push({ from: center.id, to: startId, element: el.cls });
+    startNodes.push(startId);
+
+    const regionX = center.x + Math.cos(rad) * 260;
+    const regionY = center.y + Math.sin(rad) * 260;
+
+    for (let c = 0; c < 2; c++) {
+      const offsetAngle = rad + ((c === 0 ? -30 : 30) * Math.PI) / 180;
+      const nx = regionX + Math.cos(offsetAngle) * 60;
+      const ny = regionY + Math.sin(offsetAngle) * 60;
+      const notableId = `${el.name.toLowerCase()}-notable-${c}`;
+      nodes.push({ id: notableId, x: nx, y: ny, type: 'notable', element: el.cls });
+      edges.push({ from: startId, to: notableId, element: el.cls });
+
+      const clusterSize = 4;
+      let prev = notableId;
+      let first = null;
+      for (let i = 0; i < clusterSize; i++) {
+        const ang = (Math.PI * 2 * i) / clusterSize;
+        const cx = nx + Math.cos(ang) * 30;
+        const cy = ny + Math.sin(ang) * 30;
+        const nodeId = `${el.name.toLowerCase()}-${c}-node-${i}`;
+        nodes.push({ id: nodeId, x: cx, y: cy, type: 'stat', element: el.cls });
+        edges.push({ from: prev, to: nodeId, element: el.cls });
+        prev = nodeId;
+        if (i === 0) first = nodeId;
+      }
+      edges.push({ from: prev, to: first, element: el.cls });
+      edges.push({ from: first, to: `${el.name.toLowerCase()}-${c}-node-2`, element: el.cls });
+    }
+  });
+
+  for (let i = 0; i < startNodes.length; i++) {
+    const from = startNodes[i];
+    const to = startNodes[(i + 1) % startNodes.length];
+    edges.push({ from, to, element: 'link' });
+  }
+
+  edges.forEach(edge => {
+    const from = nodes.find(n => n.id === edge.from);
+    const to = nodes.find(n => n.id === edge.to);
+    if (!from || !to) return;
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', from.x);
+    line.setAttribute('y1', from.y);
+    line.setAttribute('x2', to.x);
+    line.setAttribute('y2', to.y);
+    line.setAttribute('class', `connector ${edge.element}`);
+    svg.appendChild(line);
+  });
+
+  nodes.forEach(node => {
+    const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    circle.setAttribute('cx', node.x);
+    circle.setAttribute('cy', node.y);
+    const r = node.type === 'notable' ? 8 : node.type === 'start' ? 6 : 4;
+    circle.setAttribute('r', r);
+    circle.setAttribute('class', `node ${node.element || ''} ${node.type}`);
+    svg.appendChild(circle);
+  });
+}
+

--- a/style.css
+++ b/style.css
@@ -4488,3 +4488,55 @@ html.reduce-motion .log-sheet{transition:none;}
   color:#9ab;
   font-style:italic;
 }
+
+/* Astral Skill Tree overlay */
+.astral-skill-tree{
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  background:#000;
+  background-image:radial-gradient(#111, #000);
+  overflow:hidden;
+  display:none;
+  z-index:1000;
+}
+
+.astral-skill-tree .starfield{
+  position:absolute;
+  width:100%;
+  height:100%;
+  background-image:radial-gradient(white 1px, transparent 1px), radial-gradient(white 1px, transparent 1px);
+  background-size:50px 50px,100px 100px;
+  background-position:0 0,25px 25px;
+  opacity:0.2;
+  pointer-events:none;
+}
+
+.astral-tree-close{
+  position:absolute;
+  top:20px;
+  right:20px;
+  z-index:10;
+}
+
+.astral-tree-btn{
+  position:absolute;
+  top:10px;
+  right:10px;
+  z-index:5;
+}
+
+.astral-skill-tree svg{width:100%;height:100%;}
+.connector{stroke-width:1.5;fill:none;opacity:0.7;filter:drop-shadow(0 0 2px currentColor);}
+.node{fill:#000;stroke-width:2;filter:drop-shadow(0 0 4px currentColor);}
+.node.start{stroke-width:2;}
+
+.connector.wood,.node.wood{stroke:#4caf50;}
+.connector.fire,.node.fire{stroke:#f44336;}
+.connector.earth,.node.earth{stroke:#795548;}
+.connector.metal,.node.metal{stroke:#c0c0c0;}
+.connector.water,.node.water{stroke:#2196f3;}
+.connector.link{stroke:#888;}
+

--- a/ui/index.js
+++ b/ui/index.js
@@ -53,6 +53,7 @@ import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
 import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
+import { mountAstralTreeUI } from '../src/features/progression/ui/astralTree.js';
 import { ensureMindState, xpProgress as mindXpProgress, onTick as mindOnTick } from '../src/features/mind/index.js';
 import { renderMindMainTab, setupMindTabs } from '../src/features/mind/ui/mindMainTab.js';
 import { renderMindReadingTab, mountMindReadingUI } from '../src/features/mind/ui/mindReadingTab.js';
@@ -641,6 +642,7 @@ window.addEventListener('load', ()=>{
   mountKarmaUI(S);
   mountSectUI(S);
   mountMindReadingUI(S);
+  mountAstralTreeUI(S);
   renderMindMainTab(document.getElementById('mindMainTab'), S);
   renderMindReadingTab(document.getElementById('mindReadingTab'), S);
   renderMindStatsTab(document.getElementById('mindStatsTab'), S);


### PR DESCRIPTION
## Summary
- add astral skill tree overlay with five-element regions
- hook up button on cultivation silhouette to open skill tree
- document new UI module in project structure

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations and timers)


------
https://chatgpt.com/codex/tasks/task_e_68b0e52ba2888326b0dd40743e4dec32