### PR TITLE
feat: add astral skill tree

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -68,6 +68,7 @@ way-of-ascension/
 │   ├── cultivation-ui-style.md
 │   ├── proficiency.md
 │   ├── parameters-and-formulas.md
+│   ├── game-state-and-mechanics.md
 │   ├── project-structure.md
 │   └── ARCHITECTURE.md
 ├── node_modules/
@@ -198,6 +199,7 @@ way-of-ascension/
 │   │   │   ├── state.js
 │   │   │   ├── index.js
 │   │   │   └── ui/
+│   │   │       ├── astralTree.js
 │   │   │       ├── lawDisplay.js
 │   │   │       ├── lawsHUD.js
 │   │   │       ├── qiDisplay.js
@@ -749,6 +751,10 @@ function updateAll() {
 
 #### `src/features/progression/ui/lawsHUD.js` - Active Laws HUD
 **Purpose**: Displays learned laws and bonuses in the HUD.
+
+#### `src/features/progression/ui/astralTree.js` - Astral Skill Tree Overlay
+**Purpose**: Renders the astral skill tree with elemental regions and nodes.
+**When to modify**: Update tree layout or interactions.
 
 ### UI Effects (`src/features/combat/ui/`)
 

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
           <div class="cultivation-layout">
             <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
+                <div class="astral-tree-button"><button id="openAstralTree" class="btn astral-btn">Astral Skill Tree</button></div>
                 
                 <!-- Misty fog layers behind silhouette -->
                 <div class="misty-fog">
@@ -966,6 +967,10 @@
   </div>
 
 
+  <div id="astralSkillTreeOverlay" class="astral-skill-tree" style="display:none;">
+    <button id="closeAstralTree" class="btn astral-btn astral-close">Close</button>
+    <svg id="astralSkillTreeSvg"></svg>
+  </div>
   <script type="module" src="ui/index.js"></script>
   <script type="module">
     import { mountDevQuickMenu } from "./src/ui/dev/devQuickMenu.js";

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -1,0 +1,157 @@
+import { qs } from '../../../shared/utils/dom.js';
+
+function buildTree(svg){
+  const width = svg.clientWidth;
+  const height = svg.clientHeight;
+  const cx = width / 2;
+  const cy = height / 2;
+  const ns = 'http://www.w3.org/2000/svg';
+
+  const regions = [
+    { key: 'wood', color: '#3fa34d', angle: -90 },
+    { key: 'fire', color: '#e74c3c', angle: -18 },
+    { key: 'earth', color: '#8b4513', angle: 54 },
+    { key: 'metal', color: '#c0c0c0', angle: 126 },
+    { key: 'water', color: '#3498db', angle: 198 }
+  ];
+
+  const nodes = [];
+  const nodeMap = {};
+  const edges = [];
+
+  function radiusFor(type){
+    return type === 'hub' ? 10 : type === 'notable' ? 8 : type === 'start' ? 6 : 4;
+  }
+
+  function addNode(node){
+    node.r = radiusFor(node.type);
+    nodes.push(node);
+    nodeMap[node.id] = node;
+  }
+
+  addNode({ id: 'hub', x: cx, y: cy, type: 'hub', color: '#ffffff' });
+
+  regions.forEach(region => {
+    const rad = region.angle * Math.PI / 180;
+    const startX = cx + Math.cos(rad) * 100;
+    const startY = cy + Math.sin(rad) * 100;
+    const startId = `${region.key}-start`;
+    addNode({ id: startId, x: startX, y: startY, type: 'start', color: region.color });
+    edges.push(['hub', startId]);
+
+    const clusterCenterX = cx + Math.cos(rad) * 220;
+    const clusterCenterY = cy + Math.sin(rad) * 220;
+
+    const clusterNodes = [];
+    const numSmall = 8;
+    for(let j=0;j<numSmall;j++){
+      const offset = 2 * Math.PI * j / numSmall;
+      const r = 40;
+      const id = `${region.key}-n${j}`;
+      const x = clusterCenterX + Math.cos(offset) * r;
+      const y = clusterCenterY + Math.sin(offset) * r;
+      addNode({ id, x, y, type: 'small', color: region.color });
+      clusterNodes.push(id);
+    }
+
+    // Notables
+    for(let j=0;j<2;j++){
+      const id = `${region.key}-notable${j}`;
+      const off = Math.PI * j;
+      const x = clusterCenterX + Math.cos(off) * 80;
+      const y = clusterCenterY + Math.sin(off) * 80;
+      addNode({ id, x, y, type: 'notable', color: region.color });
+    }
+
+    // Connect start to two clusters
+    edges.push([startId, clusterNodes[0]]);
+    edges.push([startId, clusterNodes[4]]);
+
+    // Cluster 1 loop
+    for(let i=0;i<4;i++){
+      const a = clusterNodes[i];
+      const b = clusterNodes[(i+1)%4];
+      edges.push([a,b]);
+    }
+    edges.push([clusterNodes[2], `${region.key}-notable0`]);
+    edges.push([clusterNodes[3], `${region.key}-notable0`]);
+
+    // Cluster 2 loop
+    for(let i=4;i<8;i++){
+      const a = clusterNodes[i];
+      const b = clusterNodes[i===7?4:i+1];
+      edges.push([a,b]);
+    }
+    edges.push([clusterNodes[5], `${region.key}-notable1`]);
+    edges.push([clusterNodes[7], `${region.key}-notable1`]);
+
+    // Connect clusters
+    edges.push([clusterNodes[2], clusterNodes[4]]);
+  });
+
+  // Cross-links between regions
+  for(let i=0;i<regions.length;i++){
+    const cur = regions[i];
+    const next = regions[(i+1)%regions.length];
+    edges.push([`${cur.key}-notable1`, `${next.key}-start`]);
+  }
+
+  // Draw edges
+  edges.forEach(([fromId,toId]) => {
+    const a = nodeMap[fromId];
+    const b = nodeMap[toId];
+    if(!a || !b) return;
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const dist = Math.hypot(dx, dy);
+    const startX = a.x + (dx / dist) * a.r;
+    const startY = a.y + (dy / dist) * a.r;
+    const endX = b.x - (dx / dist) * b.r;
+    const endY = b.y - (dy / dist) * b.r;
+    const line = document.createElementNS(ns, 'line');
+    line.setAttribute('x1', startX);
+    line.setAttribute('y1', startY);
+    line.setAttribute('x2', endX);
+    line.setAttribute('y2', endY);
+    line.setAttribute('stroke', a.color);
+    line.classList.add('connector');
+    line.style.filter = 'drop-shadow(0 0 2px ' + a.color + ')';
+    svg.appendChild(line);
+  });
+
+  // Draw nodes
+  nodes.forEach(n => {
+    const circle = document.createElementNS(ns, 'circle');
+    circle.setAttribute('cx', n.x);
+    circle.setAttribute('cy', n.y);
+    circle.setAttribute('r', n.r);
+    circle.setAttribute('fill', n.color);
+    circle.classList.add('node');
+    circle.style.filter = 'drop-shadow(0 0 4px ' + n.color + ')';
+    if(n.type) circle.classList.add(n.type);
+    svg.appendChild(circle);
+  });
+}
+
+export function mountAstralTreeUI(state){
+  const openBtn = qs('#openAstralTree');
+  const overlay = qs('#astralSkillTreeOverlay');
+  const closeBtn = qs('#closeAstralTree');
+  const svg = qs('#astralSkillTreeSvg');
+  if(!openBtn || !overlay || !closeBtn || !svg) return;
+
+  function open(){
+    overlay.style.display = 'flex';
+    if(!svg.dataset.built){
+      buildTree(svg);
+      svg.dataset.built = '1';
+    }
+  }
+  function close(){
+    overlay.style.display = 'none';
+  }
+
+  openBtn.addEventListener('click', open);
+  closeBtn.addEventListener('click', close);
+}
+

--- a/style.css
+++ b/style.css
@@ -4488,3 +4488,53 @@ html.reduce-motion .log-sheet{transition:none;}
   color:#9ab;
   font-style:italic;
 }
+/* Astral Skill Tree overlay */
+.astral-skill-tree{
+  position:fixed;
+  inset:0;
+  display:none;
+  align-items:center;
+  justify-content:center;
+  background:radial-gradient(circle at center,#000016,#000);
+  z-index:1000;
+}
+.astral-skill-tree::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background-image:radial-gradient(rgba(255,255,255,0.3) 1px, transparent 1px);
+  background-size:2px 2px;
+  opacity:0.2;
+}
+#astralSkillTreeSvg{
+  width:100%;
+  height:100%;
+}
+.astral-skill-tree .node{
+  stroke:#fff;
+  stroke-width:1;
+  filter:drop-shadow(0 0 4px currentColor);
+}
+.astral-skill-tree .connector{
+  stroke-width:1.5;
+  filter:drop-shadow(0 0 2px currentColor);
+}
+.astral-tree-button{
+  position:absolute;
+  top:8px;
+  right:8px;
+  z-index:20;
+}
+.astral-btn{
+  background:rgba(0,0,0,0.6);
+  color:#fff;
+  border:1px solid #666;
+}
+.astral-btn:hover{
+  background:rgba(80,80,80,0.6);
+}
+.astral-close{
+  position:absolute;
+  top:16px;
+  right:16px;
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -56,6 +56,7 @@ import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
 import { ensureMindState, xpProgress as mindXpProgress, onTick as mindOnTick } from '../src/features/mind/index.js';
 import { renderMindMainTab, setupMindTabs } from '../src/features/mind/ui/mindMainTab.js';
 import { renderMindReadingTab, mountMindReadingUI } from '../src/features/mind/ui/mindReadingTab.js';
+import { mountAstralTreeUI } from '../src/features/progression/ui/astralTree.js';
 import { renderMindPuzzlesTab } from '../src/features/mind/ui/mindPuzzlesTab.js';
 import { renderMindStatsTab } from '../src/features/mind/ui/mindStatsTab.js';
 import { updateQiAndFoundation } from '../src/features/progression/ui/qiDisplay.js';
@@ -641,6 +642,7 @@ window.addEventListener('load', ()=>{
   mountKarmaUI(S);
   mountSectUI(S);
   mountMindReadingUI(S);
+  mountAstralTreeUI(S);
   renderMindMainTab(document.getElementById('mindMainTab'), S);
   renderMindReadingTab(document.getElementById('mindReadingTab'), S);
   renderMindStatsTab(document.getElementById('mindStatsTab'), S);


### PR DESCRIPTION
## Summary
- add astral skill tree overlay with elemental regions and notables
- wire silhouette button to open the astral tree
- document new feature in project structure
- adjust connectors so lines stop at node edges instead of passing through nodes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation: imports S from shared/state.js and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e52ba2888326b0dd40743e4dec32