### PR TITLE
Add tooltips and purchasing rules to astral tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -970,6 +970,7 @@
     <div class="starfield"></div>
     <button id="closeAstralTree" class="astral-tree-close">Close</button>
     <svg id="astralTreeSvg"></svg>
+    <div id="astralTooltip" class="astral-tooltip"></div>
   </div>
 
   <script type="module" src="ui/index.js"></script>

--- a/style.css
+++ b/style.css
@@ -4540,6 +4540,9 @@ html.reduce-motion .log-sheet{transition:none;}
 .connector.metal,.node.metal{stroke:#c0c0c0;color:#c0c0c0;}
 .connector.water,.node.water{stroke:#2196f3;color:#2196f3;}
 .node.taken{fill:currentColor;}
-.node.allocatable{cursor:pointer;}
+.node.allocatable{cursor:pointer;filter:drop-shadow(0 0 8px currentColor);}
+.connector.allocatable{cursor:pointer;filter:drop-shadow(0 0 6px currentColor);}
 .connector.link{stroke:#888;}
+
+.astral-tooltip{position:absolute;background:rgba(0,0,0,0.8);color:#fff;padding:4px 6px;border:1px solid #888;border-radius:4px;pointer-events:none;white-space:pre;font-size:12px;display:none;z-index:20;}
 


### PR DESCRIPTION
## Summary
- add persistent purchase state for connectors and restrict node buying to unlocked paths
- show cost and effect tooltip on node hover and highlight purchasable nodes
- style tooltip overlay and glow for allocatable nodes and connectors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b192545108832690cd00977baa9840