### PR TITLE
feat: add tooltips and purchase gating for astral tree nodes

### DIFF
--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -1,6 +1,7 @@
 import { S, save } from '../../../shared/state.js';
 
 const STORAGE_KEY = 'astralTreeAllocated';
+const START_NODES = new Set([1, 2, 3, 4, 5]);
 
 const BASIC_ROTATION = [
   { desc: '+2% Foundation Gain', bonus: { foundationGainPct: 2 } },
@@ -103,8 +104,35 @@ export function mountAstralTreeUI() {
 
 async function buildTree() {
   const svg = document.getElementById('astralTreeSvg');
-  if (!svg) return;
+  const overlay = document.getElementById('astralSkillTreeOverlay');
+  if (!svg || !overlay) return;
   svg.innerHTML = '';
+
+  const existing = document.getElementById('astralTreeTooltip');
+  if (existing) existing.remove();
+  const tooltip = document.createElement('div');
+  tooltip.id = 'astralTreeTooltip';
+  tooltip.className = 'astral-tooltip';
+  tooltip.style.display = 'none';
+  overlay.appendChild(tooltip);
+
+  function positionTooltip(evt) {
+    tooltip.style.left = `${evt.clientX + 10}px`;
+    tooltip.style.top = `${evt.clientY + 10}px`;
+  }
+
+  function showTooltip(evt, n) {
+    const info = manifest[n.id] || {};
+    const lines = [n.label, `Cost: ${info.cost ?? '-'}`];
+    if (info.effects) lines.push(...info.effects);
+    tooltip.innerHTML = lines.join('<br>');
+    tooltip.style.display = 'block';
+    positionTooltip(evt);
+  }
+
+  function hideTooltip() {
+    tooltip.style.display = 'none';
+  }
 
   const res = await fetch(new URL('../data/astral_tree.json', import.meta.url));
   const treeData = await res.json();
@@ -159,15 +187,16 @@ async function buildTree() {
     circle.setAttribute('r', r);
     circle.setAttribute('class', `node ${n.group.toLowerCase()} ${n.type}`);
 
-    const eff = manifest[n.id];
-    const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
-    const lines = [n.label];
-    if (eff) lines.push(...eff.effects);
-    title.textContent = lines.join('\n');
-    circle.appendChild(title);
+    circle.addEventListener('mouseenter', e => showTooltip(e, n));
+    circle.addEventListener('mousemove', positionTooltip);
+    circle.addEventListener('mouseleave', hideTooltip);
 
-    circle.addEventListener('click', () => {
-      if (!isAllocatable(n.id, allocated, adj)) return;
+    circle.addEventListener('click', e => {
+      showTooltip(e, n);
+      if (!isAllocatable(n.id, allocated, adj, manifest)) return;
+      const info = manifest[n.id];
+      if ((S.astralPoints || 0) < (info?.cost || 0)) return;
+      S.astralPoints -= info.cost;
       allocated.add(n.id);
       applyEffects(n.id, manifest);
       saveAllocations(allocated);
@@ -182,16 +211,22 @@ async function buildTree() {
     nodes.forEach(n => {
       const el = nodeEls[n.id];
       el.classList.toggle('taken', allocated.has(n.id));
-      el.classList.toggle('allocatable', !allocated.has(n.id) && isAllocatable(n.id, allocated, adj));
+      el.classList.toggle(
+        'allocatable',
+        !allocated.has(n.id) && isAllocatable(n.id, allocated, adj, manifest)
+      );
     });
   }
 
   refreshClasses();
 }
 
-function isAllocatable(id, allocated, adj) {
+function isAllocatable(id, allocated, adj, manifest) {
   if (allocated.has(id)) return false;
-  if (allocated.size === 0) return true;
+  const info = manifest[id];
+  if (!info) return false;
+  if ((S.astralPoints || 0) < info.cost) return false;
+  if (allocated.size === 0) return START_NODES.has(id);
   const neighbors = adj[id] || [];
   return neighbors.some(n => allocated.has(n));
 }

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -26,6 +26,7 @@ export const defaultState = () => {
   qiCapMult: 0, // Qi capacity multiplier from buildings/bonuses
   qiRegenMult: 0, // Qi regeneration multiplier from buildings/bonuses
   foundation: 0,
+  astralPoints: 50,
   ...initHp(100),
   shield: { current: 0, max: 0 },
   autoFillShieldFromQi: true,

--- a/style.css
+++ b/style.css
@@ -4540,6 +4540,27 @@ html.reduce-motion .log-sheet{transition:none;}
 .connector.metal,.node.metal{stroke:#c0c0c0;color:#c0c0c0;}
 .connector.water,.node.water{stroke:#2196f3;color:#2196f3;}
 .node.taken{fill:currentColor;}
-.node.allocatable{cursor:pointer;}
+.node.allocatable{
+  cursor:pointer;
+  animation:nodeGlow 1.5s ease-in-out infinite alternate;
+}
 .connector.link{stroke:#888;}
+
+@keyframes nodeGlow{
+  from{filter:drop-shadow(0 0 4px currentColor);}
+  to{filter:drop-shadow(0 0 10px currentColor);}
+}
+
+.astral-tooltip{
+  position:absolute;
+  background:#111;
+  color:#fff;
+  border:1px solid #fff;
+  padding:4px 8px;
+  border-radius:4px;
+  pointer-events:none;
+  white-space:nowrap;
+  z-index:20;
+  font-size:12px;
+}
 


### PR DESCRIPTION
## Summary
- show detailed tooltip with cost and effects for astral tree nodes
- restrict initial node purchases and deduct astral points on buy
- highlight purchasable nodes with animated glow

## Testing
- `npm run validate` (fails: UI state violations in existing files)
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b192545108832690cd00977baa9840