### PR TITLE
feat: add zoom controls for astral tree

### DIFF
--- a/index.html
+++ b/index.html
@@ -969,6 +969,10 @@
   <div id="astralSkillTreeOverlay" class="astral-skill-tree">
     <div class="starfield"></div>
     <div id="astralInsight" class="astral-insight"></div>
+    <div class="astral-zoom-controls">
+      <button id="astralZoomIn" class="astral-zoom-btn">+</button>
+      <button id="astralZoomOut" class="astral-zoom-btn">−</button>
+    </div>
     <button id="closeAstralTree" class="astral-tree-close">Close</button>
     <svg id="astralTreeSvg"></svg>
   </div>

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -107,6 +107,8 @@ export function mountAstralTreeUI() {
 async function buildTree() {
   const svg = document.getElementById('astralTreeSvg');
   const overlay = document.getElementById('astralSkillTreeOverlay');
+  const zoomInBtn = document.getElementById('astralZoomIn');
+  const zoomOutBtn = document.getElementById('astralZoomOut');
   if (!svg || !overlay) return;
   svg.innerHTML = '';
 
@@ -166,7 +168,38 @@ async function buildTree() {
   const maxX = Math.max(...xs) + 50;
   const minY = Math.min(...ys) - 50;
   const maxY = Math.max(...ys) + 50;
-  svg.setAttribute('viewBox', `${minX} ${minY} ${maxX - minX} ${maxY - minY}`);
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+
+  const viewBox = {
+    x: centerX - width / 4,
+    y: centerY - height / 4,
+    width: width / 2,
+    height: height / 2,
+  };
+
+  function applyViewBox() {
+    svg.setAttribute(
+      'viewBox',
+      `${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`
+    );
+  }
+
+  applyViewBox();
+
+  function zoom(factor) {
+    viewBox.width *= factor;
+    viewBox.height *= factor;
+    viewBox.x = centerX - viewBox.width / 2;
+    viewBox.y = centerY - viewBox.height / 2;
+    applyViewBox();
+  }
+
+  const ZOOM_STEP = 0.8;
+  if (zoomInBtn) zoomInBtn.addEventListener('click', () => zoom(ZOOM_STEP));
+  if (zoomOutBtn) zoomOutBtn.addEventListener('click', () => zoom(1 / ZOOM_STEP));
 
   const allocated = loadAllocations();
   S.astralTreeBonuses = {};

--- a/style.css
+++ b/style.css
@@ -4494,8 +4494,8 @@ html.reduce-motion .log-sheet{transition:none;}
   position:fixed;
   top:0;
   left:0;
-  width:100%;
-  height:100%;
+  width:100vw;
+  height:100vh;
   background:#000;
   background-image:radial-gradient(#111, #000);
   overflow:hidden;
@@ -4529,6 +4529,25 @@ html.reduce-motion .log-sheet{transition:none;}
   top:20px;
   right:20px;
   z-index:10;
+}
+
+.astral-zoom-controls{
+  position:absolute;
+  top:20px;
+  left:20px;
+  display:flex;
+  flex-direction:column;
+  gap:5px;
+  z-index:10;
+}
+
+.astral-zoom-btn{
+  width:32px;
+  height:32px;
+  background:#222;
+  color:#fff;
+  border:1px solid #555;
+  cursor:pointer;
 }
 
 .astral-tree-btn{


### PR DESCRIPTION
## Summary
- make astral tree overlay span the full screen
- add zoom in/out buttons and styles
- initialize astral tree view centered and zoomable

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js; UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js; UI state violation: src/features/adventure/ui/progressBar.js imports S from shared/state.js; UI state violation: src/features/combat/ui/combatStats.js imports S from shared/state.js; UI state violation: src/features/cooking/ui/cookControls.js imports S from shared/state.js; UI state violation: src/features/cooking/ui/cookingDisplay.js imports S from shared/state.js; UI state violation: src/features/inventory/ui/resourceDisplay.js imports S from shared/state.js; UI state violation: src/features/karma/ui/karmaHUD.js imports S from shared/state.js; UI state violation: src/features/loot/ui/lootTab.js imports S from shared/state.js; UI state violation: src/features/mining/ui/miningDisplay.js imports S from shared/state.js; UI state violation: src/features/proficiency/ui/weaponProficiencyDisplay.js imports S from shared/state.js; UI state violation: src/features/progression/ui/lawDisplay.js imports S from shared/state.js; UI state violation: src/features/progression/ui/qiDisplay.js imports S from shared/state.js; UI state violation: src/features/progression/ui/qiOrb.js imports S from shared/state.js; UI state violation: src/features/progression/ui/realm.js imports S from shared/state.js; DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js)


------
https://chatgpt.com/codex/tasks/task_e_68b1990f5c608326ae16db699d5e6036