### PR TITLE
feat: implement Insight gain tick

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -196,6 +196,7 @@ way-of-ascension/
 │   │   │   │   ├── astral_tree.json
 │   │   │   │   ├── laws.js
 │   │   │   │   └── realms.js
+│   │   │   ├── insight.js
 │   │   │   ├── logic.js
 │   │   │   ├── migrations.js
 │   │   │   ├── mutators.js
@@ -740,6 +741,10 @@ function updateAll() {
 #### `src/features/progression/logic.js` - Progression Calculations
 **Purpose**: Core formulas for cultivation and combat stats.
 **Key Functions**: `fCap(state)`, `calcAtk(state)`, `breakthroughChance(state)`.
+
+#### `src/features/progression/insight.js` - Insight Gain Tick
+**Purpose**: Computes Insight accumulation each tick based on Foundation gain and current activity.
+**Key Functions**: `tickInsight(state, dtSec)`.
 
 #### `src/features/progression/data/realms.js` - Cultivation Realms
 **Purpose**: Define realm tiers and their properties.

--- a/src/features/progression/insight.js
+++ b/src/features/progression/insight.js
@@ -1,0 +1,23 @@
+import { foundationGainPerSec } from './selectors.js';
+
+const S_BASE = 0.06;
+const ACTIVITY_MULTIPLIER = {
+  cultivation: 0.5,
+  other: 0.1,
+  idle: 0,
+};
+
+export function tickInsight(state, dtSec = 1) {
+  const FGR_pm = foundationGainPerSec(state) * 60;
+  const activities = state.activities || {};
+  let A = ACTIVITY_MULTIPLIER.idle;
+  if (activities.cultivation) {
+    A = ACTIVITY_MULTIPLIER.cultivation;
+  } else if (Object.values(activities).some(Boolean)) {
+    A = ACTIVITY_MULTIPLIER.other;
+  }
+  const pctBonus = (state.astralTreeBonuses?.insightGainPct || 0) / 100;
+  const insightRatePm = FGR_pm * S_BASE * A * (1 + pctBonus);
+  const delta = (insightRatePm / 60) * dtSec;
+  state.astralPoints = (state.astralPoints || 0) + delta;
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -74,6 +74,7 @@ import { selectActivity as selectActivityMut, startActivity as startActivityMut,
 import { getSelectedActivity } from '../src/features/activity/selectors.js';
 import { mountActivityUI, updateActivitySelectors, updateCurrentTaskDisplay } from '../src/features/activity/ui/activityUI.js';
 import { meditate } from '../src/features/progression/mutators.js';
+import { tickInsight } from '../src/features/progression/insight.js';
 import { usePill } from '../src/features/inventory/mutators.js';
 
 // Global variables
@@ -460,6 +461,9 @@ function tick(){
     S.foundation = clamp(S.foundation + gain, 0, fCap(S));
   }
   if(isAutoAdventure() && !S.activities.adventure){ startActivity('adventure'); }
+
+  // Insight gain
+  tickInsight(S, 1);
 
   // Breakthrough progress
   updateBreakthrough();


### PR DESCRIPTION
## Summary
- add Insight tick formula tied to Foundation gain and activity
- call Insight update every second in main tick loop
- document new progression Insight module

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68b262e17a548326806f28578f78e038