### PR TITLE
feat: enlarge astral tree node sizes

### DIFF
--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -224,7 +224,8 @@ async function buildTree() {
     const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
     circle.setAttribute('cx', n.x);
     circle.setAttribute('cy', n.y);
-    const r = n.type === 'notable' ? 8 : 4;
+    // Increase node sizes: basic nodes 50% larger, notables 100% larger
+    const r = n.type === 'notable' ? 16 : 6;
     circle.setAttribute('r', r);
     circle.setAttribute('class', `node ${n.group.toLowerCase()} ${n.type}`);
 


### PR DESCRIPTION
## Summary
- enlarge astral tree basic nodes by 50%
- double the size of notable nodes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aa9dd3cc832680574557eee1248f