### PR TITLE
Add purchase UI and connection highlighting for Astral Tree nodes

### DIFF
--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -130,6 +130,27 @@ async function buildTree() {
     const lines = [n.label, `Cost: ${info.cost ?? '-'}`];
     if (info.effects) lines.push(...info.effects);
     tooltip.innerHTML = lines.join('<br>');
+
+    if (isAllocatable(n.id, allocated, adj, manifest)) {
+      const btn = document.createElement('button');
+      btn.textContent = 'Purchase';
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        if (!isAllocatable(n.id, allocated, adj, manifest)) return;
+        const info2 = manifest[n.id];
+        if ((S.astralPoints || 0) < (info2?.cost || 0)) return;
+        S.astralPoints -= info2.cost;
+        allocated.add(n.id);
+        applyEffects(n.id, manifest);
+        saveAllocations(allocated);
+        updateInsight();
+        refreshClasses();
+        hideTooltip();
+      });
+      tooltip.appendChild(document.createElement('br'));
+      tooltip.appendChild(btn);
+    }
+
     tooltip.style.display = 'block';
     positionTooltip(evt);
   }
@@ -206,6 +227,7 @@ async function buildTree() {
   allocated.forEach(id => applyEffects(id, manifest));
 
   const nodeEls = {};
+  const edgeEls = [];
 
   edges.forEach(e => {
     const a = nodeById[e.from];
@@ -218,6 +240,7 @@ async function buildTree() {
     line.setAttribute('y2', b.y);
     line.setAttribute('class', `connector ${a.group.toLowerCase()}`);
     svg.appendChild(line);
+    edgeEls.push({ el: line, from: e.from, to: e.to });
   });
 
   nodes.forEach(n => {
@@ -229,26 +252,16 @@ async function buildTree() {
     circle.setAttribute('r', r);
     circle.setAttribute('class', `node ${n.group.toLowerCase()} ${n.type}`);
 
-    circle.addEventListener('mouseenter', e => showTooltip(e, n));
-    circle.addEventListener('mousemove', positionTooltip);
-    circle.addEventListener('mouseleave', hideTooltip);
-
     circle.addEventListener('click', e => {
+      e.stopPropagation();
       showTooltip(e, n);
-      if (!isAllocatable(n.id, allocated, adj, manifest)) return;
-      const info = manifest[n.id];
-      if ((S.astralPoints || 0) < (info?.cost || 0)) return;
-      S.astralPoints -= info.cost;
-      allocated.add(n.id);
-      applyEffects(n.id, manifest);
-      saveAllocations(allocated);
-      updateInsight();
-      refreshClasses();
     });
 
     nodeEls[n.id] = circle;
     svg.appendChild(circle);
   });
+
+  svg.addEventListener('click', hideTooltip);
 
   function refreshClasses() {
     nodes.forEach(n => {
@@ -258,6 +271,10 @@ async function buildTree() {
         'allocatable',
         !allocated.has(n.id) && isAllocatable(n.id, allocated, adj, manifest)
       );
+    });
+    edgeEls.forEach(e => {
+      const active = allocated.has(e.from) && allocated.has(e.to);
+      e.el.classList.toggle('active', active);
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -4576,6 +4576,11 @@ html.reduce-motion .log-sheet{transition:none;}
   cursor:pointer;
   animation:nodeGlow 1.5s ease-in-out infinite alternate;
 }
+.connector.active{
+  stroke-width:2.5;
+  opacity:1;
+  filter:drop-shadow(0 0 6px currentColor);
+}
 .connector.link{stroke:#888;}
 
 @keyframes nodeGlow{
@@ -4590,7 +4595,7 @@ html.reduce-motion .log-sheet{transition:none;}
   border:1px solid #fff;
   padding:4px 8px;
   border-radius:4px;
-  pointer-events:none;
+  pointer-events:auto;
   white-space:nowrap;
   z-index:20;
   font-size:12px;


### PR DESCRIPTION
## Summary
- Add purchase confirmation button to Astral Tree node tooltip
- Highlight purchased nodes and connectors with glowing effect
- Track edges to glow when both connected nodes are purchased

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UNDOCUMENTED FILE ... UI state violations)*
- `npm run lint:balance`
- `npm run scan-output`

------
https://chatgpt.com/codex/tasks/task_e_68b3b113f2a883269511c46e75bf228f