### PR TITLE
Add purchase UI and connection highlighting for Astral Tree nodes

### DIFF
--- a/style.css
+++ b/style.css
@@ -4576,6 +4576,11 @@ html.reduce-motion .log-sheet{transition:none;}
   cursor:pointer;
   animation:nodeGlow 1.5s ease-in-out infinite alternate;
 }
+.connector.active{
+  stroke-width:2.5;
+  opacity:1;
+  filter:drop-shadow(0 0 6px currentColor);
+}
 .connector.link{stroke:#888;}
 
 @keyframes nodeGlow{
@@ -4590,7 +4595,7 @@ html.reduce-motion .log-sheet{transition:none;}
   border:1px solid #fff;
   padding:4px 8px;
   border-radius:4px;
-  pointer-events:none;
+  pointer-events:auto;
   white-space:nowrap;
   z-index:20;
   font-size:12px;


### PR DESCRIPTION
## Summary
- Add purchase confirmation button to Astral Tree node tooltip
- Highlight purchased nodes and connectors with glowing effect
- Track edges to glow when both connected nodes are purchased
- Fix start node ids so purchase button appears on initial nodes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI timer and doc validation requirements)*
- `npm run lint:balance`
- `npm run scan-output`


------
https://chatgpt.com/codex/tasks/task_e_68b3b113f2a883269511c46e75bf228f