### PR TITLE
Center astral tree on initial node

### DIFF
--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -168,16 +168,19 @@ async function buildTree() {
   const maxX = Math.max(...xs) + 50;
   const minY = Math.min(...ys) - 50;
   const maxY = Math.max(...ys) + 50;
-  const width = maxX - minX;
-  const height = maxY - minY;
-  const centerX = (minX + maxX) / 2;
-  const centerY = (minY + maxY) / 2;
+  const treeWidth = maxX - minX;
+  const treeHeight = maxY - minY;
+
+  const firstNode = nodes[0];
+  const centerX = firstNode.x;
+  const centerY = firstNode.y;
+  const INITIAL_ZOOM = 5;
 
   const viewBox = {
-    x: centerX - width / 4,
-    y: centerY - height / 4,
-    width: width / 2,
-    height: height / 2,
+    x: centerX - treeWidth / (2 * INITIAL_ZOOM),
+    y: centerY - treeHeight / (2 * INITIAL_ZOOM),
+    width: treeWidth / INITIAL_ZOOM,
+    height: treeHeight / INITIAL_ZOOM,
   };
 
   function applyViewBox() {


### PR DESCRIPTION
## Summary
- focus the astral tree view on its first node
- start with a tighter zoom level for easier node selection

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c430a1548326a41a07198b71f249