### PR TITLE
Randomize astral tree starfield

### DIFF
--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -95,6 +95,25 @@ export function mountAstralTreeUI() {
   const closeBtn = document.getElementById('closeAstralTree');
   if (!openBtn || !overlay || !closeBtn) return;
 
+  const starfield = overlay.querySelector('.starfield');
+
+  function rand() {
+    return crypto.getRandomValues(new Uint32Array(1))[0] / 0xffffffff;
+  }
+
+  function generateStarfield(container, count = 200) {
+    const { clientWidth: w, clientHeight: h } = container;
+    for (let i = 0; i < count; i++) {
+      const star = document.createElement('span');
+      star.style.left = `${rand() * w}px`;
+      star.style.top = `${rand() * h}px`;
+      const scale = rand() * 1.5 + 0.5;
+      star.style.transform = `scale(${scale})`;
+      star.style.opacity = (rand() * 0.5 + 0.3).toString();
+      container.appendChild(star);
+    }
+  }
+
   let prevOverflowY = '';
   let prevDocOverflowY = '';
 
@@ -104,6 +123,9 @@ export function mountAstralTreeUI() {
     prevDocOverflowY = document.documentElement.style.overflowY;
     document.body.style.overflowY = 'hidden';
     document.documentElement.style.overflowY = 'hidden';
+    if (starfield && starfield.childElementCount === 0) {
+      generateStarfield(starfield);
+    }
     const el = document.getElementById('astralInsight');
     if (el) el.textContent = `Insight: ${S.astralPoints || 0}`;
   });

--- a/style.css
+++ b/style.css
@@ -4507,11 +4507,16 @@ html.reduce-motion .log-sheet{transition:none;}
   position:absolute;
   width:100%;
   height:100%;
-  background-image:radial-gradient(white 1px, transparent 1px), radial-gradient(white 1px, transparent 1px);
-  background-size:50px 50px,100px 100px;
-  background-position:0 0,25px 25px;
-  opacity:0.2;
+  overflow:hidden;
   pointer-events:none;
+}
+
+.astral-skill-tree .starfield span{
+  position:absolute;
+  width:1px;
+  height:1px;
+  background:#fff;
+  border-radius:50%;
 }
 
 .astral-insight{


### PR DESCRIPTION
## Summary
- Replace grid-pattern starfield background with generated star elements for the astral tree overlay
- Populate stars using cryptographic randomness when the astral tree is opened
- Reduce star size to make the background less distracting

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI changes blocked until validation passes)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c6cc9f7c8326b3f57dba60946261