### PR TITLE
Round insight count and show it on cultivation screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,8 @@
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
                 <button id="openAstralTree" class="astral-tree-btn">Astral Tree</button>
-                
+                <div id="astralInsightMini" class="astral-insight-mini"></div>
+
                 <!-- Misty fog layers behind silhouette -->
                 <div class="misty-fog">
                   <div class="fog-layer-1"></div>

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -124,12 +124,12 @@ export function mountAstralTreeUI() {
     prevDocOverflowY = document.documentElement.style.overflowY;
     document.body.style.overflowY = 'hidden';
     document.documentElement.style.overflowY = 'hidden';
-    if (starfield && starfield.childElementCount === 0) {
-      generateStarfield(starfield);
-    }
-    const el = document.getElementById('astralInsight');
-    if (el) el.textContent = `Insight: ${S.astralPoints || 0}`;
-  });
+      if (starfield && starfield.childElementCount === 0) {
+        generateStarfield(starfield);
+      }
+      const el = document.getElementById('astralInsight');
+      if (el) el.textContent = `Insight: ${Math.round(S.astralPoints || 0)}`;
+    });
 
   closeBtn.addEventListener('click', () => {
     overlay.style.display = 'none';
@@ -203,8 +203,11 @@ async function buildTree() {
   const manifest = buildManifest(nodes);
 
   const insightEl = document.getElementById('astralInsight');
+  const miniEl = document.getElementById('astralInsightMini');
   function updateInsight() {
-    if (insightEl) insightEl.textContent = `Insight: ${S.astralPoints || 0}`;
+    const v = Math.round(S.astralPoints || 0);
+    if (insightEl) insightEl.textContent = `Insight: ${v}`;
+    if (miniEl) miniEl.textContent = `Insight: ${v}`;
   }
   updateInsight();
 

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -40,7 +40,7 @@ export function updateRealmUI() {
 export function updateActivityCultivation() {
   setText('realmNameActivity', `${REALMS[S.realm.tier].name} ${S.realm.stage}`);
   updateCurrentRealmHeader();
-  
+
   // Update foundation text (inline above Qi bar)
   const prevFoundation = parseInt(document.getElementById('foundValSilhouette').textContent) || 0;
   const currentFoundation = Math.floor(S.foundation);
@@ -70,6 +70,7 @@ export function updateActivityCultivation() {
   setText('qiCapSilhouette', qCap(S));
   setText('qiRegenActivity', qiRegenPerSec(S).toFixed(1));
   setText('foundationRate', foundationGainPerSec(S).toFixed(1));
+  setText('astralInsightMini', `Insight: ${Math.round(S.astralPoints || 0)}`);
   setText('btChanceActivity', (breakthroughChance(S) * 100).toFixed(1) + '%');
   setText('powerMultActivity', powerMult(S).toFixed(1) + 'x');
 

--- a/style.css
+++ b/style.css
@@ -4520,13 +4520,22 @@ html.reduce-motion .log-sheet{transition:none;}
 }
 
 .astral-insight{
-  position:absolute;
-  top:20px;
-  left:50%;
-  transform:translateX(-50%);
-  color:#fff;
-  font-size:20px;
-  z-index:10;
+    position:absolute;
+    top:20px;
+    left:50%;
+    transform:translateX(-50%);
+    color:#fff;
+    font-size:20px;
+    z-index:10;
+}
+
+.astral-insight-mini{
+    position:absolute;
+    top:50px;
+    right:10px;
+    color:#fff;
+    font-size:16px;
+    z-index:5;
 }
 
 .astral-tree-close{


### PR DESCRIPTION
## Summary
- Round astral insight value before displaying it
- Add a miniature insight display under the Astral Tree button on the cultivation tab
- Keep the cultivation screen's insight counter in sync with the astral tree

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and timers)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ce6fdc8c8326823cd34c84517942