### PR TITLE
fix: make cultivation sub tabs sticky

### DIFF
--- a/style.css
+++ b/style.css
@@ -1987,8 +1987,12 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 .cultivation-tabs {
   display: flex;
   gap: 8px;
-  margin-bottom: 15px;
+  margin-bottom: 0;
   border-bottom: 1px solid var(--accent);
+  position: sticky;
+  top: var(--header-h);
+  z-index: 900;
+  background: var(--panel);
 }
 
 .cultivation-tab-btn {


### PR DESCRIPTION
## Summary
- keep cultivation sub-tabs pinned under header with a sticky bar

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violations)

------
https://chatgpt.com/codex/tasks/task_e_68b3cedb906c8326966a540ce83a4b75