### PR TITLE
fix: reserve space for log across viewports

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -574,16 +574,18 @@ function setupLogSheet() {
   const sheet = qs('#logSheet');
   const toggle = qs('#logToggle');
   if (!sheet || !toggle) return;
+  const logEl = qs('#log');
   const mq = window.matchMedia('(max-width: 768px)');
   function setHeight() {
-    if (!mq.matches) {
-      document.documentElement.style.setProperty('--bottom-log-h', '0px');
-      return;
+    if (mq.matches) {
+      const h = sheet.getAttribute('data-open') === 'true'
+        ? sheet.getBoundingClientRect().height
+        : toggle.getBoundingClientRect().height;
+      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
+    } else {
+      const h = logEl?.getBoundingClientRect().height ?? 0;
+      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
     }
-    const h = sheet.getAttribute('data-open') === 'true'
-      ? sheet.getBoundingClientRect().height
-      : toggle.getBoundingClientRect().height;
-    document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
   }
   function close() {
     sheet.setAttribute('data-open', 'false');


### PR DESCRIPTION
## Summary
- ensure log height is accounted for on all screen sizes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b3cf11ef9483268ce4c3786f4fe352