### PR TITLE
Center cultivation subtabs with compact width

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,11 +137,10 @@
       <!-- Activity Content Panels -->
       <section id="activity-cultivation" class="activity-content" style="display:none;">
         <div class="cultivation-header">
-          
-        </div>
-        <div class="cultivation-tabs tab-bar">
-          <button class="cultivation-tab-btn active" data-tab="cultivation">Cultivation</button>
-          <button class="cultivation-tab-btn" data-tab="stats">Stats</button>
+          <div class="cultivation-tabs tab-bar">
+            <button class="cultivation-tab-btn active" data-tab="cultivation">Cultivation</button>
+            <button class="cultivation-tab-btn" data-tab="stats">Stats</button>
+          </div>
         </div>
 
         <div id="cultivationSubTab" class="cultivation-tab-content tab-content active">

--- a/style.css
+++ b/style.css
@@ -1984,10 +1984,12 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 
 /* Cultivation Sub Tabs */
 .cultivation-tabs {
-  display: flex;
+  display: inline-flex;
   gap: 8px;
-  margin-bottom: 15px;
+  margin-bottom: 0;
   border-bottom: 1px solid var(--accent);
+  width: fit-content;
+  background: transparent;
 }
 
 .cultivation-tab-btn {


### PR DESCRIPTION
## Summary
- Move cultivation subtabs into the cultivation header
- Limit subtab container width to its text and remove full-width background

## Testing
- `npm test`
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b3d4e31f5c832687a5eb8e8c677356