### PR TITLE
Fix invisible timing cursor in physique training minigame

### DIFF
--- a/style.css
+++ b/style.css
@@ -2391,6 +2391,17 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   animation: perfectZonePulse 2s ease-in-out infinite;
 }
 
+.timing-cursor {
+  position: absolute;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  background: #fff;
+  border-radius: 2px;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.8);
+  transform: translateX(-50%);
+}
+
 /* Session-Based Training Interface */
 .session-controls {
   text-align: center;


### PR DESCRIPTION
## Summary
- Style training cursor so the physique timing mini-game displays a visible white bar

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js, UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js, UI state violation: src/features/adventure/ui/progressBar.js imports S from shared/state.js, UI state violation: src/features/combat/ui/combatStats.js imports S from shared/state.js, UI state violation: src/features/cooking/ui/cookControls.js imports S from shared/state.js, UI state violation: src/features/cooking/ui/cookingDisplay.js imports S from shared/state.js, UI state violation: src/features/inventory/ui/resourceDisplay.js imports S from shared/state.js, UI state violation: src/features/karma/ui/karmaHUD.js imports S from shared/state.js, UI state violation: src/features/loot/ui/lootTab.js imports S from shared/state.js, UI state violation: src/features/mining/ui/miningDisplay.js imports S from shared/state.js, UI state violation: src/features/proficiency/ui/weaponProficiencyDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/lawDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiOrb.js imports S from shared/state.js, UI state violation: src/features/progression/ui/realm.js imports S from shared/state.js, DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b3d86ca9ac8326a8c617e6fbbdd9e8