### PR TITLE
feat: enhance physique stamina and qi

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,7 +383,10 @@
             <div class="stat"><span>Current Physique</span><span id="currentPhysiqueStat">10</span></div>
             <div class="stat"><span>HP Bonus</span><span id="physiqueHpStat">+0</span></div>
             <div class="stat"><span>Carry Capacity</span><span id="physiqueCarryStat">+0</span></div>
-            <div class="muted" style="margin-top:8px">Higher physique improves health and carrying capacity</div>
+            <div class="stat"><span>Max Stamina</span><span id="physiqueMaxStaminaStat">100</span></div>
+            <div class="stat"><span>Stamina Regen</span><span id="physiqueStaminaRegenStat">+1/s</span></div>
+            <div class="stat"><span>Training Drain</span><span id="physiqueStaminaDrainStat">-6/s</span></div>
+            <div class="muted" style="margin-top:8px">Higher physique improves health, stamina, and carrying capacity</div>
           </div>
         </div>
       </section>

--- a/src/features/physique/logic.js
+++ b/src/features/physique/logic.js
@@ -13,7 +13,10 @@ export function getPhysiqueEffects(state){
   const current = root.stats.physique || 10;
   const hpBonus = Math.max(0, Math.floor((current - 10) * 5));
   const carryCapacity = Math.max(0, current - 10);
-  return { hpBonus, carryCapacity };
+  const maxStamina = current * 10;
+  const staminaRegen = 1; // base stamina recovery per second
+  const staminaDrain = 6; // stamina drain per second during training
+  return { hpBonus, carryCapacity, maxStamina, staminaRegen, staminaDrain };
 }
 
 /**

--- a/src/features/physique/mutators.js
+++ b/src/features/physique/mutators.js
@@ -12,9 +12,13 @@ export function addPhysiqueExp(amount, state = physiqueState){
     p.exp -= p.expMax;
     p.level++;
     p.expMax = Math.floor(p.expMax * 1.4);
-    p.maxStamina += 10;
     if(state.stats){
       state.stats.physique = (state.stats.physique || 10) + 1;
+      p.maxStamina = (state.stats.physique || 10) * 10;
+      p.stamina = Math.min(p.stamina || 0, p.maxStamina);
+    }else{
+      p.maxStamina += 10;
+      p.stamina = Math.min(p.stamina || 0, p.maxStamina);
     }
   }
   return p.exp;
@@ -65,10 +69,23 @@ export function endTrainingSession(state = physiqueState){
   p.trainingSession = false;
   p.timingActive = false;
   const summary = { hits: p.sessionHits, xp: Math.floor(p.sessionXP) };
+  const performance = p.sessionHits ? (p.perfectHits || 0) / p.sessionHits : 0;
+  if(state.qi !== undefined && state.qiMax){
+    const chance = performance;
+    const recoverPct = performance * 0.2; // up to 20% of max qi
+    if(Math.random() < chance){
+      const recovered = state.qiMax * recoverPct;
+      state.qi = Math.min(state.qiMax, (state.qi || 0) + recovered);
+      summary.qiRecovered = recovered;
+    }else{
+      summary.qiRecovered = 0;
+    }
+  }
   p.sessionStamina = 0;
   p.sessionHits = 0;
   p.sessionXP = 0;
   p.hitStreak = 0;
+  p.perfectHits = 0;
   p.cursorSpeed = 0;
   return summary;
 }

--- a/src/features/physique/ui/physiqueDisplay.js
+++ b/src/features/physique/ui/physiqueDisplay.js
@@ -11,8 +11,12 @@ function render(state){
   setText('physiqueLevel', `Level ${getPhysiqueLevel(state)}`);
   setFill('physiqueProgressFill', getPhysiqueExp(state) / getPhysiqueExpMax(state));
   const bonuses = getPhysiqueBonuses(state);
+  setText('currentPhysiqueStat', state.stats?.physique || 10);
   setText('physiqueHpStat', `+${bonuses.hpBonus}`);
   setText('physiqueCarryStat', `+${bonuses.carryCapacity}`);
+  setText('physiqueMaxStaminaStat', `${bonuses.maxStamina}`);
+  setText('physiqueStaminaRegenStat', `+${bonuses.staminaRegen}/s`);
+  setText('physiqueStaminaDrainStat', `-${bonuses.staminaDrain}/s`);
 }
 
 export function mountPhysiqueUI(state){

--- a/ui/index.js
+++ b/ui/index.js
@@ -452,7 +452,11 @@ function tick(){
   // Physique training progression
   const sessionEnd = tickPhysiqueTraining(S);
   if(sessionEnd){
-    log(`Training session complete! ${sessionEnd.hits} hits for ${sessionEnd.xp} XP`, 'good');
+    let msg = `Training session complete! ${sessionEnd.hits} hits for ${sessionEnd.xp} XP`;
+    if(sessionEnd.qiRecovered){
+      msg += ` and recovered ${sessionEnd.qiRecovered.toFixed(0)} Qi`;
+    }
+    log(msg, 'good');
   }
   
   // Auto meditation fallback for old saves


### PR DESCRIPTION
## Summary
- show stamina regen, drain and max stamina in physique effects
- scale max stamina with physique stat
- allow training minigame to sometimes restore Qi based on performance

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation warnings)

------
https://chatgpt.com/codex/tasks/task_e_68b3d9aa308483268a8e0c2fae10a422