### PR TITLE
Triple physique minigame cursor speed

### DIFF
--- a/src/features/physique/mutators.js
+++ b/src/features/physique/mutators.js
@@ -77,7 +77,8 @@ export function moveTrainingCursor(state = physiqueState){
   const p = slice(state);
   if(!p.timingActive || !p.trainingSession) return;
   if(!p.cursorSpeed) p.cursorSpeed = 5;
-  const { position, direction } = stepTrainingCursor(p.cursorPosition, p.cursorDirection, p.cursorSpeed);
+  const speed = p.cursorSpeed * 3; // Triple cursor movement speed
+  const { position, direction } = stepTrainingCursor(p.cursorPosition, p.cursorDirection, speed);
   p.cursorPosition = position;
   p.cursorDirection = direction;
 }


### PR DESCRIPTION
## Summary
- Speed up the training cursor in the Physique minigame by tripling its movement rate

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI verification violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d9c757348326b429d0c574b4ddfe