### PR TITLE
Ensure Qi shield applies when cotton robe equipped

### DIFF
--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -30,7 +30,13 @@ export function recomputePlayerTotals(player) {
   const mind = player.stats.mind || 0;
   const shieldMult = 1 + mind * 0.06;
   player.shield.max = Math.round(shieldMax * shieldMult);
-  player.shield.current = Math.min(player.shield.current, player.shield.max);
+  // Fully refresh the player's Qi shield whenever equipment changes so that
+  // newly equipped gear providing shield protection immediately applies its
+  // full value. Previously the shield's current value was simply clamped to
+  // the new maximum, leaving it at zero after equipping items like the
+  // Cotton Robe. This caused the Qi shield to appear inactive until it was
+  // refilled through other means.
+  player.shield.current = player.shield.max;
 }
 
 // Determine if an item can be equipped and in which slot


### PR DESCRIPTION
## Summary
- Refresh Qi shield to max whenever equipment is recalculated so gear like the Cotton Robe immediately grants its shield

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations and validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b447db571c832684430105e111f6a2