### PR TITLE
Format ability bar into two rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,9 +564,7 @@
                 </div>
               </div>
 
-              <!-- Ability Bar -->
               <div class="ability-bar-container">
-                <span class="ability-label">Ability Bar:</span>
                 <div class="ability-bar" id="abilityBar"></div>
               </div>
 

--- a/style.css
+++ b/style.css
@@ -2548,7 +2548,7 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   display: flex;
   flex-direction: column;
   gap: 16px;
-  height: calc(100vh - 120px);
+  min-height: calc(100vh - 120px);
 }
 
 .adventure-progress-container {
@@ -3372,8 +3372,9 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 }
 
 .ability-bar {
-  display: flex;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 4px;
 }
 
 .ability-slot {
@@ -4298,8 +4299,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   color: #000 !important;
 }
 
-/* Ability bar */
-.ability-bar { display:flex; gap:4px; }
+.ability-bar { display:grid; grid-template-columns: repeat(3, auto); gap:4px; }
 .ability-card { width:60px; height:90px; background:var(--panel); border:1px solid var(--ink-light); border-radius:4px; position:relative; padding:2px; display:flex; flex-direction:column; align-items:center; justify-content:space-between; }
 .ability-card .ability-name { font-size:10px; text-align:center; }
 .ability-card .ability-title { display:flex; flex-direction:column; align-items:center; }


### PR DESCRIPTION
## Summary
- Stack ability bar into two rows of three abilities
- Remove ability bar label
- Let combat card expand so the second ability row stays within the card

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b44bcee5188326896821cd0fdc3930