### PR TITLE
Display player name above adventure HP bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,6 +471,7 @@
               <div class="combat-hud">
                 <div class="hud player">
                   <div class="bar-group">
+                    <div class="player-name" id="playerName">You</div>
                     <div class="health-bar">
                       <div class="health-fill" id="playerHealthFill"></div>
                       <svg class="shield-overlay" id="advShieldOverlay" viewBox="0 0 100 24" preserveAspectRatio="none">

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -172,6 +172,7 @@ export function updateBattleDisplay() {
   const shieldMax = S.shield?.max || 0;
   const shieldCur = S.shield?.current || 0;
   const shieldFrac = shieldMax ? shieldCur / shieldMax : 0;
+  setText('playerName', 'You');
   setText('playerHealthText', `${Math.round(playerHP)}/${Math.round(playerMaxHP)}`);
   setFill('playerHealthFill', hpFrac);
   setFill('advHpMaskRect', hpFrac);

--- a/style.css
+++ b/style.css
@@ -4210,6 +4210,7 @@ tr:last-child td {
 .combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
+.combat-hud .player-name{font-size:.75rem;font-weight:600}
 .sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
 .sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}


### PR DESCRIPTION
## Summary
- Show "You" label above player's health and Qi bars in the adventure HUD
- Style player name text to match enemy name appearance
- Update battle display logic to keep the player name in sync

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation: imports S from shared/state.js; DOM in adventure logic and other warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b44e36294c8326bc57273d0d69d25f