### PR TITLE
Overlay enemy stun bar within health bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -505,11 +505,10 @@
                 <div class="hud enemy">
                   <div class="bar-group">
                     <div class="enemy-name" id="enemyName">Select an area to begin</div>
-                    <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
-                      <div class="stun-fill" id="enemyStunFill"></div>
-                      <span class="stun-text" id="enemyStunText">0/100</span>
-                    </div>
                     <div class="health-bar">
+                      <div class="stun-bar" id="enemyStunBar" title="Gauge: 0&#10;Threshold: 100&#10;Decay: 6/s">
+                        <div class="stun-fill" id="enemyStunFill"></div>
+                      </div>
                       <div class="health-fill" id="enemyHealthFill"></div>
                       <span class="health-text" id="enemyHealthText">--/--</span>
                     </div>

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -274,6 +274,8 @@ export function updateBattleDisplay() {
       stunFill.style.backgroundColor = `hsl(${hue}, 100%, 50%)`;
     }
     if (stunBarEl) {
+      const show = stunGauge > 1;
+      stunBarEl.style.display = show ? 'block' : 'none';
       stunBarEl.classList.toggle('stun-flash', stunGauge >= STUN_THRESHOLD * 0.9 && stunGauge < STUN_THRESHOLD);
       stunBarEl.classList.toggle('stun-shake', stunGauge >= STUN_THRESHOLD);
       const statuses = enemy.statuses || {};
@@ -286,7 +288,6 @@ export function updateBattleDisplay() {
       if (statuses.stunImmune) info.push('stunImmune active');
       stunBarEl.title = info.join('\n');
     }
-    setText('enemyStunText', `${Math.round(stunGauge)}/${STUN_THRESHOLD}`);
   } else {
     setText('enemyName', 'Select an area to begin');
     setText('enemyHealthText', '--/--');
@@ -308,11 +309,11 @@ export function updateBattleDisplay() {
       enemyStunFill.style.width = '0%';
       enemyStunFill.style.backgroundColor = 'hsl(39, 100%, 50%)';
     }
-    setText('enemyStunText', `0/${STUN_THRESHOLD}`);
     const enemyStunBar = document.getElementById('enemyStunBar');
     if (enemyStunBar) {
       enemyStunBar.classList.remove('stun-flash', 'stun-shake');
       enemyStunBar.title = `Gauge: 0\nThreshold: ${STUN_THRESHOLD}\nDecay: ${DECAY_PER_SECOND}/s`;
+      enemyStunBar.style.display = 'none';
     }
   }
   const combatLog = document.getElementById('combatLog');

--- a/style.css
+++ b/style.css
@@ -3282,13 +3282,15 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 }
 
 .stun-bar {
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
-  height: 12px;
-  background: rgba(251, 191, 36, 0.3);
-  border-radius: 8px;
-  margin: 4px 0;
+  height: 15%;
+  pointer-events: none;
   overflow: hidden;
+  display: none;
+  z-index: 2;
 }
 
 .stun-fill {
@@ -3296,16 +3298,6 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   width: 0%;
   background: hsl(39, 100%, 50%);
   transition: width 0.2s ease, background-color 0.2s ease;
-}
-
-.stun-text {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  color: #000;
-  font-weight: bold;
-  font-size: 0.75em;
 }
 
 @keyframes stunFlash {


### PR DESCRIPTION
## Summary
- Embed the enemy stun gauge as a slim overlay inside the health bar
- Hide the stun bar until more than 1 stun damage accrues
- Remove stun text and adjust styling so only the fill appears

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b450527c708326ac83b8f4380c0096