### PR TITLE
Fix mobile scroll spacing on mobile views

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ html,body{height:100%;overflow:hidden}
   height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));
   overflow-y:auto;
   -webkit-overflow-scrolling:touch;
-  padding-bottom:calc(var(--float-pad) + var(--bottom-log-h));
+  padding-bottom:calc(var(--float-pad) + var(--bottom-log-h) + var(--safe-bottom));
 }
 
 .tab-content>.card{
@@ -4375,7 +4375,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 .log-toggle{display:none;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:0px;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:48px;}
   html,body{overflow-x:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
@@ -4400,7 +4400,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);}
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
-  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h));}
+  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h) + var(--safe-bottom));}
   .activity-content{padding:var(--pad);}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}


### PR DESCRIPTION
## Summary
- ensure tab content accounts for safe-area insets when scrolling
- set a default log sheet height on mobile to keep last row visible

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: UI state violation: imports from shared/state.js, DOM usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b450c80bb48326b33e90f7292f9ebb