### PR TITLE
fix mobile bottom padding for scrollable views

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
   --gap: 20px;
   --pad: 16px;
   --header-h: 76px;
-  --bottom-log-h: 0px;
+  --bottom-log-h: 48px;
   --tabs-h: 48px;
   --safe-bottom: env(safe-area-inset-bottom,0px);
   --float-pad: 0px;
@@ -74,7 +74,7 @@ html,body{height:100%;overflow:hidden}
   height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));
   overflow-y:auto;
   -webkit-overflow-scrolling:touch;
-  padding-bottom:calc(var(--float-pad) + var(--bottom-log-h));
+  padding-bottom:calc(var(--float-pad) + var(--bottom-log-h) + var(--safe-bottom));
 }
 
 .tab-content>.card{
@@ -2285,7 +2285,8 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 
 /* Activity Content Panels */
 .activity-content {
-  padding: 20px;
+  padding: var(--pad);
+  padding-bottom: calc(var(--pad) + var(--bottom-log-h) + var(--safe-bottom));
   background: transparent;
 }
 
@@ -2533,7 +2534,7 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 .grid{display:grid; gap:12px}
 
 /* STYLE-GUIDE-UPDATE: Content area with parchment background */
-.content{position:relative; overflow:auto; padding:16px 16px 100px 16px; background: transparent; z-index: 10}
+.content{position:relative; overflow:auto; padding:16px 16px calc(100px + var(--bottom-log-h) + var(--safe-bottom)) 16px; background: transparent; z-index: 10}
 .content > section{display:none}
 
 /* STYLE-GUIDE-UPDATE: Cards with parchment texture */
@@ -4375,7 +4376,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 .log-toggle{display:none;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:0px;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:48px;}
   html,body{overflow-x:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
@@ -4400,8 +4401,8 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);}
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
-  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h));}
-  .activity-content{padding:var(--pad);}
+  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h) + var(--safe-bottom));}
+  .activity-content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h) + var(--safe-bottom));}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}


### PR DESCRIPTION
## Summary
- ensure scrollable views reserve space for mobile log toggle and safe area
- set default log toggle height to prevent content clipping
- restore mobile log height variable to keep last items visible
- add bottom padding to activity panels so their last rows aren't hidden by the log

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b450c80bb48326b33e90f7292f9ebb