### PR TITLE
fix: reserve space for log overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
           </div>
         </div>
 
-        <div id="cultivationSubTab" class="cultivation-tab-content tab-content active">
+        <div id="cultivationSubTab" class="cultivation-tab-content tab-content active scroll-area">
           <div class="cultivation-layout">
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
@@ -286,7 +286,7 @@
           </div>
         </div>
 
-        <div id="statsSubTab" class="cultivation-tab-content tab-content" style="display:none;">
+        <div id="statsSubTab" class="cultivation-tab-content tab-content scroll-area" style="display:none;">
           <div class="cards">
             <div class="card">
               <h4>Breakthrough Details</h4>
@@ -322,7 +322,7 @@
         </div>
       </section>
 
-      <section id="activity-physique" class="activity-content tab-content" style="display:none;">
+      <section id="activity-physique" class="activity-content tab-content scroll-area" style="display:none;">
         <h2> Physique Training</h2>
         <div class="cards">
           <div class="card">
@@ -391,7 +391,7 @@
         </div>
       </section>
 
-      <section id="activity-mining" class="activity-content tab-content" style="display:none;">
+      <section id="activity-mining" class="activity-content tab-content scroll-area" style="display:none;">
         <h2> Mining</h2>
         <div class="cards">
           <div class="card">
@@ -582,7 +582,7 @@
             </div>
 
             <!-- Combat Log -->
-            <div class="combat-log" id="combatLog">
+            <div class="combat-log scroll-area" id="combatLog">
               <div class="log-entry">Select an area to begin your adventure...</div>
             </div>
           </div>
@@ -597,7 +597,7 @@
             </div>
             
             <!-- Progress Tab -->
-            <div id="progressTab" class="adventure-tab-content tab-content active">
+            <div id="progressTab" class="adventure-tab-content tab-content active scroll-area">
               <div class="stat"><span>Total Kills</span><span id="totalKills">0</span></div>
               <div class="stat"><span>Areas Completed</span><span id="areasCompleted">0</span></div>
               <div class="stat"><span>Zones Unlocked</span><span id="zonesUnlocked">1</span></div>
@@ -613,14 +613,14 @@
             </div>
             
             <!-- Bestiary Tab -->
-            <div id="bestiaryTab" class="adventure-tab-content tab-content" style="display: none;">
-              <div class="bestiary-list" id="bestiaryList">
+            <div id="bestiaryTab" class="adventure-tab-content tab-content scroll-area" style="display: none;">
+              <div class="bestiary-list scroll-area" id="bestiaryList">
                 <div class="muted">Defeat enemies to unlock their information...</div>
               </div>
             </div>
 
             <!-- Loot Tab -->
-            <div id="lootTab" class="adventure-tab-content tab-content" style="display: none;">
+            <div id="lootTab" class="adventure-tab-content tab-content scroll-area" style="display: none;">
               <div class="muted warn">Items here are not safe. Retreat to claim; death forfeits them.</div>
               <div class="session-loot-list" id="sessionLootList"></div>
               <div class="loot-actions" style="text-align:right; margin-top:8px;">
@@ -630,7 +630,7 @@
             </div>
             
             <!-- Proficiencies Tab -->
-            <div id="proficienciesTab" class="adventure-tab-content tab-content" style="display: none;">
+            <div id="proficienciesTab" class="adventure-tab-content tab-content scroll-area" style="display: none;">
               <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
               <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
               <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>
@@ -648,14 +648,14 @@
               <h3>🗺️ Adventure Map</h3>
               <button class="btn small ghost close-button" id="closeMapButton" aria-label="Close map">✕</button>
             </div>
-            <div class="map-content" id="mapContent">
+            <div class="map-content scroll-area" id="mapContent">
               <!-- Zone accordions will be populated by JavaScript -->
             </div>
           </div>
         </div>
       </section>
 
-      <section id="activity-character" class="activity-content tab-content" style="display:none;">
+      <section id="activity-character" class="activity-content tab-content scroll-area" style="display:none;">
         <h2>🧙 Character</h2>
         <div class="cards character-cards">
           <div class="card">
@@ -683,7 +683,7 @@
               <button class="gear-tab-btn active" data-tab="gearEquip">Gear</button>
               <button class="gear-tab-btn" data-tab="gearAbilities">Abilities</button>
             </div>
-            <div id="gearEquipSubTab" class="gear-tab-content active">
+            <div id="gearEquipSubTab" class="gear-tab-content active scroll-area">
               <div class="equip-slots">
                 <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
                 <div class="equip-slot" id="slot-head"><span class="slot-label">Head</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
@@ -694,7 +694,7 @@
               <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>
               <div class="stat" title="Chance to avoid attacks">👣 <span id="dodgeVal">0</span></div>
             </div>
-            <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">
+            <div id="gearAbilitiesSubTab" class="gear-tab-content scroll-area" style="display:none;">
               <div id="abilitySlots"></div>
               <div id="availableAbilities"></div>
             </div>
@@ -713,7 +713,7 @@
         </div>
       </section>
 
-      <section id="activity-sect" class="activity-content tab-content" style="display:none;">
+      <section id="activity-sect" class="activity-content tab-content scroll-area" style="display:none;">
         <h2>🏛️ Sect Management</h2>
         <div class="cards">
           <div class="card">
@@ -724,7 +724,7 @@
         </div>
       </section>
 
-      <section id="activity-cooking" class="activity-content tab-content" style="display:none;">
+      <section id="activity-cooking" class="activity-content tab-content scroll-area" style="display:none;">
         <h2>🍳 Cooking</h2>
         <div class="cards">
           <div class="card">
@@ -885,7 +885,7 @@
         </div>
       </section>
 
-      <section id="activity-alchemy" class="activity-content tab-content" style="display:none;">
+      <section id="activity-alchemy" class="activity-content tab-content scroll-area" style="display:none;">
         <h2>⚗️ Alchemy</h2>
         <div class="cards">
           <div class="card">
@@ -919,10 +919,10 @@
           <button class="mind-tab-btn" data-tab="mindStats">Stats</button>
           <button class="mind-tab-btn" data-tab="mindPuzzles">Puzzles</button>
         </div>
-        <div id="mindMainTab" class="mind-tab-content tab-content active"></div>
-        <div id="mindReadingTab" class="mind-tab-content tab-content" style="display:none;"></div>
-        <div id="mindStatsTab" class="mind-tab-content tab-content" style="display:none;"></div>
-        <div id="mindPuzzlesTab" class="mind-tab-content tab-content" style="display:none;"></div>
+        <div id="mindMainTab" class="mind-tab-content tab-content active scroll-area"></div>
+        <div id="mindReadingTab" class="mind-tab-content tab-content scroll-area" style="display:none;"></div>
+        <div id="mindStatsTab" class="mind-tab-content tab-content scroll-area" style="display:none;"></div>
+        <div id="mindPuzzlesTab" class="mind-tab-content tab-content scroll-area" style="display:none;"></div>
       </section>
 
       <section id="tab-combat">
@@ -940,12 +940,12 @@
 
       <div class="log-sheet" id="logSheet" data-open="false">
         <button class="log-toggle" id="logToggle" aria-controls="log" aria-expanded="false">Log ▾</button>
-        <div class="log" id="log"></div>
+        <div class="log scroll-area" id="log"></div>
       </div>
     </section>
     <div class="modal-overlay" id="cultivationProgressionOverlay" style="display: none;">
       <div class="modal-backdrop"></div>
-      <div class="modal-content card cultivation-progress-card" id="cultivationProgressionCard">
+      <div class="modal-content card cultivation-progress-card scroll-area" id="cultivationProgressionCard">
         <div class="card-header">
           <h4>Cultivation Progression</h4>
           <button class="btn small ghost" id="closeProgressBtn">×</button>

--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
   --gap: 20px;
   --pad: 16px;
   --header-h: 76px;
-  --bottom-log-h: 0px;
+  --log-h: 0px;
   --tabs-h: 48px;
   --safe-bottom: env(safe-area-inset-bottom,0px);
   --float-pad: 0px;
@@ -71,10 +71,9 @@ html,body{height:100%;overflow:hidden}
   display:flex;
   flex-direction:column;
   gap:var(--gap);
-  height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));
+  height:calc(100dvh - var(--header-h) - var(--tabs-h));
   overflow-y:auto;
   -webkit-overflow-scrolling:touch;
-  padding-bottom:calc(var(--float-pad) + var(--bottom-log-h));
 }
 
 .tab-content>.card{
@@ -84,6 +83,12 @@ html,body{height:100%;overflow:hidden}
 
 .tab-content>.card:only-child{
   flex:1 0 auto;
+}
+.scroll-area{
+  padding-bottom:calc(var(--log-h) + env(safe-area-inset-bottom,0px));
+}
+.scroll-area::after{
+  content:"";display:block;height:var(--log-h);
 }
 
 /* --- Parchment-style custom scrollbar --- */
@@ -4367,7 +4372,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 .log-toggle{display:none;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:0px;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--log-h:0px;}
   html,body{overflow-x:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
@@ -4392,7 +4397,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);}
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
-  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h));}
+  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--log-h));}
   .activity-content{padding:var(--pad);}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}

--- a/ui/index.js
+++ b/ui/index.js
@@ -583,14 +583,18 @@ function setupLogSheet() {
   function setHeight() {
     if (mq.matches) {
       const h = sheet.getAttribute('data-open') === 'true'
-        ? sheet.getBoundingClientRect().height
-        : toggle.getBoundingClientRect().height;
-      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
+        ? sheet.offsetHeight
+        : toggle.offsetHeight;
+      document.documentElement.style.setProperty('--log-h', h + 'px');
     } else {
-      const h = logEl?.getBoundingClientRect().height ?? 0;
-      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
+      const h = logEl?.offsetHeight ?? 0;
+      document.documentElement.style.setProperty('--log-h', h + 'px');
     }
   }
+  const ro = new ResizeObserver(setHeight);
+  ro.observe(sheet);
+  ro.observe(toggle);
+  if (logEl) ro.observe(logEl);
   function close() {
     sheet.setAttribute('data-open', 'false');
     toggle.setAttribute('aria-expanded', 'false');


### PR DESCRIPTION
## Summary
- add --log-h CSS var and scroll-area sentinel to reserve space for bottom log
- observe log sheet height and sync --log-h via ResizeObserver
- mark scrollable panels with scroll-area padding

## Testing
- ⚠️ `npm test` (no test specified)
- ❌ `npm run validate` (UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68b4601379308326aae1bfb1b3315b63