### PR TITLE
Scale stamina regeneration with physique

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
             <div class="stat"><span>HP Bonus</span><span id="physiqueHpStat">+0</span></div>
             <div class="stat"><span>Carry Capacity</span><span id="physiqueCarryStat">+0</span></div>
             <div class="stat"><span>Max Stamina</span><span id="physiqueMaxStaminaStat">100</span></div>
-            <div class="stat"><span>Stamina Regen</span><span id="physiqueStaminaRegenStat">+1/s</span></div>
+            <div class="stat"><span>Stamina Regen</span><span id="physiqueStaminaRegenStat">+0.06/s</span></div>
             <div class="stat"><span>Training Drain</span><span id="physiqueStaminaDrainStat">-6/s</span></div>
             <div class="muted" style="margin-top:8px">Higher physique improves health, stamina, and carrying capacity</div>
           </div>

--- a/src/features/physique/logic.js
+++ b/src/features/physique/logic.js
@@ -14,7 +14,8 @@ export function getPhysiqueEffects(state){
   const hpBonus = Math.max(0, Math.floor((current - 10) * 5));
   const carryCapacity = Math.max(0, current - 10);
   const maxStamina = current * 10;
-  const staminaRegen = 1; // base stamina recovery per second
+  const baseStaminaRegen = 0.03; // base stamina recovery per second
+  const staminaRegen = baseStaminaRegen * (1 + current * 0.1); // 10% per physique point
   const staminaDrain = 6; // stamina drain per second during training
   return { hpBonus, carryCapacity, maxStamina, staminaRegen, staminaDrain };
 }

--- a/src/features/physique/mutators.js
+++ b/src/features/physique/mutators.js
@@ -1,5 +1,5 @@
 import { physiqueState } from './state.js';
-import { stepTrainingCursor, evaluateTrainingHit } from './logic.js';
+import { stepTrainingCursor, evaluateTrainingHit, getPhysiqueEffects } from './logic.js';
 
 function slice(state){
   return state.physique || state;
@@ -125,7 +125,8 @@ export function tickPhysiqueTraining(state = physiqueState){
       moveTrainingCursor(state);
     }
   }else{
-    regenPhysiqueStamina(1, state);
+    const { staminaRegen } = getPhysiqueEffects(state);
+    regenPhysiqueStamina(staminaRegen, state);
     const passiveRate = (2 + (p.level * 0.2)) / 3;
     addPhysiqueExp(passiveRate, state);
     p.passiveXpGained = (p.passiveXpGained || 0) + passiveRate;

--- a/src/features/physique/ui/physiqueDisplay.js
+++ b/src/features/physique/ui/physiqueDisplay.js
@@ -15,7 +15,7 @@ function render(state){
   setText('physiqueHpStat', `+${bonuses.hpBonus}`);
   setText('physiqueCarryStat', `+${bonuses.carryCapacity}`);
   setText('physiqueMaxStaminaStat', `${bonuses.maxStamina}`);
-  setText('physiqueStaminaRegenStat', `+${bonuses.staminaRegen}/s`);
+  setText('physiqueStaminaRegenStat', `+${bonuses.staminaRegen.toFixed(2)}/s`);
   setText('physiqueStaminaDrainStat', `-${bonuses.staminaDrain}/s`);
 }
 


### PR DESCRIPTION
## Summary
- add base stamina recovery of 0.03 per second
- increase stamina recovery by 10% per physique point
- show stamina regen with two decimal precision in the UI
- fix Physique Effects card to display the correct stamina recovery

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b4633fcff883269dde3ee20fc34fec