### PR TITLE
Fix mobile log overlap by tracking dynamic log height

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
   --gap: 20px;
   --pad: 16px;
   --header-h: 76px;
-  --bottom-log-h: 0px;
+  --log-h: 0px;
   --tabs-h: 48px;
   --safe-bottom: env(safe-area-inset-bottom,0px);
   --float-pad: 0px;
@@ -71,10 +71,16 @@ html,body{height:100%;overflow:hidden}
   display:flex;
   flex-direction:column;
   gap:var(--gap);
-  height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));
+  height:calc(100dvh - var(--header-h) - var(--tabs-h));
   overflow-y:auto;
   -webkit-overflow-scrolling:touch;
-  padding-bottom:calc(var(--float-pad) + var(--bottom-log-h));
+  padding-bottom:calc(var(--log-h) + env(safe-area-inset-bottom,0px));
+}
+
+.tab-content::after{
+  content:"";
+  display:block;
+  height:var(--log-h);
 }
 
 .tab-content>.card{
@@ -4367,8 +4373,8 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 .log-toggle{display:none;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:0px;}
-  html,body{overflow-x:hidden;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--log-h:0px;}
+  html,body{overflow:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
   .primary-row{display:flex;align-items:center;gap:var(--gap);}
@@ -4392,8 +4398,9 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);}
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
-  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h));}
-  .activity-content{padding:var(--pad);}
+  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--log-h) + env(safe-area-inset-bottom,0px));}
+  .activity-content{padding:var(--pad);height:calc(100dvh - var(--header-h) - var(--tabs-h));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:calc(var(--log-h) + env(safe-area-inset-bottom,0px));}
+  .activity-content::after{content:"";display:block;height:var(--log-h);}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}

--- a/ui/index.js
+++ b/ui/index.js
@@ -578,19 +578,17 @@ function setupLogSheet() {
   const sheet = qs('#logSheet');
   const toggle = qs('#logToggle');
   if (!sheet || !toggle) return;
-  const logEl = qs('#log');
-  const mq = window.matchMedia('(max-width: 768px)');
+
   function setHeight() {
-    if (mq.matches) {
-      const h = sheet.getAttribute('data-open') === 'true'
-        ? sheet.getBoundingClientRect().height
-        : toggle.getBoundingClientRect().height;
-      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
-    } else {
-      const h = logEl?.getBoundingClientRect().height ?? 0;
-      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
-    }
+    const h = sheet.getAttribute('data-open') === 'true'
+      ? sheet.offsetHeight
+      : toggle.offsetHeight;
+    document.documentElement.style.setProperty('--log-h', `${h}px`);
   }
+
+  const ro = new ResizeObserver(setHeight);
+  ro.observe(sheet);
+  ro.observe(toggle);
   function close() {
     sheet.setAttribute('data-open', 'false');
     toggle.setAttribute('aria-expanded', 'false');
@@ -615,7 +613,7 @@ function setupLogSheet() {
     sheet.getAttribute('data-open') === 'true' ? close() : open();
   });
   window.addEventListener('resize', setHeight);
-  mq.addEventListener('change', setHeight);
+  window.addEventListener('orientationchange', setHeight);
   setHeight();
 }
 


### PR DESCRIPTION
## Summary
- track bottom log height with ResizeObserver and expose via `--log-h`
- convert activity panels into self-scrolling areas that pad for the log

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b465d92b3883268e0e67d6591171b0