### PR TITLE
Fix mobile log overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,7 +682,7 @@
               <button class="gear-tab-btn active" data-tab="gearEquip">Gear</button>
               <button class="gear-tab-btn" data-tab="gearAbilities">Abilities</button>
             </div>
-            <div id="gearEquipSubTab" class="gear-tab-content active">
+            <div id="gearEquipSubTab" class="gear-tab-content tab-content active">
               <div class="equip-slots">
                 <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
                 <div class="equip-slot" id="slot-head"><span class="slot-label">Head</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
@@ -693,7 +693,7 @@
               <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>
               <div class="stat" title="Chance to avoid attacks">👣 <span id="dodgeVal">0</span></div>
             </div>
-            <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">
+            <div id="gearAbilitiesSubTab" class="gear-tab-content tab-content" style="display:none;">
               <div id="abilitySlots"></div>
               <div id="availableAbilities"></div>
             </div>

--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
   --gap: 20px;
   --pad: 16px;
   --header-h: 76px;
-  --bottom-log-h: 0px;
+  --log-h: 0px;
   --tabs-h: 48px;
   --safe-bottom: env(safe-area-inset-bottom,0px);
   --float-pad: 0px;
@@ -71,10 +71,16 @@ html,body{height:100%;overflow:hidden}
   display:flex;
   flex-direction:column;
   gap:var(--gap);
-  height:calc(100dvh - var(--header-h) - var(--tabs-h) - var(--bottom-log-h) - var(--safe-bottom));
+  height:calc(100dvh - var(--header-h) - var(--tabs-h));
   overflow-y:auto;
   -webkit-overflow-scrolling:touch;
-  padding-bottom:calc(var(--float-pad) + var(--bottom-log-h));
+  padding-bottom:calc(var(--log-h) + env(safe-area-inset-bottom, 0px));
+}
+
+.tab-content::after{
+  content:"";
+  display:block;
+  height:var(--log-h);
 }
 
 .tab-content>.card{
@@ -2117,7 +2123,7 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
 }
 
 .gear-tab-content.active {
-  display: block;
+  display: flex;
 }
 
 .ability-slot,
@@ -4367,7 +4373,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 .log-toggle{display:none;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--bottom-log-h:0px;}
+  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--log-h:0px;}
   html,body{overflow-x:hidden;}
   .mist-layer{inset:-10vh 0;}
   header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
@@ -4392,7 +4398,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);}
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
-  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--bottom-log-h));}
+  .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--log-h) + env(safe-area-inset-bottom,0px));}
   .activity-content{padding:var(--pad);}
   img,canvas{max-width:100%;height:auto;}
   .hp-chip .hp-bar{width:100%;max-width:100%;}

--- a/ui/index.js
+++ b/ui/index.js
@@ -580,16 +580,16 @@ function setupLogSheet() {
   if (!sheet || !toggle) return;
   const logEl = qs('#log');
   const mq = window.matchMedia('(max-width: 768px)');
-  function setHeight() {
+  function updateHeight() {
+    let h = 0;
     if (mq.matches) {
-      const h = sheet.getAttribute('data-open') === 'true'
-        ? sheet.getBoundingClientRect().height
-        : toggle.getBoundingClientRect().height;
-      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
+      h = sheet.getAttribute('data-open') === 'true'
+        ? sheet.offsetHeight
+        : toggle.offsetHeight;
     } else {
-      const h = logEl?.getBoundingClientRect().height ?? 0;
-      document.documentElement.style.setProperty('--bottom-log-h', h + 'px');
+      h = logEl?.offsetHeight ?? 0;
     }
+    document.documentElement.style.setProperty('--log-h', h + 'px');
   }
   function close() {
     sheet.setAttribute('data-open', 'false');
@@ -598,7 +598,7 @@ function setupLogSheet() {
     sheet.removeAttribute('aria-modal');
     toggle.textContent = 'Log \u25BE';
     toggle.focus();
-    setHeight();
+    updateHeight();
     window.removeEventListener('keydown', esc);
   }
   function open() {
@@ -607,16 +607,20 @@ function setupLogSheet() {
     sheet.setAttribute('role', 'dialog');
     sheet.setAttribute('aria-modal', 'true');
     toggle.textContent = 'Log \u25B4';
-    setHeight();
+    updateHeight();
     window.addEventListener('keydown', esc);
   }
   function esc(e) { if (e.key === 'Escape') close(); }
   toggle.addEventListener('click', () => {
     sheet.getAttribute('data-open') === 'true' ? close() : open();
   });
-  window.addEventListener('resize', setHeight);
-  mq.addEventListener('change', setHeight);
-  setHeight();
+  const ro = new ResizeObserver(updateHeight);
+  ro.observe(sheet);
+  if (logEl) ro.observe(logEl);
+  window.addEventListener('resize', updateHeight);
+  window.addEventListener('orientationchange', updateHeight);
+  mq.addEventListener('change', updateHeight);
+  updateHeight();
 }
 
 function enableLayoutDebug() {


### PR DESCRIPTION
## Summary
- add global `--log-h` CSS variable and keep it updated via `ResizeObserver`
- make tab panels scroll within `100dvh` and pad for the log and safe-area
- adjust gear tabs and content spacing so bottom log no longer covers controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b465d92b3883268e0e67d6591171b0