### PR TITLE
fix: ensure cards fit mobile screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -4409,6 +4409,9 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   .cards .card{width:100%;box-sizing:border-box;}
   .cards .card h4{font-size:1rem;}
   .cards .btn{font-size:0.9rem;}
+  /* Prevent cards and their contents from overflowing the viewport */
+  .card{width:100%;max-width:100%;box-sizing:border-box;overflow-x:auto;}
+  .card table{width:100%;font-size:0.9rem;}
   .cultivation-layout{
     flex-direction:column;
     align-items:stretch;


### PR DESCRIPTION
## Summary
- prevent cards and tables from overflowing the viewport on small screens

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b469592f988326b5ceb5399a0605fa