### PR TITLE
Add sequence memory mind puzzle with modal overlay

### DIFF
--- a/src/features/mind/puzzles/sequenceMemory.js
+++ b/src/features/mind/puzzles/sequenceMemory.js
@@ -1,0 +1,144 @@
+// src/features/mind/puzzles/sequenceMemory.js
+// Implements a simple sequence memory puzzle similar to "Simon".
+// Shows a sequence of rune buttons with audio/visual cues and verifies
+// user input. On success, awards puzzle multiplier via solvePuzzle.
+
+import { solvePuzzle } from '../mutators.js';
+import { save } from '../../../shared/state.js';
+
+const RUNES = [
+  { icon: 'mdi:triangle-outline', color: '#f87171', freq: 440 },
+  { icon: 'mdi:square-outline', color: '#60a5fa', freq: 520 },
+  { icon: 'mdi:circle-outline', color: '#34d399', freq: 600 },
+  { icon: 'mdi:diamond-outline', color: '#fbbf24', freq: 700 },
+];
+
+function playTone(freq, dur = 200) {
+  try {
+    const ctx = new (window.AudioContext || window.webkitAudioContext)();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = freq;
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    gain.gain.setValueAtTime(0.2, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + dur / 1000);
+    osc.stop(ctx.currentTime + dur / 1000);
+  } catch (e) {
+    // ignore audio errors (e.g., unsupported browser)
+  }
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function calcDifficulty(len, delay) {
+  let diff = Math.max(0, len - 3);
+  if (delay < 700) diff += 1;
+  if (delay < 500) diff += 1;
+  return diff;
+}
+
+export function startSequenceMemoryTest(S, { length = 3, delay = 800 } = {}) {
+  return new Promise(resolve => {
+    const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay';
+  overlay.innerHTML = `
+    <div class="modal-backdrop"></div>
+    <div class="modal-content card sequence-memory-card">
+      <div class="card-header">
+        <h4>Sequence Memory</h4>
+        <button class="btn small ghost close-btn">×</button>
+      </div>
+      <div class="memory-runes"></div>
+      <div class="memory-msg">Watch the sequence</div>
+    </div>`;
+  document.body.appendChild(overlay);
+
+    const close = () => {
+      overlay.remove();
+      resolve(false);
+    };
+    overlay.querySelector('.modal-backdrop').addEventListener('click', close);
+    overlay.querySelector('.close-btn').addEventListener('click', close);
+
+  const runeWrap = overlay.querySelector('.memory-runes');
+  const msg = overlay.querySelector('.memory-msg');
+
+  const runeEls = RUNES.map((r, idx) => {
+    const btn = document.createElement('button');
+    btn.className = 'rune-btn';
+    btn.dataset.idx = String(idx);
+    btn.style.setProperty('--clr', r.color);
+    btn.innerHTML = `<iconify-icon icon="${r.icon}" aria-hidden="true"></iconify-icon>`;
+    runeWrap.appendChild(btn);
+    return btn;
+  });
+
+  const sequence = Array.from({ length }, () => Math.floor(Math.random() * RUNES.length));
+
+  let accepting = false;
+  let pos = 0;
+
+  async function playback() {
+    accepting = false;
+    msg.textContent = 'Watch the sequence';
+    for (const idx of sequence) {
+      const el = runeEls[idx];
+      el.classList.add('active');
+      playTone(RUNES[idx].freq);
+      await wait(delay);
+      el.classList.remove('active');
+      await wait(200);
+    }
+    msg.textContent = 'Repeat the sequence';
+    accepting = true;
+  }
+
+    function success() {
+      accepting = false;
+      msg.textContent = 'Correct!';
+      const diff = calcDifficulty(sequence.length, delay);
+      solvePuzzle(S, diff);
+      save?.();
+      setTimeout(() => {
+        overlay.remove();
+        resolve(true);
+      }, 600);
+    }
+
+  function failure() {
+    accepting = false;
+    msg.textContent = 'Incorrect';
+    setTimeout(() => {
+      pos = 0;
+      playback();
+    }, 1000);
+  }
+
+  runeEls.forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (!accepting) return;
+      const idx = parseInt(btn.dataset.idx, 10);
+      const el = runeEls[idx];
+      el.classList.add('active');
+      playTone(RUNES[idx].freq);
+      setTimeout(() => el.classList.remove('active'), 200);
+      if (sequence[pos] === idx) {
+        pos += 1;
+        if (pos >= sequence.length) {
+          success();
+        }
+      } else {
+        failure();
+      }
+    });
+  });
+
+    playback();
+  });
+}
+
+export default startSequenceMemoryTest;

--- a/src/features/mind/ui/mindPuzzlesTab.js
+++ b/src/features/mind/ui/mindPuzzlesTab.js
@@ -1,7 +1,7 @@
 // src/features/mind/ui/mindPuzzlesTab.js
 
-import { solvePuzzle } from '../mutators.js';
 import { save } from '../../../shared/state.js';
+import { startSequenceMemoryTest } from '../puzzles/sequenceMemory.js';
 
 /**
  * Render the Mind Puzzles tab UI.
@@ -34,21 +34,29 @@ export function renderMindPuzzlesTab(rootEl, S) {
     diffSelect.appendChild(opt);
   }
 
-  const solveBtn = document.createElement('button');
-  solveBtn.className = 'btn primary';
-  solveBtn.textContent = 'Solve';
+  const startBtn = document.createElement('button');
+  startBtn.className = 'btn primary';
+  startBtn.textContent = 'Start Memory Test';
 
-  solveBtn.addEventListener('click', () => {
+  startBtn.addEventListener('click', () => {
     const idx = parseInt(diffSelect.value, 10) || 0;
-    solvePuzzle(S, idx);
-    save?.();
-    renderMindPuzzlesTab(rootEl, S);
+    const configs = [
+      { length: 3, delay: 800 },
+      { length: 4, delay: 700 },
+      { length: 5, delay: 600 },
+      { length: 6, delay: 500 },
+      { length: 7, delay: 400 },
+    ];
+    startSequenceMemoryTest(S, configs[idx] || configs[0]).then(() => {
+      save?.();
+      renderMindPuzzlesTab(rootEl, S);
+    });
   });
 
   const row = document.createElement('div');
   row.className = 'row';
   row.appendChild(diffSelect);
-  row.appendChild(solveBtn);
+  row.appendChild(startBtn);
 
   nextCard.appendChild(row);
   rootEl.appendChild(nextCard);

--- a/style.css
+++ b/style.css
@@ -4633,3 +4633,31 @@ html.reduce-motion .log-sheet{transition:none;}
   font-size:12px;
 }
 
+/* Sequence memory puzzle */
+.sequence-memory-card .memory-runes{
+  display:flex;
+  gap:1rem;
+  justify-content:center;
+  margin:1rem 0;
+}
+
+.sequence-memory-card .rune-btn{
+  width:60px;
+  height:60px;
+  border-radius:50%;
+  border:none;
+  cursor:pointer;
+  background:var(--clr,#ccc);
+  color:#fff;
+  font-size:24px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  transition:transform .1s,filter .1s;
+}
+
+.sequence-memory-card .rune-btn.active{
+  transform:scale(1.2);
+  filter:brightness(1.3);
+}
+


### PR DESCRIPTION
## Summary
- implement sequence memory puzzle with difficulty scaling and audio/visual cues
- expose Start Memory Test action in Mind Puzzles tab
- style rune buttons for sequence memory puzzle

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b4698df86483269ab7399c030738e1