### PR TITLE
fix: enable adventure tab scrolling on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -2563,7 +2563,8 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   display: flex;
   flex-direction: column;
   gap: 16px;
-  height: calc(100vh - 120px);
+  /* use min-height so content like the proficiency card isn't clipped on mobile */
+  min-height: calc(100dvh - 120px);
 }
 
 .adventure-progress-container {


### PR DESCRIPTION
## Summary
- let adventure layout grow with content using `min-height: calc(100dvh - 120px)`
- restore validation log

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: document updates required)*

------
https://chatgpt.com/codex/tasks/task_e_68b46e0d89e88326abd512e8ad18bd55