### PR TITLE
feat: apply astral tree bonus to foundation gain

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -89,7 +89,8 @@ export function foundationGainPerSec(state = progressionState){
   const bonuses = getBuildingBonuses(state);
   const buildingMult = state.cultivation.buildingMult * (1 + (bonuses.foundationMult || 0));
   const pillMult = state.cultivation.pillMult;
-  return baseGain * cultivationMult * lawMult * buildingMult * pillMult;
+  return baseGain * cultivationMult * lawMult * buildingMult * pillMult *
+    (1 + (state.astralTreeBonuses?.foundationGainPct || 0) / 100);
 }
 
 export function foundationGainPerMeditate(state = progressionState){


### PR DESCRIPTION
## Summary
- apply astral tree percentage bonus when computing foundation gain per second
- ensure meditation gain uses the updated foundation gain value

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `node -e "import('./src/features/progression/logic.js').then(m=>{const state={realm:{tier:0,stage:1},stats:{comprehension:10},qiRegenMult:0,cultivation:{talent:1,foundationMult:1,pillMult:1,buildingMult:1},sect:{bonuses:{}},astralTreeBonuses:{foundationGainPct:50},karma:{qiRegen:0}};console.log('perSec', m.foundationGainPerSec(state)); console.log('perMeditate', m.foundationGainPerMeditate(state));})"`


------
https://chatgpt.com/codex/tasks/task_e_68b4785b41548326a8cb5133e9a0eceb