### PR TITLE
Add elemental cultivation gear with bonuses

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -257,6 +257,8 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── puzzles/
+│   │   │   │   └── sequenceMemory.js
 │   │   │   └── ui/
 │   │   │       ├── mindMainTab.js
 │   │   │       ├── mindPuzzlesTab.js
@@ -977,6 +979,7 @@ Paths added:
 - `src/features/mind/ui/mindPuzzlesTab.js` – Displays puzzle progress and multiplier info.
 - `src/features/mind/ui/mindReadingTab.js` – Lists manuals and controls reading actions.
 - `src/features/mind/ui/mindStatsTab.js` – Shows cumulative manual bonuses.
+- `src/features/mind/puzzles/sequenceMemory.js` – Implements the sequence memory puzzle used for mind training.
 
 ### Mining Feature (`src/features/mining/`)
 - `src/features/mining/state.js` – Tracks mining level, experience, unlocked resources and yields.

--- a/src/features/gearGeneration/logic.js
+++ b/src/features/gearGeneration/logic.js
@@ -1,5 +1,21 @@
 import { BODY_BASES } from './data/bodyBases.js';
 import { MATERIALS_STUB } from '../weaponGeneration/data/materials.stub.js';
+import { ZONES as ZONE_IDS } from '../adventure/data/zoneIds.js';
+
+const ELEMENTS = ['metal', 'earth', 'wood', 'water', 'fire'];
+const ZONE_ELEMENT_WEIGHTS = {
+  [ZONE_IDS.STARTING]: { earth: 3, wood: 3, metal: 1, water: 1, fire: 1 },
+};
+
+function pickWeighted(rows) {
+  const total = rows.reduce((s, r) => s + (r.weight || 0), 0);
+  let r = Math.random() * total;
+  for (const row of rows) {
+    r -= row.weight || 0;
+    if (r <= 0) return row;
+  }
+  return rows[rows.length - 1];
+}
 
 /**
  * @typedef {{
@@ -34,6 +50,24 @@ export function generateGear({ baseKey, materialKey, qualityKey = 'normal' }/** 
     quality: qualityKey,
     material: material?.key,
   };
+}
+
+export function generateCultivationGear(gear, zoneKey) {
+  const weights = ZONE_ELEMENT_WEIGHTS[zoneKey] || {};
+  const element = pickWeighted(
+    ELEMENTS.map(el => ({ key: el, weight: weights[el] || 1 }))
+  ).key;
+  const out = { ...gear };
+  delete out.protection;
+  delete out.offense;
+  out.element = element;
+  out.bonuses = {
+    foundationMult: 0.1,
+    breakthroughBonus: 0.05,
+    qiRegenMult: 0.1,
+  };
+  out.cultivation = true;
+  return out;
 }
 
 function composeName(baseName, materialName) {

--- a/src/features/gearGeneration/selectors.js
+++ b/src/features/gearGeneration/selectors.js
@@ -1,4 +1,4 @@
-import { generateGear } from './logic.js';
+import { generateGear, generateCultivationGear } from './logic.js';
 import { GEAR_LOOT_TABLES } from '../loot/data/lootTables.gear.js';
 
 function pickWeighted(rows) {
@@ -16,5 +16,9 @@ export function rollGearDropForZone(zoneKey) {
   if (!rows || !rows.length) return null;
   const row = pickWeighted(rows);
   if (Math.random() > (row.chance ?? 1)) return null;
-  return generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey: row.qualityKey });
+  let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey: row.qualityKey });
+  if (Math.random() < 0.1) {
+    gear = generateCultivationGear(gear, zoneKey);
+  }
+  return gear;
 }

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -8,6 +8,9 @@ export function recomputePlayerTotals(player) {
   let accuracy = 0;
   let dodge = 0;
   let shieldMax = 0;
+  let foundationMult = 0;
+  let breakthroughBonus = 0;
+  let qiRegenMult = 0;
   const equipped = Object.values(player.equipment || {});
   for (const item of equipped) {
     if (!item) continue;
@@ -20,6 +23,11 @@ export function recomputePlayerTotals(player) {
     if (item.shield?.max) shieldMax += item.shield.max; // legacy support
     if (item.stats?.accuracy) accuracy += item.stats.accuracy; // legacy support
     if (item.stats?.dodge) dodge += item.stats.dodge; // legacy support
+    if (item.bonuses) {
+      foundationMult += item.bonuses.foundationMult || 0;
+      breakthroughBonus += item.bonuses.breakthroughBonus || 0;
+      qiRegenMult += item.bonuses.qiRegenMult || 0;
+    }
   }
   player.stats = player.stats || {};
   const baseArmor = calcBaseArmor(player);
@@ -37,6 +45,11 @@ export function recomputePlayerTotals(player) {
   // Cotton Robe. This caused the Qi shield to appear inactive until it was
   // refilled through other means.
   player.shield.current = player.shield.max;
+  player.gearBonuses = {
+    foundationMult,
+    breakthroughBonus,
+    qiRegenMult,
+  };
 }
 
 // Determine if an item can be equipped and in which slot

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -9,6 +9,14 @@ import { ABILITIES } from '../../ability/data/abilities.js';
 let currentFilter = 'all';
 let slotFilter = null;
 
+const ELEMENT_BG_COLORS = {
+  metal: 'rgba(153, 153, 153, 0.2)',
+  earth: 'rgba(181, 139, 0, 0.2)',
+  wood: 'rgba(46, 139, 87, 0.2)',
+  water: 'rgba(30, 144, 255, 0.2)',
+  fire: 'rgba(255, 69, 0, 0.2)'
+};
+
 export function renderEquipmentPanel() {
   recomputePlayerTotals(S);
   renderEquipment();
@@ -63,6 +71,11 @@ function renderEquipment() {
     el.querySelector('.slot-name').innerHTML = nameHtml;
     el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory(); };
     el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
+    if (item?.element) {
+      el.style.backgroundColor = ELEMENT_BG_COLORS[item.element] || '';
+    } else {
+      el.style.backgroundColor = '';
+    }
   });
   const armorEl = document.getElementById('armorVal');
   if (armorEl) armorEl.textContent = S.stats?.armor || 0;
@@ -98,6 +111,9 @@ function showDetails(item) {
 function createInventoryRow(item) {
   const row = document.createElement('div');
   row.className = 'inventory-row';
+  if (item.element) {
+    row.style.backgroundColor = ELEMENT_BG_COLORS[item.element] || '';
+  }
   const iconKey = item.type === 'weapon' ? WEAPONS[item.key]?.proficiencyKey : null;
   const icon = iconKey ? WEAPON_ICONS[iconKey] : null;
   const displayName = item.name || item.key;

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -62,7 +62,8 @@ export function qCap(state = progressionState){
 export function qiRegenPerSec(state = progressionState){
   const lawBonuses = getLawBonuses(state);
   const building = getBuildingBonuses(state).qiRegenMult || 0;
-  return (REALMS[state.realm.tier].baseRegen + karmaQiRegenBonus(state)) * (1 + state.qiRegenMult + building) * lawBonuses.qiRegen;
+  const gear = state.gearBonuses?.qiRegenMult || 0;
+  return (REALMS[state.realm.tier].baseRegen + karmaQiRegenBonus(state)) * (1 + state.qiRegenMult + building + gear) * lawBonuses.qiRegen;
 }
 
 export function fCap(state = progressionState){
@@ -89,7 +90,8 @@ export function foundationGainPerSec(state = progressionState){
   const bonuses = getBuildingBonuses(state);
   const buildingMult = state.cultivation.buildingMult * (1 + (bonuses.foundationMult || 0));
   const pillMult = state.cultivation.pillMult;
-  return baseGain * cultivationMult * lawMult * buildingMult * pillMult;
+  const gear = state.gearBonuses?.foundationMult || 0;
+  return baseGain * cultivationMult * lawMult * buildingMult * pillMult * (1 + gear);
 }
 
 export function foundationGainPerMeditate(state = progressionState){
@@ -193,7 +195,9 @@ export function breakthroughChance(state = progressionState){
   const buildingBonus = getBuildingBonuses(state).breakthroughBonus || 0;
   const cultivationBonus = (state.cultivation.talent - 1) * 0.1;
 
-  const totalChance = base + ward + cookingBonus + buildingBonus + cultivationBonus;
+  const gearBonus = state.gearBonuses?.breakthroughBonus || 0;
+
+  const totalChance = base + ward + cookingBonus + buildingBonus + cultivationBonus + gearBonus;
 
   return clamp(totalChance, 0.01, 0.95);
 }

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -128,6 +128,7 @@ export const defaultState = () => {
 
   equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, food: null }, // EQUIP-CHAR-UI
   inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
+  gearBonuses: {},
   sessionLoot: [], // EQUIP-CHAR-UI
   flags: { weaponsEnabled: true },
   cultivation: {


### PR DESCRIPTION
## Summary
- Introduce elemental cultivation gear with zone-based element weights
- Grant cultivation bonuses (foundation, breakthrough, qi regen) instead of combat stats
- Tint gear backgrounds in inventory and equipment based on element

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: multiple UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b47834b71c8326b7c95592ff4c909e