### PR TITLE
Apply astral tree bonus to manual speed

### DIFF
--- a/src/features/mind/logic.js
+++ b/src/features/mind/logic.js
@@ -7,7 +7,7 @@ export function calcFromProficiency(profXp) {
   return Math.max(0, profXp) * 0.25;
 }
 
-export function calcManualSpeed(manual, stats) {
+export function calcManualSpeed(manual, stats, state) {
   const weights = manual?.statWeights;
   if (!weights || !stats) return 1;
   let boost = 0;
@@ -17,11 +17,13 @@ export function calcManualSpeed(manual, stats) {
   }
   const mult = 1 + boost / 10;
   const cap = 1 + (manual?.maxSpeedBoostPct || 0) / 100;
-  return Math.min(mult, cap);
+  const treeMult = 1 + (state?.astralTreeBonuses?.manualComprehensionPct || 0) / 100;
+  return Math.min(mult, cap) * treeMult;
 }
 
 // Return detailed reading speed information including per-stat
-// contributions and the final multiplier after caps.
+// contributions and the multiplier after caps. Does not include
+// comprehension bonuses from the astral tree.
 export function calcManualSpeedDetails(manual, stats) {
   const weights = manual?.statWeights;
   if (!weights || !stats) return { mult: 1, contributions: {} };
@@ -49,9 +51,9 @@ export function calcManualSpeedDetails(manual, stats) {
   return { mult, contributions };
 }
 
-export function calcFromManual(manual, dt, stats) {
+export function calcFromManual(manual, dt, stats, state) {
   if (!manual) return 0;
-  const speed = calcManualSpeed(manual, stats);
+  const speed = calcManualSpeed(manual, stats, state);
   return manual.xpRate * dt * speed;
 }
 

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -79,7 +79,7 @@ export function onTick(S, dt) {
     stopReading(S);
     return;
   }
-  const add = calcFromManual(manual, dt, S.stats);
+  const add = calcFromManual(manual, dt, S.stats, S);
   const applied = applyPuzzleMultiplier(add, S.mind.multiplier);
   S.mind.fromReading += add;
   S.mind.xp += applied;


### PR DESCRIPTION
## Summary
- Factor in astral tree manual comprehension bonus when calculating manual reading speed
- Show astral comprehension separately from attribute-based reading speed in manual UI
- Restore "Manual Comprehension" terminology for astral tree nodes and bonus labels

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation and documentation requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68b478d54bfc8326b4ed31c8d8f15d15