### PR TITLE
Prevent retreat during boss fights

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -974,6 +974,12 @@ export function selectZone(zoneIndex) {
 
 export function retreatFromCombat() {
   if (!S.adventure) return;
+  if (S.adventure.isBossFight) {
+    S.adventure.combatLog = S.adventure.combatLog || [];
+    S.adventure.combatLog.push('Retreat is impossible during a boss fight.');
+    log('Retreat is impossible during a boss fight.', 'bad');
+    return;
+  }
   if (S.adventure.inCombat) {
     S.hp = S.adventure.playerHP;
     S.adventure.inCombat = false;

--- a/src/features/adventure/mutators.js
+++ b/src/features/adventure/mutators.js
@@ -42,6 +42,10 @@ export function startAdventure(state = S) {
 }
 
 export function retreatFromCombat(state = S) {
+  if (state.adventure?.isBossFight) {
+    log('Retreat is impossible during a boss fight.', 'bad');
+    return;
+  }
   baseRetreatFromCombat();
   const loss = Math.floor(qCap(state) * 0.25);
   state.qi = Math.max(0, state.qi - loss);

--- a/src/features/adventure/ui/adventureDisplay.js
+++ b/src/features/adventure/ui/adventureDisplay.js
@@ -1,5 +1,5 @@
 import { S } from '../../../shared/state.js';
-import { setFill, setText } from '../../../shared/utils/dom.js';
+import { setFill, setText, log } from '../../../shared/utils/dom.js';
 import { ZONES } from '../data/zones.js';
 import { startAdventure, startAdventureCombat, startBossCombat, progressToNextArea, retreatFromCombat, resetQiOnRetreat } from '../mutators.js';
 import { updateActivityAdventure } from '../logic.js';
@@ -27,6 +27,10 @@ export function mountAdventureControls(root) {
   function startRetreatCountdown() {
     const btn = document.getElementById('startBattleButton');
     if (!root.adventure || !root.adventure.inCombat || !btn) return;
+    if (root.adventure.isBossFight) {
+      log('You cannot retreat from a boss fight!', 'bad');
+      return;
+    }
     let remaining = 5;
     btn.disabled = true;
     btn.textContent = `Retreating (${remaining})`;


### PR DESCRIPTION
## Summary
- Block retreat attempts when a boss fight is active
- Warn players via combat log and UI when retreating from bosses
- Guard UI retreat countdown from triggering during boss encounters

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b47d3254148326897d44ab09511575