### PR TITLE
Remove unused browser-tools-mcp submodule

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ At the root of the repository you will find the following top‑level folders:
 | `src/ui/`         | Legacy user interface code organised by view or component.  Feature UIs being added in the new structure live inside `src/features/<feature>/ui`. |
 | `docs/`           | Project documentation (design guides, UI style guidelines, proficiency explanation, etc.).  This file lives here. |
 
-Other folders such as `scripts/` (build or deployment scripts), `browser-tools-mcp/` (internal dev tooling), and `index.html` remain unchanged from the previous structure.
+Other folders such as `scripts/` (build or deployment scripts) and `index.html` remain unchanged from the previous structure.
 
 #### Runtime Orchestration: GameController
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -27,30 +27,6 @@ way-of-ascension/
 │   │   ├── astral_tree-base-structure.json
 │   │   └── astral_tree_pentagon.json
 │   └── workoround-tree.html
-├── browser-tools-mcp/
-│   ├── browser-tools-mcp/
-│   │   ├── README.md
-│   │   ├── mcp-server.ts
-│   │   ├── package-lock.json
-│   │   ├── package.json
-│   │   └── tsconfig.json
-│   ├── browser-tools-server/
-│   │   ├── lighthouse/
-│   │   ├── README.md
-│   │   ├── browser-connector.ts
-│   │   ├── package.json
-│   │   ├── server.ts
-│   │   └── tsconfig.json
-│   ├── chrome-extension/
-│   │   ├── background.js
-│   │   ├── devtools.html
-│   │   ├── devtools.js
-│   │   ├── manifest.json
-│   │   ├── panel.html
-│   │   └── panel.js
-│   └── docs/
-│       ├── mcp-docs.md
-│       └── mcp.md
 ├── docs/
 │   ├── To-dos/
 │   │   ├── Balance.md

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -88,7 +88,7 @@ class StructureValidator {
   }
 
   scanCurrentStructure() {
-    const ignoreDirs = ['node_modules', '.git', 'browser-tools-mcp', '.vscode', '.idea'];
+    const ignoreDirs = ['node_modules', '.git', '.vscode', '.idea'];
     const importantExtensions = ['.js', '.md', '.html', '.css', '.json'];
 
     const scanDir = (dirPath, relativePath = '') => {


### PR DESCRIPTION
## Summary
- remove unused `browser-tools-mcp` submodule metadata
- drop references to removed submodule

## Testing
- `git submodule status`
- `git grep -n "browser-tools-mcp"`


------
https://chatgpt.com/codex/tasks/task_e_68b48b38f414832693b5ed46571eb2da