### PR TITLE
feat: display astral node cost before modifiers

### DIFF
--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -227,7 +227,7 @@ async function buildTree() {
 
   function showTooltip(evt, n) {
     const info = manifest[n.id] || {};
-    const lines = [n.label, `Cost: ${info.cost ?? '-'}`];
+    const lines = [n.label, `Cost: ${info.cost ?? '-'}`, ''];
     if (info.effects) lines.push(...info.effects);
     tooltip.innerHTML = lines.join('<br>');
 


### PR DESCRIPTION
## Summary
- ensure astral node tooltips list cost above modifier lines with a blank space

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and DOM usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b491143600832683b5a7851fc65e06