### PR TITLE
Ensure Qi shield initializes on load

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -48,6 +48,7 @@ import { ZONES } from '../src/features/adventure/data/zones.js'; // MAP-UI-UPDAT
 import { setReduceMotion } from '../src/features/combat/ui/index.js';
 import { tickAbilityCooldowns } from '../src/features/ability/mutators.js';
 import { setupAbilityUI } from '../src/features/ability/ui.js';
+import { recomputePlayerTotals } from '../src/features/inventory/logic.js';
 import { advanceMining } from '../src/features/mining/logic.js';
 import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
@@ -646,6 +647,8 @@ window.addEventListener('load', ()=>{
   setupAdventureTabs();
   setupMindTabs();
   setupEquipmentTab(); // EQUIP-CHAR-UI
+  // Ensure derived stats like Qi shield are initialized based on equipped gear
+  recomputePlayerTotals(S);
   mountAlchemyUI(S);
   mountKarmaUI(S);
   mountSectUI(S);


### PR DESCRIPTION
## Summary
- Recompute player stats on load so equipped gear immediately sets Qi shield values
- Import inventory stat calculator into main UI init

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b46dea7d6083269e11f5299307d734