### PR TITLE
Integrate label effects with astral tree rotation

### DIFF
--- a/src/features/progression/data/astral_tree.json
+++ b/src/features/progression/data/astral_tree.json
@@ -134,7 +134,7 @@
     },
     {
       "id": 24,
-      "label": " Accuracy +50",
+      "label": "Accuracy +50",
       "group": "Wood",
       "type": "basic",
       "x": 379.2538906914845,


### PR DESCRIPTION
## Summary
- parse basic node labels and merge their bonuses with rotating astral tree bonuses
- show combined effects in tooltip and center tree using root node ID
- handle boolean bonuses in applyEffects and clean up stray label whitespace

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation warnings)
- `npm run lint:balance`
- `npm run scan-output`


------
https://chatgpt.com/codex/tasks/task_e_68b4ce0122dc8326b8a18ee9879f948e