### PR TITLE
Restore cultivation stats card with foundation bonuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
               </div>
             </div>
 
-            <div class="card" id="cultivationStatsCard" style="display:none;">
+            <div class="card" id="cultivationStatsCard">
               <h4>🌟 Cultivation Stats</h4>
               <p class="muted">Enhanced cultivation abilities and multipliers:</p>
               <div class="stat"><span>Talent</span><span id="cultivationTalent">1.0x</span></div>

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -105,26 +105,24 @@ export function updateActivityCultivation() {
 
   const statsCard = document.getElementById('cultivationStatsCard');
   if (statsCard) {
-    statsCard.style.display = S.activities.cultivation ? 'block' : 'none';
+    statsCard.style.display = 'block';
   }
 
-  if (S.activities.cultivation) {
-    if (!S.cultivation) {
-      S.cultivation = {
-        talent: 1.0,
-        comprehension: 1.0,
-        foundationMult: 1.0,
-        pillMult: 1.0,
-        buildingMult: 1.0
-      };
-    }
-
-    setText('cultivationTalent', (S.cultivation.talent || 1.0).toFixed(1) + 'x');
-    setText('cultivationComprehension', (S.cultivation.comprehension || 1.0).toFixed(1) + 'x');
-    setText('cultivationFoundationMult', (S.cultivation.foundationMult || 1.0).toFixed(1) + 'x');
-    setText('cultivationPillMult', (S.cultivation.pillMult || 1.0).toFixed(1) + 'x');
-    setText('cultivationBuildingMult', (S.cultivation.buildingMult || 1.0).toFixed(1) + 'x');
+  if (!S.cultivation) {
+    S.cultivation = {
+      talent: 1.0,
+      comprehension: 1.0,
+      foundationMult: 1.0,
+      pillMult: 1.0,
+      buildingMult: 1.0
+    };
   }
+
+  setText('cultivationTalent', (S.cultivation.talent || 1.0).toFixed(1) + 'x');
+  setText('cultivationComprehension', (S.cultivation.comprehension || 1.0).toFixed(1) + 'x');
+  setText('cultivationFoundationMult', (S.cultivation.foundationMult || 1.0).toFixed(1) + 'x');
+  setText('cultivationPillMult', (S.cultivation.pillMult || 1.0).toFixed(1) + 'x');
+  setText('cultivationBuildingMult', (S.cultivation.buildingMult || 1.0).toFixed(1) + 'x');
 
   updateCultivationProgressionTree();
   setupCultivationTabs();


### PR DESCRIPTION
## Summary
- Restore Cultivation Stats card and always display foundation multipliers
- Ensure cultivation bonuses update regardless of activity state

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation warnings; AI changes blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ce2f793083269f3f8c095d2c28d6