### PR TITLE
feat: add weighted item quality

### DIFF
--- a/src/features/gearGeneration/selectors.js
+++ b/src/features/gearGeneration/selectors.js
@@ -11,12 +11,24 @@ function pickWeighted(rows) {
   return rows[rows.length - 1];
 }
 
+function pickQuality(weights = { normal: 80, magic: 15, rare: 5 }) {
+  const entries = Object.entries(weights);
+  const total = entries.reduce((s, [, w]) => s + w, 0);
+  let r = Math.random() * total;
+  for (const [key, weight] of entries) {
+    r -= weight;
+    if (r <= 0) return key;
+  }
+  return entries[0][0];
+}
+
 export function rollGearDropForZone(zoneKey) {
   const rows = GEAR_LOOT_TABLES[zoneKey];
   if (!rows || !rows.length) return null;
   const row = pickWeighted(rows);
   if (Math.random() > (row.chance ?? 1)) return null;
-  let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey: row.qualityKey });
+  const qualityKey = row.qualityKey || pickQuality();
+  let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey });
   if (Math.random() < 0.1) {
     gear = generateCultivationGear(gear, zoneKey);
   }

--- a/src/features/loot/data/lootTables.gear.js
+++ b/src/features/loot/data/lootTables.gear.js
@@ -3,7 +3,7 @@ import { ZONES } from '../../adventure/data/zoneIds.js';
 export const GEAR_LOOT_TABLES = {
   [ZONES.STARTING]: [
     { baseKey: 'iron_cuirass', materialKey: 'iron', qualityKey: 'normal', weight: 100, chance: 0.35 },
-    { baseKey: 'leather_tunic', materialKey: 'leather', qualityKey: 'normal', weight: 100, chance: 0.35 },
-    { baseKey: 'cotton_robe', materialKey: 'cotton', qualityKey: 'normal', weight: 100, chance: 0.35 },
+    { baseKey: 'leather_tunic', materialKey: 'leather', weight: 100, chance: 0.35 },
+    { baseKey: 'cotton_robe', materialKey: 'cotton', weight: 100, chance: 0.35 },
   ],
 };

--- a/src/features/loot/data/lootTables.weapons.js
+++ b/src/features/loot/data/lootTables.weapons.js
@@ -5,7 +5,7 @@ import { ZONES } from '../../adventure/data/zoneIds.js';
 /** Minimal v1: starting zone only */
 export const WEAPON_LOOT_TABLES /** @type {Record<string, WeaponLootRow[]>} */ = {
   [ZONES.STARTING]: [
-    // v1 guarantee: only Iron Sword can drop here
+    // v1 guarantee: only Iron Sword can drop here; quality determined by weights
     { typeKey: 'sword', materialKey: 'iron', weight: 100 },
   ],
   // other zones → add later

--- a/src/features/weaponGeneration/logic.js
+++ b/src/features/weaponGeneration/logic.js
@@ -4,6 +4,7 @@ import { MATERIALS_STUB } from './data/materials.stub.js';
 /** @typedef {{
  *  typeKey:string,
  *  materialKey?:string,         // optional; for naming only (no stats impact)
+ *  qualityKey?:'normal'|'magic'|'rare',
  *  level?:number                // placeholder; no scaling applied yet
  * }} GenArgs */
 
@@ -20,11 +21,11 @@ import { MATERIALS_STUB } from './data/materials.stub.js';
  * }} WeaponItem */
 
 /** Compose final item. Minimal quality/affix support. */
-export function generateWeapon(args/** @type {GenArgs} */){
-  const type = WEAPON_TYPES[args.typeKey];
-  if (!type) throw new Error(`Unknown weapon type: ${args.typeKey}`);
+export function generateWeapon({ typeKey, materialKey, qualityKey = 'normal' }/** @type {GenArgs} */){
+  const type = WEAPON_TYPES[typeKey];
+  if (!type) throw new Error(`Unknown weapon type: ${typeKey}`);
 
-  const material = args.materialKey ? MATERIALS_STUB[args.materialKey] : undefined;
+  const material = materialKey ? MATERIALS_STUB[materialKey] : undefined;
 
   const abilityKeys = [];
   if (type.signatureAbilityKey) abilityKeys.push(type.signatureAbilityKey);
@@ -40,7 +41,7 @@ export function generateWeapon(args/** @type {GenArgs} */){
     scales: { ...type.scales },
     tags: [...type.tags],       // only 'physical' or []
     abilityKeys,                // e.g., ['powerSlash'] for swords
-    quality: 'normal',
+    quality: qualityKey,
     affixes: [],
   };
 }

--- a/src/features/weaponGeneration/selectors.js
+++ b/src/features/weaponGeneration/selectors.js
@@ -16,13 +16,26 @@ function pickWeighted(rows){
   return rows[rows.length - 1];
 }
 
+function pickQuality(weights = { normal: 80, magic: 15, rare: 5 }) {
+  const entries = Object.entries(weights);
+  const total = entries.reduce((s, [, w]) => s + w, 0);
+  let r = Math.random() * total;
+  for (const [key, weight] of entries) {
+    r -= weight;
+    if (r <= 0) return key;
+  }
+  return entries[0][0];
+}
+
 export function rollWeaponDropForZone(zoneKey){
   const rows = WEAPON_LOOT_TABLES[zoneKey];
   if (!rows || rows.length === 0) return null;
 
   const row = pickWeighted(rows);
+  const qualityKey = row.qualityKey || pickQuality();
   return generateWeapon({
     typeKey: row.typeKey,
     materialKey: row.materialKey,
+    qualityKey,
   });
 }


### PR DESCRIPTION
## Summary
- add weighted quality helper for gear and weapon drops
- allow loot tables to omit qualityKey for random quality
- forward selected quality to item generators

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js)


------
https://chatgpt.com/codex/tasks/task_e_68b4ce405fa48326be226c65169bdeeb