### PR TITLE
Integrate label effects with astral tree rotation

### DIFF
--- a/src/features/progression/data/astral_tree.json
+++ b/src/features/progression/data/astral_tree.json
@@ -134,7 +134,7 @@
     },
     {
       "id": 24,
-      "label": " Accuracy +50",
+      "label": "Accuracy +50",
       "group": "Wood",
       "type": "basic",
       "x": 379.2538906914845,

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -65,6 +65,7 @@ const BONUS_LABELS = {
   breakthroughChancePct: 'Breakthrough Chance',
   qiRegenPct: 'Qi Regeneration',
   maxQiPct: 'Max Qi',
+  maxQi: 'Max Qi',
   castSpeedPct: 'Cast Speed',
   spellDamagePct: 'Spell Damage',
   summonDamagePct: 'Summon Damage',
@@ -124,18 +125,55 @@ function renderAstralTreeTotals() {
 function buildManifest(nodes) {
   const manifest = {};
   const basicNodes = nodes.filter(n => n.type === 'basic');
+  const notableNodes = nodes.filter(n => n.type === 'notable');
   let idx = 0;
+
+  function parseLabel(label) {
+    const effects = label.split(/\n/).map(s => s.trim()).filter(Boolean);
+    const bonus = {};
+    effects.forEach(line => {
+      const m = line.match(/([+-]?\d+(?:\.\d+)?)\s*%?\+?/);
+      if (!m) return;
+      const value = Number(m[1]);
+      const before = line.slice(0, m.index).trim();
+      const after = line.slice(m.index + m[0].length).trim();
+      const words = (before || after).replace(/[^a-zA-Z ]/g, '').trim();
+      if (!words) return;
+      const key =
+        words
+          .split(/\s+/)
+          .map((w, i) =>
+            i === 0 ? w.toLowerCase() : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
+          )
+          .join('') + (line.includes('%') ? 'Pct' : '');
+      bonus[key] = (bonus[key] || 0) + value;
+    });
+    return { effects, bonus };
+  }
+
   basicNodes.forEach(n => {
+    const parsed = parseLabel(n.label || '');
     if (n.group === 'Hub') {
-      manifest[n.id] = { cost: 10 };
+      manifest[n.id] = { cost: 10, ...parsed };
       return;
     }
     const rot = BASIC_ROTATION[idx % BASIC_ROTATION.length];
-    manifest[n.id] = { cost: 10, effects: [rot.desc], bonus: rot.bonus };
+    const effects = [...parsed.effects, rot.desc];
+    const bonus = { ...parsed.bonus };
+    for (const [k, v] of Object.entries(rot.bonus)) {
+      bonus[k] = typeof v === 'number' ? (bonus[k] || 0) + v : v || bonus[k];
+    }
+    manifest[n.id] = { cost: 10, effects, bonus };
     idx++;
   });
-  Object.entries(NOTABLES).forEach(([id, data]) => {
-    manifest[Number(id)] = { cost: 30, ...data };
+  notableNodes.forEach(n => {
+    const parsed = parseLabel(n.label || '');
+    const extra = NOTABLES[n.id] || {};
+    const effects = extra.effects
+      ? [...new Set([...parsed.effects, ...extra.effects])]
+      : parsed.effects;
+    const bonus = { ...parsed.bonus, ...(extra.bonus || {}) };
+    manifest[n.id] = { cost: 30, effects, bonus };
   });
   return manifest;
 }
@@ -227,8 +265,8 @@ async function buildTree() {
 
   function showTooltip(evt, n) {
     const info = manifest[n.id] || {};
-    const lines = [n.label, `Cost: ${info.cost ?? '-'}`];
-    if (info.effects) lines.push(...info.effects);
+    const lines = info.effects ? [...info.effects] : [];
+    lines.push(`Cost: ${info.cost ?? '-'}`);
     tooltip.innerHTML = lines.join('<br>');
 
     if (isAllocatable(n.id, allocated, adj, manifest)) {
@@ -295,9 +333,8 @@ async function buildTree() {
   const treeWidth = maxX - minX;
   const treeHeight = maxY - minY;
 
-  // Center on the initial "max Qi +50" node shown in the screenshot
-  const startNode =
-    nodes.find(n => n.label === 'max Qi +50') || nodes[0];
+  // Center on the initial root node (id 4054)
+  const startNode = nodeById[4054] || nodes[0];
   const centerX = startNode.x;
   const centerY = startNode.y;
   const INITIAL_ZOOM = 5;
@@ -502,7 +539,11 @@ function applyEffects(id, manifest) {
   if (!info || !info.bonus) return;
   const bonuses = S.astralTreeBonuses || (S.astralTreeBonuses = {});
   for (const [k, v] of Object.entries(info.bonus)) {
-    bonuses[k] = (bonuses[k] || 0) + v;
+    if (typeof v === 'number') {
+      bonuses[k] = (bonuses[k] || 0) + v;
+    } else if (typeof v === 'boolean') {
+      bonuses[k] = bonuses[k] || v;
+    }
   }
   renderAstralTreeTotals();
 }


### PR DESCRIPTION
## Summary
- parse basic node labels and merge with rotating astral tree bonuses
- preserve hub node effects and merge parsed bonuses with notables' structured data
- show combined effects in tooltip and center tree using root node ID
- handle boolean bonuses in applyEffects and clean up stray label whitespace

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation warnings)
- `npm run lint:balance`
- `npm run scan-output`


------
https://chatgpt.com/codex/tasks/task_e_68b4ce0122dc8326b8a18ee9879f948e