### PR TITLE
Scale weapon damage by quality tier

### DIFF
--- a/src/features/weaponGeneration/data/weapons.js
+++ b/src/features/weaponGeneration/data/weapons.js
@@ -80,9 +80,9 @@ const PALM_WRAPS = {
 export const WEAPONS = {
   fist: FIST,
   palmWraps: PALM_WRAPS,
-  ironSword: toLegacy('ironSword', generateWeapon({ typeKey: 'sword', materialKey: 'iron' })),
-  bronzeHammer: toLegacy('bronzeHammer', generateWeapon({ typeKey: 'hammer', materialKey: 'bronze' })),
-  elderWand: toLegacy('elderWand', generateWeapon({ typeKey: 'wand', materialKey: 'spiritwood' })),
+  ironSword: toLegacy('ironSword', generateWeapon({ typeKey: 'sword', materialKey: 'iron', qualityKey: 'normal' })),
+  bronzeHammer: toLegacy('bronzeHammer', generateWeapon({ typeKey: 'hammer', materialKey: 'bronze', qualityKey: 'normal' })),
+  elderWand: toLegacy('elderWand', generateWeapon({ typeKey: 'wand', materialKey: 'spiritwood', qualityKey: 'normal' })),
 };
 
 const FIST_BASE_MAX = FIST.base.max;

--- a/src/features/weaponGeneration/logic.js
+++ b/src/features/weaponGeneration/logic.js
@@ -27,17 +27,25 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'normal' }/*
 
   const material = materialKey ? MATERIALS_STUB[materialKey] : undefined;
 
+  const qualityMult = { normal: 1, magic: 1.1, rare: 1.25 }[qualityKey] || 1;
+
   const abilityKeys = [];
   if (type.signatureAbilityKey) abilityKeys.push(type.signatureAbilityKey);
 
   const name = composeName({ typeName: type.displayName, materialName: material?.displayName });
+
+  const base = {
+    min: Math.round(type.base.min * qualityMult),
+    max: Math.round(type.base.max * qualityMult),
+    rate: type.base.rate,
+  };
 
   /** @type {WeaponItem} */
   return {
     name,
     typeKey: type.key,
     materialKey: material?.key,
-    base: { ...type.base },
+    base,
     scales: { ...type.scales },
     tags: [...type.tags],       // only 'physical' or []
     abilityKeys,                // e.g., ['powerSlash'] for swords


### PR DESCRIPTION
## Summary
- apply quality-based multipliers to weapon base damage
- specify quality when generating default weapon data

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b4d400f9d08326bffd32dde07429a9