### PR TITLE
Use quality weight helper for weapon drops

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -153,6 +153,7 @@ way-of-ascension/
 │   │   │   ├── logic.js
 │   │   │   ├── migrations.js
 │   │   │   ├── mutators.js
+│   │   │   ├── qualityWeights.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
 │   │   │   ├── index.js
@@ -518,6 +519,11 @@ export function runMigrations(save) {
 **Purpose**: Provides weighted random item selection based on zone loot tables.
 **Key Functions**: `rollLoot()`, `toLootTableKey()`, `onEnemyDefeated()`.
 **When to modify**: Adjust loot algorithms or add new drop behaviors.
+
+#### `src/features/loot/qualityWeights.js` - Quality Weight Helper
+**Purpose**: Rolls a weapon or gear quality based on weighted chances.
+**Key Functions**: `rollQualityKey()`.
+**When to modify**: Adjust default quality probabilities or introduce zone-specific distributions.
 
 #### `src/features/loot/data/lootTables.gear.js` - Gear Loot Tables
 **Purpose**: Defines starter zone body gear drops and their weights.

--- a/src/features/loot/qualityWeights.js
+++ b/src/features/loot/qualityWeights.js
@@ -1,0 +1,10 @@
+export function rollQualityKey(weights = { normal: 80, magic: 15, rare: 5 }, rng = Math.random) {
+  const entries = Object.entries(weights);
+  const total = entries.reduce((sum, [, w]) => sum + w, 0);
+  let r = rng() * total;
+  for (const [key, weight] of entries) {
+    r -= weight;
+    if (r <= 0) return key;
+  }
+  return entries[0][0];
+}

--- a/src/features/weaponGeneration/selectors.js
+++ b/src/features/weaponGeneration/selectors.js
@@ -1,6 +1,7 @@
 import { weaponGenerationState } from './state.js';
 import { WEAPON_LOOT_TABLES } from '../loot/data/lootTables.weapons.js';
 import { generateWeapon } from './logic.js';
+import { rollQualityKey } from '../loot/qualityWeights.js';
 
 export function getGeneratedWeapon(state = weaponGenerationState) {
   return state.generated;
@@ -16,23 +17,12 @@ function pickWeighted(rows){
   return rows[rows.length - 1];
 }
 
-function pickQuality(weights = { normal: 80, magic: 15, rare: 5 }) {
-  const entries = Object.entries(weights);
-  const total = entries.reduce((s, [, w]) => s + w, 0);
-  let r = Math.random() * total;
-  for (const [key, weight] of entries) {
-    r -= weight;
-    if (r <= 0) return key;
-  }
-  return entries[0][0];
-}
-
 export function rollWeaponDropForZone(zoneKey){
   const rows = WEAPON_LOOT_TABLES[zoneKey];
   if (!rows || rows.length === 0) return null;
 
   const row = pickWeighted(rows);
-  const qualityKey = row.qualityKey || pickQuality();
+  const qualityKey = row.qualityKey || rollQualityKey(row.qualityWeights);
   return generateWeapon({
     typeKey: row.typeKey,
     materialKey: row.materialKey,


### PR DESCRIPTION
## Summary
- add shared helper to roll item quality from weighted chances
- use quality weight helper when rolling weapon drops and pass chosen quality to generator
- document new qualityWeights helper in project structure

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations and DOM usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d4101af4832686fe27a0daf95f4f