### PR TITLE
Rename item quality tiers

### DIFF
--- a/src/features/gearGeneration/logic.js
+++ b/src/features/gearGeneration/logic.js
@@ -21,15 +21,15 @@ function pickWeighted(rows) {
  * @typedef {{
  *  baseKey:string,
  *  materialKey?:string,
- *  qualityKey?:'normal'|'magic'|'rare'
+ *  qualityKey?:'basic'|'refined'|'superior'
  * }} GearGenArgs
  */
 
-export function generateGear({ baseKey, materialKey, qualityKey = 'normal' }/** @type {GearGenArgs} */) {
+export function generateGear({ baseKey, materialKey, qualityKey = 'basic' }/** @type {GearGenArgs} */) {
   const base = BODY_BASES[baseKey];
   if (!base) throw new Error(`Unknown base gear: ${baseKey}`);
   const material = materialKey ? MATERIALS_STUB[materialKey] : null;
-  const qualityMult = { normal: 1, magic: 1.1, rare: 1.25 }[qualityKey] || 1;
+  const qualityMult = { basic: 1, refined: 1.1, superior: 1.25 }[qualityKey] || 1;
   const protection = {
     armor: Math.round((base.baseProtection.armor || 0) * qualityMult),
     dodge: Math.round((base.baseProtection.dodge || 0) * qualityMult),

--- a/src/features/gearGeneration/selectors.js
+++ b/src/features/gearGeneration/selectors.js
@@ -11,7 +11,7 @@ function pickWeighted(rows) {
   return rows[rows.length - 1];
 }
 
-function pickQuality(weights = { normal: 80, magic: 15, rare: 5 }) {
+function pickQuality(weights = { basic: 80, refined: 15, superior: 5 }) {
   const entries = Object.entries(weights);
   const total = entries.reduce((s, [, w]) => s + w, 0);
   let r = Math.random() * total;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -18,9 +18,9 @@ const ELEMENT_BG_COLORS = {
 };
 
 const QUALITY_STARS = {
-  normal: '',
-  magic: '★',
-  rare: '★★'
+  basic: '',
+  refined: '★',
+  superior: '★★',
 };
 
 export function renderEquipmentPanel() {
@@ -102,7 +102,7 @@ function weaponDetailsText(item) {
     .map(([k, v]) => `${k} ${(v * 100).toFixed(0)}%`)
     .join(', ');
   const reqs = w.reqs ? `Realm ${w.reqs.realmMin}, Proficiency ${w.reqs.proficiencyMin}` : 'None';
-  const quality = w.quality ?? 'normal';
+  const quality = w.quality ?? 'basic';
   const affixes = w.affixes && w.affixes.length ? w.affixes.join(', ') : 'None';
   return `${w.displayName || w.name}\nQuality: ${quality}\nAffixes: ${affixes}\nBase: ${base}\nScales: ${scales}\nTags: ${(w.tags || []).join(', ')}\nReqs: ${reqs}`;
 }

--- a/src/features/loot/data/lootTables.gear.js
+++ b/src/features/loot/data/lootTables.gear.js
@@ -2,7 +2,7 @@ import { ZONES } from '../../adventure/data/zoneIds.js';
 
 export const GEAR_LOOT_TABLES = {
   [ZONES.STARTING]: [
-    { baseKey: 'iron_cuirass', materialKey: 'iron', qualityKey: 'normal', weight: 100, chance: 0.35 },
+    { baseKey: 'iron_cuirass', materialKey: 'iron', qualityKey: 'basic', weight: 100, chance: 0.35 },
     { baseKey: 'leather_tunic', materialKey: 'leather', weight: 100, chance: 0.35 },
     { baseKey: 'cotton_robe', materialKey: 'cotton', weight: 100, chance: 0.35 },
   ],

--- a/src/features/loot/qualityWeights.js
+++ b/src/features/loot/qualityWeights.js
@@ -1,4 +1,4 @@
-export function rollQualityKey(weights = { normal: 80, magic: 15, rare: 5 }, rng = Math.random) {
+export function rollQualityKey(weights = { basic: 80, refined: 15, superior: 5 }, rng = Math.random) {
   const entries = Object.entries(weights);
   const total = entries.reduce((sum, [, w]) => sum + w, 0);
   let r = rng() * total;

--- a/src/features/weaponGeneration/data/weapons.js
+++ b/src/features/weaponGeneration/data/weapons.js
@@ -51,7 +51,7 @@ const FIST = {
   key: 'fist',
   displayName: 'Fists',
   typeKey: 'fist',
-  quality: 'normal',
+  quality: 'basic',
   affixes: [],
   slot: 'mainhand',
   base: { min: 1, max: 3, attackRate: 1.0 },
@@ -80,9 +80,9 @@ const PALM_WRAPS = {
 export const WEAPONS = {
   fist: FIST,
   palmWraps: PALM_WRAPS,
-  ironSword: toLegacy('ironSword', generateWeapon({ typeKey: 'sword', materialKey: 'iron', qualityKey: 'normal' })),
-  bronzeHammer: toLegacy('bronzeHammer', generateWeapon({ typeKey: 'hammer', materialKey: 'bronze', qualityKey: 'normal' })),
-  elderWand: toLegacy('elderWand', generateWeapon({ typeKey: 'wand', materialKey: 'spiritwood', qualityKey: 'normal' })),
+  ironSword: toLegacy('ironSword', generateWeapon({ typeKey: 'sword', materialKey: 'iron', qualityKey: 'basic' })),
+  bronzeHammer: toLegacy('bronzeHammer', generateWeapon({ typeKey: 'hammer', materialKey: 'bronze', qualityKey: 'basic' })),
+  elderWand: toLegacy('elderWand', generateWeapon({ typeKey: 'wand', materialKey: 'spiritwood', qualityKey: 'basic' })),
 };
 
 const FIST_BASE_MAX = FIST.base.max;

--- a/src/features/weaponGeneration/logic.js
+++ b/src/features/weaponGeneration/logic.js
@@ -4,7 +4,7 @@ import { MATERIALS_STUB } from './data/materials.stub.js';
 /** @typedef {{
  *  typeKey:string,
  *  materialKey?:string,         // optional; for naming only (no stats impact)
- *  qualityKey?:'normal'|'magic'|'rare',
+ *  qualityKey?:'basic'|'refined'|'superior',
  *  level?:number                // placeholder; no scaling applied yet
  * }} GenArgs */
 
@@ -21,13 +21,13 @@ import { MATERIALS_STUB } from './data/materials.stub.js';
  * }} WeaponItem */
 
 /** Compose final item. Minimal quality/affix support. */
-export function generateWeapon({ typeKey, materialKey, qualityKey = 'normal' }/** @type {GenArgs} */){
+export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic' }/** @type {GenArgs} */){
   const type = WEAPON_TYPES[typeKey];
   if (!type) throw new Error(`Unknown weapon type: ${typeKey}`);
 
   const material = materialKey ? MATERIALS_STUB[materialKey] : undefined;
 
-  const qualityMult = { normal: 1, magic: 1.1, rare: 1.25 }[qualityKey] || 1;
+  const qualityMult = { basic: 1, refined: 1.1, superior: 1.25 }[qualityKey] || 1;
 
   const abilityKeys = [];
   if (type.signatureAbilityKey) abilityKeys.push(type.signatureAbilityKey);


### PR DESCRIPTION
## Summary
- Rename `normal/magic/rare` qualities to `basic/refined/superior`
- Update generation logic, loot tables, and UI star display for new tiers
- Keep drop odds at 80/15/5 for basic/refined/superior

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI changes blocked until validation passes)*

------
https://chatgpt.com/codex/tasks/task_e_68b53dea87688326bb06343a4c8d91fe