### PR TITLE
feat: add craftable talismans with utility bonuses

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -258,6 +258,9 @@ way-of-ascension/
 │   │   │   └── ui/
 │   │   │       ├── physiqueDisplay.js
 │   │   │       └── trainingGame.js
+│   │   ├── talismans/
+│   │   │   └── data/
+│   │   │       └── talismans.js
 │   │   ├── gearGeneration/
 │   │   │   ├── data/
 │   │   │   │   ├── _balance.contract.js
@@ -955,13 +958,16 @@ Paths added:
 - `src/features/mind/selectors.js` – Accessors for current mind stats and progress.
 - `src/features/mind/index.js` – Bundles mind exports and event listeners.
 - `src/features/mind/data/manuals.js` – Manual definitions with requirements, timers and max levels.
-- `src/features/mind/data/talismans.js` – Talisman definitions and their bonuses.
+- `src/features/mind/data/talismans.js` – Crafting recipes for talismans.
 - `src/features/mind/data/_balance.contract.js` – Balance snapshot for mind-related data.
 - `src/features/mind/ui/mindMainTab.js` – Renders summary view for the Mind feature.
 - `src/features/mind/ui/mindPuzzlesTab.js` – Displays puzzle progress and multiplier info.
 - `src/features/mind/ui/mindReadingTab.js` – Lists manuals and controls reading actions.
 - `src/features/mind/ui/mindStatsTab.js` – Shows cumulative manual bonuses.
 - `src/features/mind/puzzles/sequenceMemory.js` – Implements the sequence memory puzzle used for mind training.
+
+### Talismans Feature (`src/features/talismans/`)
+- `src/features/talismans/data/talismans.js` – Definitions for equipable talismans with utility bonuses.
 
 ### Mining Feature (`src/features/mining/`)
 - `src/features/mining/state.js` – Tracks mining level, experience, unlocked resources and yields.

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -660,8 +660,9 @@ function defeatEnemy() {
   });
 
   if (enemy.drops) {
+    const dropMult = 1 + (S.gearBonuses?.dropRateMult || 0);
     Object.entries(enemy.drops).forEach(([item, chance]) => {
-      if (Math.random() < chance) {
+      if (Math.random() < Math.min(1, chance * dropMult)) {
         addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'mat', qty: 1, source: area?.name });
         lootEntries.push([item, 1]);
       }

--- a/src/features/gearGeneration/selectors.js
+++ b/src/features/gearGeneration/selectors.js
@@ -1,5 +1,6 @@
 import { generateGear, generateCultivationGear } from './logic.js';
 import { GEAR_LOOT_TABLES } from '../loot/data/lootTables.gear.js';
+import { S } from '../../shared/state.js';
 
 function pickWeighted(rows) {
   const total = rows.reduce((s, r) => s + (r.weight || 0), 0);
@@ -26,7 +27,8 @@ export function rollGearDropForZone(zoneKey) {
   const rows = GEAR_LOOT_TABLES[zoneKey];
   if (!rows || !rows.length) return null;
   const row = pickWeighted(rows);
-  if (Math.random() > (row.chance ?? 1)) return null;
+  const dropMult = 1 + (S.gearBonuses?.dropRateMult || 0);
+  if (Math.random() > Math.min(1, (row.chance ?? 1) * dropMult)) return null;
   const qualityKey = row.qualityKey || pickQuality();
   let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey });
   if (Math.random() < 0.1) {

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -11,6 +11,7 @@ export function recomputePlayerTotals(player) {
   let foundationMult = 0;
   let breakthroughBonus = 0;
   let qiRegenMult = 0;
+  let dropRateMult = 0;
   const equipped = Object.values(player.equipment || {});
   for (const item of equipped) {
     if (!item) continue;
@@ -27,6 +28,7 @@ export function recomputePlayerTotals(player) {
       foundationMult += item.bonuses.foundationMult || 0;
       breakthroughBonus += item.bonuses.breakthroughBonus || 0;
       qiRegenMult += item.bonuses.qiRegenMult || 0;
+      dropRateMult += item.bonuses.dropRateMult || 0;
     }
   }
   player.stats = player.stats || {};
@@ -49,6 +51,7 @@ export function recomputePlayerTotals(player) {
     foundationMult,
     breakthroughBonus,
     qiRegenMult,
+    dropRateMult,
   };
 }
 

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -142,6 +142,9 @@ function gearDetailsText(item) {
         case 'qiRegenMult':
           label = 'Qi Regen';
           break;
+        case 'dropRateMult':
+          label = 'Drop Rate';
+          break;
       }
       return `${label}: +${(v * 100).toFixed(0)}%`;
     });

--- a/src/features/mind/data/talismans.js
+++ b/src/features/mind/data/talismans.js
@@ -1,16 +1,16 @@
 // src/features/mind/data/talismans.js
 
-export const TALISMANS = {
-  wardPaper: { id: 'wardPaper', name: 'Paper Ward', tier: 1, type: 'armor', xpMult: 1.0, cost: { fiber: 5 } },
-  inkSeal:   { id: 'inkSeal',   name: 'Ink Seal',   tier: 2, type: 'focus',   xpMult: 1.4, cost: { fiber: 10, ink: 3 } },
-  jadeGlyph: { id: 'jadeGlyph', name: 'Jade Glyph', tier: 3, type: 'clarity', xpMult: 1.9, cost: { jade: 1, ink: 5 } },
+export const TALISMAN_RECIPES = {
+  qiPendant: { id: 'qiPendant', name: 'Qi Pendant', tier: 1, xpMult: 1.0, cost: { fiber: 5 } },
+  luckyCharm: { id: 'luckyCharm', name: 'Lucky Charm', tier: 1, xpMult: 1.0, cost: { fiber: 5, herb: 2 } },
+  scholarSeal: { id: 'scholarSeal', name: "Scholar's Seal", tier: 2, xpMult: 1.4, cost: { fiber: 10, ink: 3 } },
 };
 
-export function getTalisman(id) {
-  return TALISMANS[id] || null;
+export function getTalismanRecipe(id) {
+  return TALISMAN_RECIPES[id] || null;
 }
 
-export function listTalismans() {
-  return Object.values(TALISMANS);
+export function listTalismanRecipes() {
+  return Object.values(TALISMAN_RECIPES);
 }
 

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -1,7 +1,9 @@
 // src/features/mind/mutators.js
 
 import { getManual } from './data/manuals.js';
-import { getTalisman } from './data/talismans.js';
+import { getTalismanRecipe } from './data/talismans.js';
+import { getTalisman as getTalismanItem } from '../talismans/data/talismans.js';
+import { addToInventory } from '../inventory/mutators.js';
 import {
   calcFromProficiency,
   calcFromManual,
@@ -52,13 +54,15 @@ export function debugLevelManual(S) {
 }
 
 export function craftTalisman(S, talismanId) {
-  const t = getTalisman(talismanId);
-  if (!t) return false;
+  const recipe = getTalismanRecipe(talismanId);
+  if (!recipe) return false;
   // assume resource checks done elsewhere for now
-  const add = calcFromCraft(t);
+  const add = calcFromCraft(recipe);
   S.mind.fromCrafting += add;
   S.mind.xp += applyPuzzleMultiplier(add, S.mind.multiplier);
   S.mind.level = levelForXp(S.mind.xp);
+  const item = getTalismanItem(talismanId);
+  if (item) addToInventory(item, S);
   return true;
 }
 

--- a/src/features/mind/ui/mindMainTab.js
+++ b/src/features/mind/ui/mindMainTab.js
@@ -2,7 +2,7 @@
 
 import { mindBreakdown } from '../selectors.js';
 import { craftTalisman } from '../mutators.js';
-import { listTalismans } from '../data/talismans.js';
+import { listTalismanRecipes } from '../data/talismans.js';
 import { renderMindReadingTab } from './mindReadingTab.js';
 import { renderMindPuzzlesTab } from './mindPuzzlesTab.js';
 import { renderMindStatsTab } from './mindStatsTab.js';
@@ -73,7 +73,7 @@ export function renderMindMainTab(rootEl, state) {
 
   const select = document.createElement('select');
   select.className = 'btn';
-  for (const t of listTalismans()) {
+  for (const t of listTalismanRecipes()) {
     const opt = document.createElement('option');
     opt.value = t.id;
     opt.textContent = t.name;

--- a/src/features/talismans/data/talismans.js
+++ b/src/features/talismans/data/talismans.js
@@ -1,0 +1,31 @@
+export const TALISMANS = {
+  qiPendant: {
+    key: 'qiPendant',
+    name: 'Qi Pendant',
+    type: 'talisman',
+    bonuses: { qiRegenMult: 0.1 },
+    desc: '+10% Qi regeneration',
+  },
+  luckyCharm: {
+    key: 'luckyCharm',
+    name: 'Lucky Charm',
+    type: 'talisman',
+    bonuses: { dropRateMult: 0.1 },
+    desc: '+10% drop rate',
+  },
+  scholarSeal: {
+    key: 'scholarSeal',
+    name: "Scholar's Seal",
+    type: 'talisman',
+    bonuses: { qiRegenMult: 0.05, dropRateMult: 0.05 },
+    desc: '+5% Qi regen, +5% drop rate',
+  },
+};
+
+export function getTalisman(id) {
+  return TALISMANS[id] || null;
+}
+
+export function listTalismans() {
+  return Object.values(TALISMANS);
+}


### PR DESCRIPTION
## Summary
- define Qi Pendant, Lucky Charm and Scholar's Seal talismans with Qi regen and drop-rate bonuses
- add crafting recipes and inventory integration for equipping talismans
- apply drop-rate gear bonuses to enemy and gear loot rolls

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations and DOM usage warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b5ad6b39888326877834498df6619e