### PR TITLE
feat: add forging activity

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,6 +95,14 @@ Its `state.js` defines `automationState` and an `initialState()` helper that add
 `logic.js` contains pure calculations like `isAnyAutomationEnabled()` for derived checks.
 Mutators flip automation flags while selectors read them, and `migrations.js` exports an array for save upgrades.
 
+### Forging feature
+The **Forging** module lets players imbue gear with elemental power and raise its tier.
+- **State:** `level, exp, expMax, current` (active job)
+- **Mutators:** `startForging`, `advanceForging`
+- **Logic:** `getForgingTime` computes tier duration with level-based reduction.
+- **UI:** `ui/forgingDisplay.js` updates forging panel and sidebar.
+- **Interactions:** Consumes `wood`, `cores`, and Qi; locks other activities while active.
+
 ## Legacy `src/game` modules
 
 The original `src/game` folder has largely been superseded.  With the root state and helpers moved into `src/shared/`, this directory now primarily houses `GameController.js` as a bridge for the legacy world.  Any remaining legacy systems will continue to be migrated into `src/features` until the folder can be retired entirely.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -249,6 +249,13 @@ way-of-ascension/
 │   │   │   ├── state.js
 │   │   │   └── ui/
 │   │   │       └── miningDisplay.js
+│   │   ├── forging/
+│   │   │   ├── logic.js
+│   │   │   ├── mutators.js
+│   │   │   ├── selectors.js
+│   │   │   ├── state.js
+│   │   │   └── ui/
+│   │   │       └── forgingDisplay.js
 │   │   ├── physique/
 │   │   │   ├── logic.js
 │   │   │   ├── migrations.js
@@ -331,6 +338,7 @@ way-of-ascension/
 ├── src/features/combat/index.js
 ├── src/features/karma/index.js
 ├── src/features/mining/index.js
+├── src/features/forging/index.js
 ├── src/features/physique/index.js
 └── style.css
 ```
@@ -976,6 +984,14 @@ Paths added:
 - `src/features/mining/selectors.js` – Provides accessors for mining state and derived rates.
 - `src/features/mining/ui/miningDisplay.js` – Updates mining activity and sidebar displays.
 
+
+
+### Forging Feature (`src/features/forging/`)
+- `src/features/forging/state.js` – Tracks forging level, experience, and current forging job.
+- `src/features/forging/logic.js` – Calculates tier times, costs, and applies forging results.
+- `src/features/forging/mutators.js` – Starts forging jobs and advances progress each tick.
+- `src/features/forging/selectors.js` – Helpers to read forging state.
+- `src/features/forging/ui/forgingDisplay.js` – Renders forging panel and sidebar info.
 
 ### Physique Feature (`src/features/physique/`)
 - `src/features/physique/state.js` – Tracks physique training progress and stamina.

--- a/index.html
+++ b/index.html
@@ -443,6 +443,30 @@
         </div>
       </section>
 
+      <section id="activity-forging" class="activity-content tab-content" style="display:none;">
+        <h2>⚒️ Forging</h2>
+        <div class="cards">
+          <div class="card">
+            <h4>Forging</h4>
+            <div class="stat"><span>Level</span><span id="forgingLevel">1</span></div>
+            <div class="stat"><span>Experience</span><span id="forgingExp">0</span> / <span id="forgingExpMax">100</span></div>
+            <div class="progress-bar"><div class="progress-fill" id="forgingProgressFill"></div></div>
+            <div class="stat"><span>Status</span><span id="forgingStatus">Idle</span></div>
+            <div class="stat">
+              <span>Item</span>
+              <select id="forgeItemSelect"></select>
+            </div>
+            <div class="stat">
+              <span>Element</span>
+              <select id="forgeElementSelect">
+                <option value="wood">Wood</option>
+              </select>
+            </div>
+            <button class="btn primary" id="startForgingBtn">Start Forging</button>
+          </div>
+        </div>
+      </section>
+
       <section id="activity-adventure" class="activity-content" style="display:none;">
         <h2>🗺️ Adventure</h2>
         <div class="adventure-layout"> <!-- MAP-UI-UPDATE -->

--- a/src/features/activity/state.js
+++ b/src/features/activity/state.js
@@ -9,6 +9,7 @@ export function ensureActivities(root) {
       cooking: false,
       alchemy: false,
       sect: false,
+      forging: false,
     };
   }
 }

--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -113,6 +113,7 @@ export function updateCurrentTaskDisplay(root) {
     cultivation: 'Cultivating',
     physique: 'Physique Training',
     mining: 'Mining',
+    forging: 'Forging',
     adventure: 'Adventuring',
     cooking: 'Cooking',
     alchemy: 'Brewing'

--- a/src/features/forging/index.js
+++ b/src/features/forging/index.js
@@ -1,0 +1,6 @@
+import { forgingState } from './state.js';
+
+export const ForgingFeature = {
+  key: 'forging',
+  initialState: () => ({ ...forgingState, _v: 0 }),
+};

--- a/src/features/forging/logic.js
+++ b/src/features/forging/logic.js
@@ -1,0 +1,56 @@
+import { S } from '../../shared/state.js';
+import { log } from '../../shared/utils/dom.js';
+
+export function getForgingTime(tier, state = S) {
+  const baseMinutes = tier === 0 ? 1 : Math.pow(3, tier + 1);
+  const level = state.forging?.level || 1;
+  const reduction = Math.pow(0.95, Math.max(0, level - 1));
+  return baseMinutes * 60 * reduction; // seconds
+}
+
+export function startForging(itemId, element, state = S) {
+  if (!state.forging) return;
+  const item = state.inventory?.find(it => it.id === itemId);
+  if (!item) { log?.('Item not found', 'bad'); return; }
+  const tier = item.tier || 0;
+  const woodCost = (tier + 1) * 10;
+  const coreCost = (tier + 1) * 5;
+  const qiCost = (tier + 1) * 10;
+  if ((state.wood || 0) < woodCost || (state.cores || 0) < coreCost || (state.qi || 0) < qiCost) {
+    log?.('Not enough resources', 'bad');
+    return;
+  }
+  state.wood -= woodCost;
+  state.cores -= coreCost;
+  state.qi -= qiCost;
+  state.forging.current = {
+    itemId,
+    element,
+    targetTier: tier + 1,
+    time: getForgingTime(tier, state),
+  };
+  log?.(`Started forging ${item.name || item.id} (${element}) to tier ${tier + 1}`, 'good');
+}
+
+export function advanceForging(state = S) {
+  if (!state.activities?.forging || !state.forging?.current) return;
+  const job = state.forging.current;
+  job.time -= 1;
+  if (job.time <= 0) {
+    const item = state.inventory?.find(it => it.id === job.itemId);
+    if (item) {
+      item.element = job.element;
+      item.tier = job.targetTier;
+      log?.(`Finished forging ${item.name || item.id} to tier ${item.tier}`, 'good');
+    }
+    state.forging.exp += 10;
+    while (state.forging.exp >= state.forging.expMax) {
+      state.forging.exp -= state.forging.expMax;
+      state.forging.level += 1;
+      state.forging.expMax = Math.floor(state.forging.expMax * 1.2);
+      log?.(`Forging level up! Level ${state.forging.level}`, 'good');
+    }
+    state.forging.current = null;
+    if (state.activities) state.activities.forging = false;
+  }
+}

--- a/src/features/forging/mutators.js
+++ b/src/features/forging/mutators.js
@@ -1,0 +1,10 @@
+import { S } from '../../shared/state.js';
+import { startForging as logicStart, advanceForging as logicAdvance } from './logic.js';
+
+export function startForging(itemId, element, state = S) {
+  logicStart(itemId, element, state);
+}
+
+export function advanceForging(state = S) {
+  logicAdvance(state);
+}

--- a/src/features/forging/selectors.js
+++ b/src/features/forging/selectors.js
@@ -1,0 +1,5 @@
+import { S } from '../../shared/state.js';
+
+export function getForgingState(state = S) {
+  return state.forging || { level: 1, exp: 0, expMax: 100, current: null };
+}

--- a/src/features/forging/state.js
+++ b/src/features/forging/state.js
@@ -1,0 +1,6 @@
+export const forgingState = {
+  level: 1,
+  exp: 0,
+  expMax: 100,
+  current: null,
+};

--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -1,0 +1,71 @@
+import { S } from '../../../shared/state.js';
+import { setText } from '../../../shared/utils/dom.js';
+import { on } from '../../../shared/events.js';
+import { startForging } from '../mutators.js';
+
+function updateForgingActivity(state = S) {
+  if (!state.forging) return;
+  setText('forgingLevel', state.forging.level);
+  setText('forgingExp', Math.floor(state.forging.exp));
+  setText('forgingExpMax', state.forging.expMax);
+  const fill = document.getElementById('forgingProgressFill');
+  if (fill) {
+    const pct = (state.forging.exp / state.forging.expMax) * 100;
+    fill.style.width = pct + '%';
+  }
+  const status = document.getElementById('forgingStatus');
+  if (status) {
+    if (state.activities.forging && state.forging.current) {
+      status.textContent = `Forging... ${Math.ceil(state.forging.current.time)}s`; }
+    else status.textContent = 'Idle';
+  }
+  const itemSel = document.getElementById('forgeItemSelect');
+  if (itemSel) {
+    const prev = itemSel.value;
+    itemSel.innerHTML = '';
+    state.inventory?.filter(it => it.type === 'weapon' || it.type === 'gear')
+      .forEach(it => {
+        const opt = document.createElement('option');
+        opt.value = it.id;
+        opt.textContent = it.name || it.id;
+        itemSel.appendChild(opt);
+      });
+    if (prev) itemSel.value = prev;
+  }
+  const btn = document.getElementById('startForgingBtn');
+  if (btn) {
+    if (state.activities.forging) {
+      btn.textContent = '🛑 Stop Forging';
+      btn.onclick = () => { state.forging.current = null; window.stopActivity('forging'); };
+    } else {
+      btn.textContent = 'Start Forging';
+      btn.onclick = () => {
+        const itemId = document.getElementById('forgeItemSelect')?.value;
+        const element = document.getElementById('forgeElementSelect')?.value;
+        if (!itemId || !element) return;
+        window.startActivity('forging');
+        startForging(itemId, element, state);
+      };
+    }
+  }
+}
+
+function updateForgingSidebar(state = S) {
+  if (!state.forging) return;
+  setText('forgingLevelSidebar', `Level ${state.forging.level}`);
+  const fill = document.getElementById('forgingProgressFillSidebar');
+  if (fill) {
+    const pct = (state.forging.exp / state.forging.expMax) * 100;
+    fill.style.width = pct + '%';
+    setText('forgingProgressTextSidebar', pct.toFixed(0) + '%');
+  }
+}
+
+export function mountForgingUI(state = S) {
+  on('RENDER', () => {
+    updateForgingActivity(state);
+    updateForgingSidebar(state);
+  });
+  updateForgingActivity(state);
+  updateForgingSidebar(state);
+}

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -11,6 +11,7 @@ import { mountMiningUI } from "./mining/ui/miningDisplay.js";
 import { mountPhysiqueUI } from "./physique/ui/physiqueDisplay.js";
 import { mountMindReadingUI } from "./mind/ui/mindReadingTab.js";
 import { mountAstralTreeUI } from "./progression/ui/astralTree.js";
+import { mountForgingUI } from "./forging/ui/forgingDisplay.js";
 
 
 // Example placeholder for later:
@@ -23,6 +24,7 @@ export function mountAllFeatureUIs(state) {
   mountAlchemyUI(state);
   mountCookingUI(state);
   mountMiningUI(state);
+  mountForgingUI(state);
   mountPhysiqueUI(state);
   mountLawDisplay(state);
   mountMindReadingUI(state);

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -6,6 +6,7 @@ import { recalculateBuildingBonuses } from '../features/sect/mutators.js';
 import { karmaState } from '../features/karma/state.js';
 import { miningState } from '../features/mining/state.js';
 import { physiqueState } from '../features/physique/state.js';
+import { forgingState } from '../features/forging/state.js';
 
 export function loadSave(){
   try{
@@ -80,11 +81,13 @@ export const defaultState = () => {
     mining: false,
     adventure: false,
     cooking: false,
-    alchemy: false
+    alchemy: false,
+    forging: false
   },
   // Activity data containers
   physique: structuredClone(physiqueState),
   mining: structuredClone(miningState),
+  forging: structuredClone(forgingState),
   cooking: {
     level: 1,
     exp: 0,

--- a/src/ui/sidebar.js
+++ b/src/ui/sidebar.js
@@ -34,6 +34,17 @@ export function renderSidebarActivities() {
       cost: {}
     },
     {
+      id: 'forging',
+      label: 'Forging',
+      icon: '<iconify-icon icon="mdi:anvil" class="ui-icon" width="20"></iconify-icon>',
+      group: 'leveling',
+      levelId: 'forgingLevelSidebar',
+      initialLevel: 'Level 1',
+      progressFillId: 'forgingProgressFillSidebar',
+      progressTextId: 'forgingProgressTextSidebar',
+      cost: {},
+    },
+    {
       id: 'cooking',
       label: 'Cooking',
       icon: '<iconify-icon icon="ep:food" class="ui-icon" width="20"></iconify-icon>',

--- a/ui/index.js
+++ b/ui/index.js
@@ -50,6 +50,7 @@ import { tickAbilityCooldowns } from '../src/features/ability/mutators.js';
 import { setupAbilityUI } from '../src/features/ability/ui.js';
 import { recomputePlayerTotals } from '../src/features/inventory/logic.js';
 import { advanceMining } from '../src/features/mining/logic.js';
+import { advanceForging } from '../src/features/forging/logic.js';
 import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
@@ -449,6 +450,7 @@ function tick(){
   
   // Passive mining progression
   advanceMining(S);
+  advanceForging(S);
   
   // Physique training progression
   const sessionEnd = tickPhysiqueTraining(S);


### PR DESCRIPTION
## Summary
- add forging feature with time-based tiering and resource costs
- wire forging into activity system and sidebar
- document forging structure and architecture

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations and DOM usage)


------
https://chatgpt.com/codex/tasks/task_e_68b5b13c120c8326b441f6cc308c2141