### PR TITLE
Include astral tree Qi regen bonus

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -63,7 +63,8 @@ export function qiRegenPerSec(state = progressionState){
   const lawBonuses = getLawBonuses(state);
   const building = getBuildingBonuses(state).qiRegenMult || 0;
   const gear = state.gearBonuses?.qiRegenMult || 0;
-  return (REALMS[state.realm.tier].baseRegen + karmaQiRegenBonus(state)) * (1 + state.qiRegenMult + building + gear) * lawBonuses.qiRegen;
+  const astral = 1 + (state.astralTreeBonuses?.qiRegenPct || 0) / 100;
+  return (REALMS[state.realm.tier].baseRegen + karmaQiRegenBonus(state)) * (1 + state.qiRegenMult + building + gear) * lawBonuses.qiRegen * astral;
 }
 
 export function fCap(state = progressionState){

--- a/src/features/progression/ui/qiDisplay.js
+++ b/src/features/progression/ui/qiDisplay.js
@@ -1,15 +1,23 @@
 import { S } from '../../../shared/state.js';
-import { qCap, qiRegenPerSec, fCap } from '../selectors.js';
+import { qCap, qiRegenPerSec, fCap, foundationGainPerSec } from '../selectors.js';
+// updateActivityCultivation also updates qi regen display, but that function
+// isn't invoked every tick. Include foundation gain selector to keep the
+// cultivation tab's rate display in sync during regular UI refreshes.
 import { setText, setFill } from '../../../shared/utils/dom.js';
 import { fmt } from '../../../shared/utils/number.js';
 import { updateQiOrbEffect } from './qiOrb.js';
 
 export function updateQiAndFoundation(state = S) {
+  const qiRegen = qiRegenPerSec(state);
+  const foundationRate = foundationGainPerSec(state);
   setText('qiVal', fmt(state.qi));
   setText('qiCap', fmt(qCap(state)));
   setText('qiValL', fmt(state.qi));
   setText('qiCapL', fmt(qCap(state)));
-  setText('qiRegen', qiRegenPerSec(state).toFixed(1));
+  setText('qiRegen', qiRegen.toFixed(1));
+  // Keep cultivation activity display updated even when activity UI isn't refreshed
+  setText('qiRegenActivity', qiRegen.toFixed(1));
+  setText('foundationRate', foundationRate.toFixed(1));
   setFill('qiFill', state.qi / qCap(state));
   setFill('qiFill2', state.qi / qCap(state));
   setText('qiPct', Math.floor(100 * state.qi / qCap(state)) + '%');

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -66,9 +66,10 @@ export function updateActivityCultivation() {
   }
   
   // Update qi display below silhouette
+  const qiRegen = qiRegenPerSec(S);
   setText('qiValSilhouette', Math.floor(S.qi));
   setText('qiCapSilhouette', qCap(S));
-  setText('qiRegenActivity', qiRegenPerSec(S).toFixed(1));
+  setText('qiRegenActivity', qiRegen.toFixed(1));
   setText('foundationRate', foundationGainPerSec(S).toFixed(1));
   setText('astralInsightMini', `Insight: ${Math.round(S.astralPoints || 0)}`);
   setText('btChanceActivity', (breakthroughChance(S) * 100).toFixed(1) + '%');


### PR DESCRIPTION
## Summary
- Factor astral tree Qi regeneration bonus into `qiRegenPerSec`
- Use calculated Qi regen in progression displays
- Refresh cultivation tab's regen and foundation rate each tick

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68b5b1fe73bc8326a2aee206a4ed36f8