### PR TITLE
Include astral tree bonuses in Qi cap calculation

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -52,11 +52,12 @@ export function getLawBonuses(state = progressionState){
 
 export function qCap(state = progressionState){
   const realm = REALMS[state.realm.tier];
-  const baseQi = realm.cap;
+  const baseQi = realm.cap + (state.astralTreeBonuses?.maxQi || 0);
   const stageMultiplier = 1 + (state.realm.stage - 1) * 0.12;
   const lawBonuses = getLawBonuses(state);
   const building = getBuildingBonuses(state).qiCapMult || 0;
-  return Math.floor(baseQi * stageMultiplier * (1 + state.qiCapMult + building) * lawBonuses.qiCap);
+  const astralPct = (state.astralTreeBonuses?.maxQiPct || 0) / 100;
+  return Math.floor(baseQi * stageMultiplier * (1 + state.qiCapMult + building) * lawBonuses.qiCap * (1 + astralPct));
 }
 
 export function qiRegenPerSec(state = progressionState){

--- a/src/features/progression/ui/qiDisplay.js
+++ b/src/features/progression/ui/qiDisplay.js
@@ -5,14 +5,15 @@ import { fmt } from '../../../shared/utils/number.js';
 import { updateQiOrbEffect } from './qiOrb.js';
 
 export function updateQiAndFoundation(state = S) {
+  const cap = qCap(state);
   setText('qiVal', fmt(state.qi));
-  setText('qiCap', fmt(qCap(state)));
+  setText('qiCap', fmt(cap));
   setText('qiValL', fmt(state.qi));
-  setText('qiCapL', fmt(qCap(state)));
+  setText('qiCapL', fmt(cap));
   setText('qiRegen', qiRegenPerSec(state).toFixed(1));
-  setFill('qiFill', state.qi / qCap(state));
-  setFill('qiFill2', state.qi / qCap(state));
-  setText('qiPct', Math.floor(100 * state.qi / qCap(state)) + '%');
+  setFill('qiFill', state.qi / cap);
+  setFill('qiFill2', state.qi / cap);
+  setText('qiPct', Math.floor(100 * state.qi / cap) + '%');
 
   setFill('cultivationProgressFill', state.foundation / fCap(state));
   setText('cultivationProgressText', `${fmt(state.foundation)} / ${fmt(fCap(state))}`);

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -67,7 +67,8 @@ export function updateActivityCultivation() {
   
   // Update qi display below silhouette
   setText('qiValSilhouette', Math.floor(S.qi));
-  setText('qiCapSilhouette', qCap(S));
+  const cap = qCap(S);
+  setText('qiCapSilhouette', cap);
   setText('qiRegenActivity', qiRegenPerSec(S).toFixed(1));
   setText('foundationRate', foundationGainPerSec(S).toFixed(1));
   setText('astralInsightMini', `Insight: ${Math.round(S.astralPoints || 0)}`);
@@ -77,7 +78,7 @@ export function updateActivityCultivation() {
   // Update qi fill bar in silhouette
   const qiFillSilhouette = document.getElementById('qiFillSilhouette');
   if (qiFillSilhouette) {
-    qiFillSilhouette.style.width = (S.qi / qCap(S) * 100) + '%';
+    qiFillSilhouette.style.width = (S.qi / cap * 100) + '%';
   }
 
   const startBtn = document.getElementById('startCultivationActivity');


### PR DESCRIPTION
## Summary
- Include astral tree flat and percent max Qi bonuses when computing Qi cap
- Use cached Qi cap value in progression UI displays

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b20bba448326961dad36f129e015