### PR TITLE
Apply cast speed bonuses to ability cast timing and display

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -25,7 +25,11 @@ export function tryCastAbility(abilityKey, state = S) {
   state.abilityCooldowns[abilityKey] = cooldownMs;
   if (!state.actionQueue) state.actionQueue = [];
   const enqueue = () => state.actionQueue.push({ type: 'ABILITY_HIT', abilityKey });
-  let castTimeMs = Math.round(ability.castTimeMs * (1 + (mods.castTimePct || 0) / 100));
+  let castTimeMs = Math.round(
+    ability.castTimeMs *
+      (1 + (mods.castTimePct || 0) / 100) /
+      (1 + (state.astralTreeBonuses?.castSpeedPct || 0) / 100)
+  );
   if (castTimeMs > 0) setTimeout(enqueue, castTimeMs);
   else {
     enqueue();

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -365,18 +365,30 @@ export function updateAbilityBar() {
     if (slot.abilityKey) {
       const def = ABILITIES[slot.abilityKey];
       const dmg = getAbilityDamage(slot.abilityKey, S);
+      const mods = S.abilityMods?.[slot.abilityKey] || {};
+      const castTimeMs = Math.round(
+        def.castTimeMs *
+          (1 + (mods.castTimePct || 0) / 100) /
+          (1 + (S.astralTreeBonuses?.castSpeedPct || 0) / 100)
+      );
       const dmgLine = dmg !== null ? `<div class="ability-damage">${dmg}</div>` : '';
+      const castLine = castTimeMs > 0 ? `<div class="ability-cast-time">${(castTimeMs / 1000).toFixed(2)}s</div>` : '';
       card.innerHTML = `
         <div class="ability-title">
           <div class="ability-name">${def.displayName}</div>
           ${dmgLine}
+          ${castLine}
         </div>
         <div class="ability-icon">${iconMap[def.icon] || def.icon}</div>
         <div class="qi-badge">${def.costQi} Qi</div>
         <div class="keybind">[${i + 1}]</div>
       `;
       const cdSec = (def.cooldownMs || 0) / 1000;
-      card.title = `${def.displayName} — Cost ${def.costQi} Qi, CD ${cdSec}s`;
+      const ctSec = castTimeMs / 1000;
+      let title = `${def.displayName} — Cost ${def.costQi} Qi`;
+      if (castTimeMs > 0) title += `, Cast ${ctSec}s`;
+      title += `, CD ${cdSec}s`;
+      card.title = title;
       if (slot.cooldownRemainingMs > 0) {
         const overlay = document.createElement('div');
         overlay.className = 'cooldown-overlay';

--- a/style.css
+++ b/style.css
@@ -4313,6 +4313,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 .ability-card .ability-name { font-size:8px; text-align:center; }
 .ability-card .ability-title { display:flex; flex-direction:column; align-items:center; }
 .ability-card .ability-damage { font-size:8px; }
+.ability-card .ability-cast-time { font-size:8px; }
 .ability-card .ability-icon { font-size:19.2px; }
 .ability-card .qi-badge { position:absolute; bottom:9.6px; right:1.6px; font-size:8px; background:var(--panel); padding:0.8px 2.4px; border-radius:2.4px; }
 .ability-card .keybind { font-size:8px; }


### PR DESCRIPTION
## Summary
- Factor astral tree cast speed bonus into ability casting delays
- Show ability cast time in bar tooltips and card UI
- Style ability card to display cast-time line

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b20fcc0c8326b369826525fb151b