### PR TITLE
Apply astral tree spell damage bonus

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -78,7 +78,8 @@ function applyAbilityResult(abilityKey, res, state) {
     if (isSpell) {
       const { spellPowerMult } = getStatEffects(state);
       const spellDamage = state.stats?.spellDamage || 0;
-      amount = Math.round(amount * spellPowerMult * (1 + spellDamage / 100));
+      const treeMult = 1 + (state.astralTreeBonuses?.spellDamagePct || 0) / 100;
+      amount = Math.round(amount * spellPowerMult * (1 + spellDamage / 100) * treeMult);
     }
 
     const dealt = processAttack(amount, { target, type, attacker: state, nowMs: Date.now() }, state);

--- a/src/features/ability/selectors.js
+++ b/src/features/ability/selectors.js
@@ -51,7 +51,8 @@ export function getAbilityDamage(abilityKey, state = S) {
   if (ability.tags?.includes('spell')) {
     const { spellPowerMult } = getStatEffects(state);
     const spellDamage = state.stats?.spellDamage || 0;
-    amount = Math.round(amount * spellPowerMult * (1 + spellDamage / 100));
+    const treeMult = 1 + (state.astralTreeBonuses?.spellDamagePct || 0) / 100;
+    amount = Math.round(amount * spellPowerMult * (1 + spellDamage / 100) * treeMult);
   }
   return amount;
 }


### PR DESCRIPTION
## Summary
- Scale spell ability damage with astral tree bonuses
- Apply spell damage bonus when resolving ability results

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`

------
https://chatgpt.com/codex/tasks/task_e_68b5b2133b6c83268992291585ec28b1