### PR TITLE
Add imbuement system for gear and weapons

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -272,6 +272,7 @@ way-of-ascension/
 │   │   │   ├── data/
 │   │   │   │   ├── _balance.contract.js
 │   │   │   │   └── gearBases.js
+│   │   │   ├── imbuement.js
 │   │   │   ├── logic.js
 │   │   │   └── selectors.js
 │   │   └── weaponGeneration/
@@ -1021,6 +1022,7 @@ Paths added:
 ### Gear Generation Feature (`src/features/gearGeneration/`)
 - `src/features/gearGeneration/logic.js` – Generates gear from base definitions and materials.
 - `src/features/gearGeneration/selectors.js` – Rolls zone gear drops using gear loot tables.
+- `src/features/gearGeneration/imbuement.js` – Defines imbuement tiers, multipliers, and zone element themes.
 - `src/features/gearGeneration/data/gearBases.js` – Base armor definitions (body, head, feet).
 - `src/features/gearGeneration/data/_balance.contract.js` – Balance contract placeholder for gear generation.
 

--- a/src/features/forging/logic.js
+++ b/src/features/forging/logic.js
@@ -10,7 +10,7 @@ export function getForgingTime(tier, state = S) {
 
 export function startForging(itemId, element, state = S) {
   if (!state.forging) return;
-  const item = state.inventory?.find(it => it.id === itemId);
+  const item = state.inventory?.find(it => String(it.id) === String(itemId));
   if (!item) { log?.('Item not found', 'bad'); return; }
   const tier = item.tier || 0;
   const woodCost = (tier + 1) * 10;
@@ -24,7 +24,7 @@ export function startForging(itemId, element, state = S) {
   state.cores -= coreCost;
   state.qi -= qiCost;
   state.forging.current = {
-    itemId,
+    itemId: String(itemId),
     element,
     targetTier: tier + 1,
     time: getForgingTime(tier, state),
@@ -37,7 +37,7 @@ export function advanceForging(state = S) {
   const job = state.forging.current;
   job.time -= 1;
   if (job.time <= 0) {
-    const item = state.inventory?.find(it => it.id === job.itemId);
+    const item = state.inventory?.find(it => String(it.id) === job.itemId);
     if (item) {
       item.element = job.element;
       item.tier = job.targetTier;
@@ -53,4 +53,20 @@ export function advanceForging(state = S) {
     state.forging.current = null;
     if (state.activities) state.activities.forging = false;
   }
+}
+
+export function imbueItem(itemId, element, state = S) {
+  const item = state.inventory?.find(it => String(it.id) === String(itemId));
+  if (!item) { log?.('Item not found', 'bad'); return; }
+  const tier = item.imbuement?.tier || 0;
+  const woodCost = (tier + 1) * 20;
+  const coreCost = (tier + 1) * 10;
+  if ((state.wood || 0) < woodCost || (state.cores || 0) < coreCost) {
+    log?.('Not enough resources', 'bad');
+    return;
+  }
+  state.wood -= woodCost;
+  state.cores -= coreCost;
+  item.imbuement = { element, tier: tier + 1 };
+  log?.(`Imbued ${item.name || item.id} with ${element} to tier ${tier + 1}`, 'good');
 }

--- a/src/features/forging/mutators.js
+++ b/src/features/forging/mutators.js
@@ -1,5 +1,5 @@
 import { S } from '../../shared/state.js';
-import { startForging as logicStart, advanceForging as logicAdvance } from './logic.js';
+import { startForging as logicStart, advanceForging as logicAdvance, imbueItem as logicImbue } from './logic.js';
 
 export function startForging(itemId, element, state = S) {
   logicStart(itemId, element, state);
@@ -7,4 +7,8 @@ export function startForging(itemId, element, state = S) {
 
 export function advanceForging(state = S) {
   logicAdvance(state);
+}
+
+export function imbueItem(itemId, element, state = S) {
+  logicImbue(itemId, element, state);
 }

--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -26,7 +26,7 @@ function updateForgingActivity(state = S) {
     state.inventory?.filter(it => it.type === 'weapon' || it.type === 'gear')
       .forEach(it => {
         const opt = document.createElement('option');
-        opt.value = it.id;
+        opt.value = String(it.id);
         opt.textContent = it.name || it.id;
         itemSel.appendChild(opt);
       });

--- a/src/features/gearGeneration/imbuement.js
+++ b/src/features/gearGeneration/imbuement.js
@@ -1,0 +1,31 @@
+import { ZONES as ZONE_IDS } from '../adventure/data/zoneIds.js';
+
+// Tiers and their stat multipliers
+export const IMBUEMENT_TIERS = {
+  0: 1,
+  1: 1.1,
+  2: 1.25,
+  3: 1.45,
+};
+
+export function getImbuementMultiplier(tier = 0) {
+  return IMBUEMENT_TIERS[tier] || 1;
+}
+
+// Zone themed element weights
+export const ELEMENTS = ['metal', 'earth', 'wood', 'water', 'fire'];
+export const ZONE_ELEMENT_WEIGHTS = {
+  [ZONE_IDS.STARTING]: { earth: 3, wood: 3, metal: 1, water: 1, fire: 1 },
+};
+
+export function pickZoneElement(zoneKey, rng = Math.random) {
+  const weights = ZONE_ELEMENT_WEIGHTS[zoneKey] || {};
+  const rows = ELEMENTS.map(el => ({ key: el, weight: weights[el] || 1 }));
+  const total = rows.reduce((s, r) => s + (r.weight || 0), 0);
+  let r = rng() * total;
+  for (const row of rows) {
+    r -= row.weight || 0;
+    if (r <= 0) return row.key;
+  }
+  return rows[0].key;
+}

--- a/src/features/gearGeneration/selectors.js
+++ b/src/features/gearGeneration/selectors.js
@@ -1,6 +1,7 @@
 import { generateGear, generateCultivationGear } from './logic.js';
 import { GEAR_LOOT_TABLES } from '../loot/data/lootTables.gear.js';
 import { S } from '../../shared/state.js';
+import { pickZoneElement } from './imbuement.js';
 
 function pickWeighted(rows) {
   const total = rows.reduce((s, r) => s + (r.weight || 0), 0);
@@ -30,7 +31,9 @@ export function rollGearDropForZone(zoneKey, stage = 1) {
   const dropMult = 1 + (S.gearBonuses?.dropRateMult || 0);
   if (Math.random() > Math.min(1, (row.chance ?? 1) * dropMult)) return null;
   const qualityKey = row.qualityKey || pickQuality();
-  let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey, stage });
+  const imbChance = 0.05 + Math.random() * 0.05;
+  const imbuement = Math.random() < imbChance ? { element: pickZoneElement(zoneKey), tier: 1 } : undefined;
+  let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey, stage, imbuement });
   if (Math.random() < 0.1) {
     gear = generateCultivationGear(gear, zoneKey);
   }

--- a/src/features/weaponGeneration/logic.js
+++ b/src/features/weaponGeneration/logic.js
@@ -1,12 +1,14 @@
 import { WEAPON_TYPES } from './data/weaponTypes.js';
 import { MATERIALS_STUB } from './data/materials.stub.js';
+import { getImbuementMultiplier } from '../gearGeneration/imbuement.js';
 
 /** @typedef {{
  *  typeKey:string,
  *  materialKey?:string,         // optional; for naming only (no stats impact)
  *  qualityKey?:'basic'|'refined'|'superior',
  *  level?:number,               // placeholder; no scaling applied yet
- *  stage?:number                // zone stage for scaling
+ *  stage?:number,               // zone stage for scaling
+ *  imbuement?:{element:string,tier:number}
  * }} GenArgs */
 
 /** @typedef {{
@@ -23,7 +25,7 @@ import { MATERIALS_STUB } from './data/materials.stub.js';
  * }} WeaponItem */
 
 /** Compose final item. Minimal quality/affix support. */
-export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', stage = 1 }/** @type {GenArgs} */){
+export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', stage = 1, imbuement }/** @type {GenArgs} */){
   const type = WEAPON_TYPES[typeKey];
   if (!type) throw new Error(`Unknown weapon type: ${typeKey}`);
 
@@ -31,6 +33,7 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', sta
 
   const qualityMult = { basic: 1, refined: 1.1, superior: 1.25 }[qualityKey] || 1;
   const stageMult = 1.04 ** (stage - 1);
+  const imbMult = getImbuementMultiplier(imbuement?.tier || 0);
 
   const abilityKeys = [];
   if (type.signatureAbilityKey) abilityKeys.push(type.signatureAbilityKey);
@@ -38,8 +41,8 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', sta
   const name = composeName({ typeName: type.displayName, materialName: material?.displayName });
 
   const base = {
-    min: Math.round(type.base.min * qualityMult * stageMult),
-    max: Math.round(type.base.max * qualityMult * stageMult),
+    min: Math.round(type.base.min * qualityMult * stageMult * imbMult),
+    max: Math.round(type.base.max * qualityMult * stageMult * imbMult),
     rate: type.base.rate,
   };
 
@@ -56,9 +59,10 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', sta
     affixes: [],
     stats: type.implicitStats
       ? Object.fromEntries(
-          Object.entries(type.implicitStats).map(([k, v]) => [k, v * stageMult])
+          Object.entries(type.implicitStats).map(([k, v]) => [k, v * stageMult * imbMult])
         )
       : undefined,
+    imbuement: imbuement && { ...imbuement },
   };
 }
 

--- a/src/features/weaponGeneration/selectors.js
+++ b/src/features/weaponGeneration/selectors.js
@@ -2,6 +2,7 @@ import { weaponGenerationState } from './state.js';
 import { WEAPON_LOOT_TABLES } from '../loot/data/lootTables.weapons.js';
 import { generateWeapon } from './logic.js';
 import { rollQualityKey } from '../loot/qualityWeights.js';
+import { pickZoneElement } from '../gearGeneration/imbuement.js';
 
 export function getGeneratedWeapon(state = weaponGenerationState) {
   return state.generated;
@@ -23,10 +24,13 @@ export function rollWeaponDropForZone(zoneKey, stage = 1){
 
   const row = pickWeighted(rows);
   const qualityKey = row.qualityKey || rollQualityKey(row.qualityWeights);
+  const imbChance = 0.05 + Math.random() * 0.05;
+  const imbuement = Math.random() < imbChance ? { element: pickZoneElement(zoneKey), tier: 1 } : undefined;
   return generateWeapon({
     typeKey: row.typeKey,
     materialKey: row.materialKey,
     qualityKey,
     stage,
+    imbuement,
   });
 }


### PR DESCRIPTION
## Summary
- add shared imbuement module with tiers, multipliers, and zone element weights
- apply imbuement multipliers in gear and weapon generation
- allow forging to imbue items and selectors to roll pre-imbued loot
- normalize item IDs in forging so dropdown selections match inventory items

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations and DOM usage)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b8af21508326ac5fa09c7f0fee8e