### PR TITLE
Display imbuement tier for gear and weapons

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -109,7 +109,19 @@ function weaponDetailsText(item) {
   const reqs = w.reqs ? `Realm ${w.reqs.realmMin}, Proficiency ${w.reqs.proficiencyMin}` : 'None';
   const quality = w.quality ?? 'basic';
   const affixes = w.affixes && w.affixes.length ? w.affixes.join(', ') : 'None';
-  return `${w.displayName || w.name}\nQuality: ${quality}\nAffixes: ${affixes}\nBase: ${base}\nScales: ${scales}\nTags: ${(w.tags || []).join(', ')}\nReqs: ${reqs}`;
+  const imbLine = item.imbuement
+    ? `Imbue: ${item.imbuement.element} Tier ${item.imbuement.tier}`
+    : 'Imbue: None';
+  return [
+    w.displayName || w.name,
+    imbLine,
+    `Quality: ${quality}`,
+    `Affixes: ${affixes}`,
+    `Base: ${base}`,
+    `Scales: ${scales}`,
+    `Tags: ${(w.tags || []).join(', ')}`,
+    `Reqs: ${reqs}`,
+  ].join('\n');
 }
 
 function gearDetailsText(item) {
@@ -117,6 +129,8 @@ function gearDetailsText(item) {
   if (item.quality) lines.push(`Quality: ${item.quality}`);
   if (item.guardType) lines.push(`Guard: ${item.guardType}`);
   if (item.element) lines.push(`Element: ${item.element}`);
+  if (item.imbuement) lines.push(`Imbue: ${item.imbuement.element} Tier ${item.imbuement.tier}`);
+  else lines.push('Imbue: None');
   if (item.protection) {
     const prot = [];
     if (item.protection.armor) prot.push(`Armor ${item.protection.armor}`);


### PR DESCRIPTION
## Summary
- Show imbuement tier for weapons in equipment details
- Include imbuement tier line for all gear items

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: AI changes blocked until validation passes)

------
https://chatgpt.com/codex/tasks/task_e_68b5c11eeea083269810ab9f140f0858