### PR TITLE
feat: show item details via tooltip

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -153,15 +153,58 @@ function gearDetailsText(item) {
   return lines.join('\n');
 }
 
-function showDetails(item) {
+let currentTooltip = null;
+let currentTooltipListener = null;
+
+function hideItemTooltip() {
+  if (currentTooltip) {
+    currentTooltip.remove();
+    currentTooltip = null;
+  }
+  if (currentTooltipListener) {
+    document.removeEventListener('pointerdown', currentTooltipListener);
+    currentTooltipListener = null;
+  }
+}
+
+function showItemTooltip(anchor, text) {
+  hideItemTooltip();
+  const tooltip = document.createElement('div');
+  tooltip.className = 'astral-tooltip';
+  tooltip.innerHTML = text.replace(/\n/g, '<br>');
+  document.body.appendChild(tooltip);
+  const rect = anchor.getBoundingClientRect();
+  const tRect = tooltip.getBoundingClientRect();
+  let left = rect.right + 8;
+  let top = rect.top + rect.height / 2 - tRect.height / 2;
+  if (left + tRect.width > window.innerWidth - 8) left = rect.left - tRect.width - 8;
+  if (left < 8) left = 8;
+  if (top < 8) top = 8;
+  if (top + tRect.height > window.innerHeight - 8) top = window.innerHeight - tRect.height - 8;
+  tooltip.style.left = `${left}px`;
+  tooltip.style.top = `${top}px`;
+  currentTooltip = tooltip;
+  function onDocPointerDown(e) {
+    if (!tooltip.contains(e.target)) {
+      hideItemTooltip();
+    }
+  }
+  document.addEventListener('pointerdown', onDocPointerDown);
+  currentTooltipListener = onDocPointerDown;
+}
+
+function showDetails(item, evt) {
+  let text = '';
   if (item.type === 'weapon') {
-    const text = weaponDetailsText(item);
-    if (text) window.alert(text);
+    text = weaponDetailsText(item);
   } else if (['armor', 'foot', 'ring', 'talisman'].includes(item.type)) {
-    const text = gearDetailsText(item);
-    if (text) window.alert(text);
+    text = gearDetailsText(item);
   } else {
-    window.alert(item.name || item.key);
+    text = item.name || item.key;
+  }
+  if (text && evt?.target) {
+    evt.stopPropagation();
+    showItemTooltip(evt.target, text);
   }
 }
 
@@ -214,7 +257,7 @@ function createInventoryRow(item) {
     const detailsBtn = document.createElement('button');
     detailsBtn.className = 'btn small';
     detailsBtn.textContent = 'Details';
-    detailsBtn.onclick = () => showDetails(item);
+    detailsBtn.onclick = (e) => showDetails(item, e);
     act.appendChild(detailsBtn);
   }
   row.appendChild(act);
@@ -238,6 +281,7 @@ function canEquipToSlot(item, slot) {
 }
 
 function renderInventory() {
+  hideItemTooltip();
   const list = document.getElementById('inventoryList');
   if (!list) return;
   list.innerHTML = '';


### PR DESCRIPTION
## Summary
- Replace weapon/gear detail alerts with tooltip UI
- Tooltip now centers near source and clamps within viewport
- Tooltips persist until clicking elsewhere and clean up listeners on hide

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68b5c2095e34832687e8d2a964f87f84