### PR TITLE
Display element background for imbued items

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -84,11 +84,8 @@ function renderEquipment() {
     el.querySelector('.slot-name').innerHTML = nameHtml;
     el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory(); };
     el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
-    if (item?.element) {
-      el.style.backgroundColor = ELEMENT_BG_COLORS[item.element] || '';
-    } else {
-      el.style.backgroundColor = '';
-    }
+    const element = item?.element || item?.imbuement?.element;
+    el.style.backgroundColor = element ? (ELEMENT_BG_COLORS[element] || '') : '';
   });
   const armorEl = document.getElementById('armorVal');
   if (armorEl) armorEl.textContent = S.stats?.armor || 0;
@@ -182,8 +179,9 @@ function showDetails(item) {
 function createInventoryRow(item) {
   const row = document.createElement('div');
   row.className = 'inventory-row';
-  if (item.element) {
-    row.style.backgroundColor = ELEMENT_BG_COLORS[item.element] || '';
+  const element = item.element || item.imbuement?.element;
+  if (element) {
+    row.style.backgroundColor = ELEMENT_BG_COLORS[element] || '';
   }
   const iconKey = item.type === 'weapon' ? WEAPONS[item.key]?.proficiencyKey : null;
   const icon = iconKey ? WEAPON_ICONS[iconKey] : null;


### PR DESCRIPTION
## Summary
- color equipped slots based on item imbuement element when present
- highlight inventory rows for imbued gear and weapons

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b5c7e923a08326a74f01274a628f26