### PR TITLE
feat: introduce ring accessories and boss drops

### DIFF
--- a/src/features/accessories/data/rings.js
+++ b/src/features/accessories/data/rings.js
@@ -1,0 +1,38 @@
+export const RINGS = {
+  ironSignet: {
+    key: 'ironSignet',
+    name: 'Iron Signet',
+    type: 'ring',
+    protection: { armor: 15 },
+    desc: '+15 Armor',
+  },
+  jadeBand: {
+    key: 'jadeBand',
+    name: 'Jade Band',
+    type: 'ring',
+    protection: { dodge: 10 },
+    desc: '+10 Dodge',
+  },
+  scholarRing: {
+    key: 'scholarRing',
+    name: "Scholar's Ring",
+    type: 'ring',
+    offense: { accuracy: 20 },
+    desc: '+20 Accuracy',
+  },
+  spiritBand: {
+    key: 'spiritBand',
+    name: 'Spirit Band',
+    type: 'ring',
+    bonuses: { qiRegenMult: 0.05 },
+    desc: '+5% Qi regeneration',
+  },
+};
+
+export function getRing(key) {
+  return RINGS[key] || null;
+}
+
+export function listRings() {
+  return Object.values(RINGS);
+}

--- a/src/features/accessories/logic.js
+++ b/src/features/accessories/logic.js
@@ -1,0 +1,47 @@
+import { RINGS } from './data/rings.js';
+import { MODIFIERS, MODIFIER_KEYS } from '../gearGeneration/data/modifiers.js';
+
+function rollMinorModifiers() {
+  const count = Math.floor(Math.random() * 3); // 0-2
+  const keys = [...MODIFIER_KEYS];
+  const mods = [];
+  for (let i = 0; i < count && keys.length; i++) {
+    const idx = Math.floor(Math.random() * keys.length);
+    const key = keys.splice(idx, 1)[0];
+    mods.push({ key, ...MODIFIERS[key] });
+  }
+  return mods;
+}
+
+function applyRingModifiers(ring, mods) {
+  for (const mod of mods) {
+    switch (mod.lane) {
+      case 'armor':
+        ring.protection = ring.protection || {};
+        ring.protection.armor = Math.round((ring.protection.armor || 0) + mod.value * 100);
+        break;
+      case 'dodge':
+        ring.protection = ring.protection || {};
+        ring.protection.dodge = Math.round((ring.protection.dodge || 0) + mod.value * 100);
+        break;
+      case 'accuracy':
+        ring.offense = ring.offense || {};
+        ring.offense.accuracy = Math.round((ring.offense.accuracy || 0) + mod.value * 100);
+        break;
+      case 'damage':
+        ring.bonuses = ring.bonuses || {};
+        ring.bonuses.damageMult = (ring.bonuses.damageMult || 0) + mod.value;
+        break;
+    }
+  }
+}
+
+export function generateRing(baseKey) {
+  const base = RINGS[baseKey];
+  if (!base) throw new Error(`Unknown ring: ${baseKey}`);
+  const ring = JSON.parse(JSON.stringify(base));
+  const mods = rollMinorModifiers();
+  applyRingModifiers(ring, mods);
+  ring.modifiers = mods.map(m => m.key);
+  return ring;
+}

--- a/src/features/accessories/selectors.js
+++ b/src/features/accessories/selectors.js
@@ -1,0 +1,22 @@
+import { generateRing } from './logic.js';
+import { RING_LOOT_TABLES } from '../loot/data/lootTables.rings.js';
+import { S } from '../../shared/state.js';
+
+function pickWeighted(rows) {
+  const total = rows.reduce((s, r) => s + (r.weight || 0), 0);
+  let r = Math.random() * total;
+  for (const row of rows) {
+    r -= row.weight || 0;
+    if (r <= 0) return row;
+  }
+  return rows[rows.length - 1];
+}
+
+export function rollRingDropForZone(zoneKey) {
+  const rows = RING_LOOT_TABLES[zoneKey];
+  if (!rows || !rows.length) return null;
+  const row = pickWeighted(rows);
+  const dropMult = 1 + (S.gearBonuses?.dropRateMult || 0);
+  if (Math.random() > Math.min(1, (row.chance ?? 1) * dropMult)) return null;
+  return generateRing(row.key);
+}

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -69,6 +69,7 @@ export function canEquip(item, slot = null, state = {}) {
     case 'foot':
       return { slot: 'foot' };
     case 'ring':
+      // rings occupy two dedicated slots
       if (slot === 'ring1' || slot === 'ring2') return { slot };
       if (!state.equipment?.ring1) return { slot: 'ring1' };
       if (!state.equipment?.ring2) return { slot: 'ring2' };

--- a/src/features/loot/data/lootTables.rings.js
+++ b/src/features/loot/data/lootTables.rings.js
@@ -1,0 +1,10 @@
+import { ZONES } from '../../adventure/data/zoneIds.js';
+
+export const RING_LOOT_TABLES = {
+  [ZONES.STARTING]: [
+    { key: 'ironSignet', weight: 25, chance: 0.5 },
+    { key: 'jadeBand', weight: 25, chance: 0.5 },
+    { key: 'scholarRing', weight: 25, chance: 0.5 },
+    { key: 'spiritBand', weight: 25, chance: 0.5 },
+  ],
+};

--- a/src/features/loot/logic.js
+++ b/src/features/loot/logic.js
@@ -2,6 +2,7 @@
 import { LOOT_TABLES } from './data/lootTables.js';
 import { rollWeaponDropForZone } from '../weaponGeneration/selectors.js';
 import { rollGearDropForZone } from '../gearGeneration/selectors.js';
+import { rollRingDropForZone } from '../accessories/selectors.js';
 import { addToInventory } from '../inventory/mutators.js';
 import { ZONES } from '../adventure/data/zoneIds.js';
 
@@ -42,8 +43,17 @@ export function onEnemyDefeated(state) {
     state.log.push(`You found: ${gearDrop.name}.`);
   }
 
+  if (state.adventure?.isBossFight) {
+    const ringDrop = rollRingDropForZone(zoneKey);
+    if (ringDrop) {
+      addToInventory(ringDrop, state);
+      state.log = state.log || [];
+      state.log.push(`You found: ${ringDrop.name}.`);
+    }
+  }
+
   // … add other rewards (xp, coins) as you already do
 }
 
-// Re-export weapon drop helper for any callers that previously imported it from this module.
-export { rollWeaponDropForZone, rollGearDropForZone };
+// Re-export drop helpers for any callers that previously imported them from this module.
+export { rollWeaponDropForZone, rollGearDropForZone, rollRingDropForZone };


### PR DESCRIPTION
## Summary
- add ring accessory definitions and generation with minor modifiers
- allow bosses to roll rings from new loot table
- ensure inventory logic recognizes ring slots

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cdee578083268e9e3b6649c412ec