### PR TITLE
feat: show forge inventory and slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -452,17 +452,12 @@
             <div class="stat"><span>Experience</span><span id="forgingExp">0</span> / <span id="forgingExpMax">100</span></div>
             <div class="progress-bar"><div class="progress-fill" id="forgingProgressFill"></div></div>
             <div class="stat"><span>Status</span><span id="forgingStatus">Idle</span></div>
-            <div class="stat">
-              <span>Item</span>
-              <select id="forgeItemSelect"></select>
-            </div>
-            <div class="stat">
-              <span>Element</span>
-              <select id="forgeElementSelect">
-                <option value="wood">Wood</option>
-              </select>
-            </div>
-            <button class="btn primary" id="startForgingBtn">Start Forging</button>
+            <div id="forgeSlot" class="forge-slot">Select an item</div>
+            <div id="forgeOptions" class="forge-options"></div>
+          </div>
+          <div class="card">
+            <h4>Inventory</h4>
+            <div id="forgeInventory" class="forge-inventory"></div>
           </div>
         </div>
       </section>

--- a/src/features/forging/state.js
+++ b/src/features/forging/state.js
@@ -3,4 +3,5 @@ export const forgingState = {
   exp: 0,
   expMax: 100,
   current: null,
+  slot: null,
 };

--- a/style.css
+++ b/style.css
@@ -4682,3 +4682,32 @@ html.reduce-motion .log-sheet{transition:none;}
   filter:brightness(1.3);
 }
 
+/* Forging UI */
+.forge-inventory{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+
+.forge-item-card{
+  border:1px solid #ccc;
+  padding:4px 8px;
+  border-radius:4px;
+  cursor:pointer;
+}
+
+.forge-item-card.selected{
+  border-color:#3b82f6;
+}
+
+.forge-slot{
+  border:1px dashed #666;
+  padding:8px;
+  margin:8px 0;
+  min-height:40px;
+}
+
+.forge-options button{
+  margin-right:4px;
+}
+


### PR DESCRIPTION
## Summary
- display gear and weapons as cards in forge tab
- select items into a forge slot with Imbue or Feed material options
- add basic styling for forge inventory and slots

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cfe60b3c83269b2ac96a5aa55adf