### PR TITLE
feat: expand loot drop logic

### DIFF
--- a/src/features/gearGeneration/data/gearBases.js
+++ b/src/features/gearGeneration/data/gearBases.js
@@ -70,4 +70,13 @@ export const GEAR_BASES = {
     guardType: 'qiShield',
     baseProtection: { qiShield: 20 },
   },
+
+  // Ring gear (boss drops)
+  iron_ring: {
+    key: 'iron_ring',
+    displayName: 'Iron Ring',
+    slot: 'ring',
+    guardType: 'none',
+    baseProtection: {},
+  },
 };

--- a/src/features/gearGeneration/logic.js
+++ b/src/features/gearGeneration/logic.js
@@ -32,9 +32,11 @@ export function generateGear({ baseKey, materialKey, qualityKey = 'basic', stage
   const mods = rollModifiers(rarity);
   applyGearModifiers({ protection, offense }, mods);
 
+  const type = base.slot === 'ring' ? 'ring' : 'armor';
+
   return {
     key: base.key,
-    type: 'armor',
+    type,
     slot: base.slot,
     name,
     guardType: base.guardType,

--- a/src/features/gearGeneration/selectors.js
+++ b/src/features/gearGeneration/selectors.js
@@ -24,7 +24,7 @@ function pickQuality(weights = { basic: 80, refined: 15, superior: 5 }) {
   return entries[0][0];
 }
 
-export function rollGearDropForZone(zoneKey, stage = 1) {
+export function rollGearDropForZone(zoneKey, stage = 1, rarity = 'normal') {
   const rows = GEAR_LOOT_TABLES[zoneKey];
   if (!rows || !rows.length) return null;
   const row = pickWeighted(rows);
@@ -33,7 +33,7 @@ export function rollGearDropForZone(zoneKey, stage = 1) {
   const qualityKey = row.qualityKey || pickQuality();
   const imbChance = 0.05 + Math.random() * 0.05;
   const imbuement = Math.random() < imbChance ? { element: pickZoneElement(zoneKey), tier: 1 } : undefined;
-  let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey, stage, imbuement });
+  let gear = generateGear({ baseKey: row.baseKey, materialKey: row.materialKey, qualityKey, stage, imbuement, rarity });
   if (Math.random() < 0.1) {
     gear = generateCultivationGear(gear, zoneKey);
   }

--- a/src/features/loot/logic.js
+++ b/src/features/loot/logic.js
@@ -4,6 +4,8 @@ import { rollWeaponDropForZone } from '../weaponGeneration/selectors.js';
 import { rollGearDropForZone } from '../gearGeneration/selectors.js';
 import { addToInventory } from '../inventory/mutators.js';
 import { ZONES } from '../adventure/data/zoneIds.js';
+import { TALISMANS } from '../talismans/data/talismans.js';
+import { generateGear } from '../gearGeneration/logic.js';
 
 export function toLootTableKey(id = '') {
   return (id || '')
@@ -12,7 +14,7 @@ export function toLootTableKey(id = '') {
 }
 
 export function rollLoot(key, rng = Math.random) {
-  const table = LOOT_TABLES[key];
+  const table = (LOOT_TABLES[key] || []).filter(entry => !TALISMANS[entry.item]);
   if (!table || !table.length) return null;
   const total = table.reduce((sum, e) => sum + (e.weight || 0), 0);
   const roll = rng() * total;
@@ -24,22 +26,37 @@ export function rollLoot(key, rng = Math.random) {
   return null;
 }
 
+function rollDropRarity() {
+  const r = Math.random();
+  if (r < 0.01) return 'rare';
+  if (r < 0.11) return 'magic';
+  return 'normal';
+}
+
 export function onEnemyDefeated(state) {
   const zoneKey = state.world?.zoneKey ?? ZONES.STARTING;
   const zoneStage = (state.world?.stage ?? state.adventure?.currentArea ?? 0) + 1;
+  const isBoss = state.adventure?.isBossFight || state.world?.isBoss;
 
-  const weaponDrop = rollWeaponDropForZone(zoneKey, zoneStage);
+  const weaponDrop = rollWeaponDropForZone(zoneKey, zoneStage, rollDropRarity());
   if (weaponDrop) {
     addToInventory(weaponDrop, state);
     state.log = state.log || [];
     state.log.push(`You found: ${weaponDrop.name}.`);
   }
 
-  const gearDrop = rollGearDropForZone(zoneKey, zoneStage);
+  const gearDrop = rollGearDropForZone(zoneKey, zoneStage, rollDropRarity());
   if (gearDrop) {
     addToInventory(gearDrop, state);
     state.log = state.log || [];
     state.log.push(`You found: ${gearDrop.name}.`);
+  }
+
+  if (isBoss && Math.random() < 0.5) {
+    const ring = generateGear({ baseKey: 'iron_ring', materialKey: 'iron', qualityKey: 'basic', stage: zoneStage, rarity: rollDropRarity() });
+    addToInventory(ring, state);
+    state.log = state.log || [];
+    state.log.push(`You found: ${ring.name}.`);
   }
 
   // … add other rewards (xp, coins) as you already do

--- a/src/features/weaponGeneration/selectors.js
+++ b/src/features/weaponGeneration/selectors.js
@@ -18,7 +18,7 @@ function pickWeighted(rows){
   return rows[rows.length - 1];
 }
 
-export function rollWeaponDropForZone(zoneKey, stage = 1){
+export function rollWeaponDropForZone(zoneKey, stage = 1, rarity = 'normal'){
   const rows = WEAPON_LOOT_TABLES[zoneKey];
   if (!rows || rows.length === 0) return null;
 
@@ -32,5 +32,6 @@ export function rollWeaponDropForZone(zoneKey, stage = 1){
     qualityKey,
     stage,
     imbuement,
+    rarity,
   });
 }


### PR DESCRIPTION
## Summary
- add ring gear base and dynamic type support
- roll rarity for weapon, gear, and ring drops
- boss fights can drop rings and talismans removed from loot tables

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UNDOCUMENTED FILE, UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68b5ce41d2d88326a7ed5b3c14ec0f29