### PR TITLE
Keep gear tooltips visible until outside click

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -202,6 +202,7 @@ function showItemTooltip(anchor, text) {
   tooltip.className = 'astral-tooltip';
   tooltip.innerHTML = text.replace(/\n/g, '<br>');
   document.body.appendChild(tooltip);
+  tooltip.addEventListener('pointerdown', e => e.stopPropagation());
   const rect = anchor.getBoundingClientRect();
   const tRect = tooltip.getBoundingClientRect();
   let left = rect.right + 8;


### PR DESCRIPTION
## Summary
- Prevent gear detail tooltip from dismissing when clicking inside it

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f7a3a390832683723d8d8f2af0ba