### PR TITLE
Keep gear tooltips visible until outside click

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -202,6 +202,10 @@ function showItemTooltip(anchor, text) {
   tooltip.className = 'astral-tooltip';
   tooltip.innerHTML = text.replace(/\n/g, '<br>');
   document.body.appendChild(tooltip);
+  // Prevent clicks inside the tooltip from bubbling and closing it
+  ['pointerdown', 'click'].forEach(evt =>
+    tooltip.addEventListener(evt, e => e.stopPropagation())
+  );
   const rect = anchor.getBoundingClientRect();
   const tRect = tooltip.getBoundingClientRect();
   let left = rect.right + 8;
@@ -218,8 +222,12 @@ function showItemTooltip(anchor, text) {
       hideItemTooltip();
     }
   }
-  document.addEventListener('pointerdown', onDocPointerDown);
-  currentTooltipListener = onDocPointerDown;
+  // Defer adding the outside click listener so the initial click that
+  // triggered the tooltip doesn't immediately close it
+  setTimeout(() => {
+    document.addEventListener('pointerdown', onDocPointerDown);
+    currentTooltipListener = onDocPointerDown;
+  });
 }
 
 function showDetails(item, evt) {
@@ -233,6 +241,7 @@ function showDetails(item, evt) {
   }
   if (text && evt?.target) {
     evt.stopPropagation();
+    evt.preventDefault();
     showItemTooltip(evt.target, text);
   }
 }


### PR DESCRIPTION
## Summary
- Prevent clicks inside gear tooltips from closing them
- Delay outside-click binding so initial click doesn't dismiss tooltip

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f7a3a390832683723d8d8f2af0ba