### PR TITLE
feat: apply astral armor bonuses

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -132,7 +132,12 @@ export function calcArmor(state = progressionState){
   const base = Number(state.armorBase) || 0;
   const temp = Number(state.tempArmor) || 0;
   const karma = Number(karmaArmorBonus(state)) || 0;
-  return Math.floor((base + building + temp + baseArmor + stageBonus + karma) * (lawBonuses.armor || 1));
+  const astral = 1 + (state.astralTreeBonuses?.armorPct || 0) / 100;
+  return Math.floor(
+    (base + building + temp + baseArmor + stageBonus + karma) *
+      (lawBonuses.armor || 1) *
+      astral
+  );
 }
 
 export function getStatEffects(state = progressionState) {

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -1,4 +1,5 @@
 import { S, save } from '../../../shared/state.js';
+import { recomputePlayerTotals } from '../../inventory/logic.js';
 
 const STORAGE_KEY = 'astralTreeAllocated';
 // Starting nodes must match the roots in the astral_tree.json dataset
@@ -581,5 +582,6 @@ function applyEffects(id, manifest) {
     }
   }
   renderAstralTreeTotals();
+  recomputePlayerTotals(S);
 }
 


### PR DESCRIPTION
## Summary
- scale armor by astral tree armor percent bonus
- recompute player totals when astral tree bonuses update

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fbf2ab0c832697917f34a1e1b9e0