### PR TITLE
Apply astral tree cooldown bonus

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -21,7 +21,11 @@ export function tryCastAbility(abilityKey, state = S) {
   if (cd > 0) return false;
   if (state.qi < ability.costQi) return false;
   if (!state.abilityCooldowns) state.abilityCooldowns = {};
-  const cooldownMs = Math.round(ability.cooldownMs * (1 + (mods.cooldownPct || 0) / 100));
+  const cooldownMs = Math.round(
+    ability.cooldownMs *
+      (1 + (mods.cooldownPct || 0) / 100) *
+      (1 + (state.astralTreeBonuses?.cooldownPct || 0) / 100)
+  );
   state.abilityCooldowns[abilityKey] = cooldownMs;
   if (!state.actionQueue) state.actionQueue = [];
   const enqueue = () => state.actionQueue.push({ type: 'ABILITY_HIT', abilityKey });


### PR DESCRIPTION
## Summary
- factor astral tree cooldown bonus into ability cooldown computations

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation, etc.)
- `node -e` snippet verifying tree bonus reduces cooldown from 30000ms to 24000ms

------
https://chatgpt.com/codex/tasks/task_e_68b5fbf583788326abd2e36ca90bafdd