### PR TITLE
Add dev menu button for astral points

### DIFF
--- a/src/ui/dev/devQuickMenu.js
+++ b/src/ui/dev/devQuickMenu.js
@@ -109,6 +109,21 @@ export function mountDevQuickMenu() {
   mindWrap.append(manualBtn);
   panel.appendChild(row("Mind", mindWrap));
 
+  // Astral point helpers
+  const astralWrap = el("div");
+  astralWrap.style.display = "flex";
+  astralWrap.style.gap = "6px";
+  const astralBtn = smallBtn("+100", () => {
+    S.astralPoints = (S.astralPoints || 0) + 100;
+    const v = Math.round(S.astralPoints || 0);
+    const insightEl = document.getElementById('astralInsight');
+    if (insightEl) insightEl.textContent = `Insight: ${v}`;
+    const miniEl = document.getElementById('astralInsightMini');
+    if (miniEl) miniEl.textContent = `Insight: ${v}`;
+  });
+  astralWrap.append(astralBtn);
+  panel.appendChild(row("Astral", astralWrap));
+
   // Auto-mount console using Eruda
   const consoleHdr = el("div", { textContent: "Console" });
   consoleHdr.style.cssText = "margin-top:8px; font:600 12px ui-monospace,monospace; opacity:.9;";


### PR DESCRIPTION
## Summary
- add dev quick menu control to grant 100 astral points for debugging

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fff462e0832694dc8e75321222c3