### PR TITLE
Keep adventure loot tooltips visible

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -4,7 +4,7 @@ import { WEAPON_ICONS } from '../../weaponGeneration/data/weaponIcons.js';
 import { equipItem, unequip, removeFromInventory } from '../mutators.js';
 import { recomputePlayerTotals } from '../logic.js';
 import { ABILITIES } from '../../ability/data/abilities.js';
-import { MODIFIERS } from '../../gearGeneration/data/modifiers.js';
+import { showItemDetails as showDetails, hideItemTooltip } from '../../../shared/utils/itemTooltip.js';
 
 // Consolidated equipment/inventory panel
 let currentFilter = 'all';
@@ -106,136 +106,6 @@ function renderEquipment() {
   if (dodgeEl) dodgeEl.textContent = S.stats?.dodge || 0;
 }
 
-function weaponDetailsText(item) {
-  const w = WEAPONS[item.key] || item;
-  if (!w) return '';
-  const baseRate = w.base ? (w.base.attackRate ?? w.base.rate) : null;
-  const base = w.base ? `${w.base.min}-${w.base.max} (${baseRate}/s)` : 'n/a';
-  const scales = Object.entries(w.scales || {})
-    .map(([k, v]) => `${k} ${(v * 100).toFixed(0)}%`)
-    .join(', ');
-  const reqs = w.reqs ? `Realm ${w.reqs.realmMin}, Proficiency ${w.reqs.proficiencyMin}` : 'None';
-  const quality = w.quality ?? 'basic';
-  const mods = (w.modifiers || []).map(k => MODIFIERS[k]?.desc || k);
-  const modLine = mods.length ? mods.join(', ') : 'None';
-  const imbLine = item.imbuement
-    ? `Imbue: ${item.imbuement.element} Tier ${item.imbuement.tier}`
-    : 'Imbue: None';
-  return [
-    w.displayName || w.name,
-    imbLine,
-    `Quality: ${quality}`,
-    `Modifiers: ${modLine}`,
-    `Rarity: ${w.rarity || 'normal'}`,
-    `Base: ${base}`,
-    `Scales: ${scales}`,
-    `Tags: ${(w.tags || []).join(', ')}`,
-    `Reqs: ${reqs}`,
-  ].join('\n');
-}
-
-function gearDetailsText(item) {
-  const lines = [item.name || item.key];
-  if (item.quality) lines.push(`Quality: ${item.quality}`);
-  if (item.rarity) lines.push(`Rarity: ${item.rarity}`);
-  if (item.guardType) lines.push(`Guard: ${item.guardType}`);
-  if (item.element) lines.push(`Element: ${item.element}`);
-  if (item.imbuement) lines.push(`Imbue: ${item.imbuement.element} Tier ${item.imbuement.tier}`);
-  else lines.push('Imbue: None');
-  if (item.protection) {
-    const prot = [];
-    if (item.protection.armor) prot.push(`Armor ${item.protection.armor}`);
-    if (item.protection.dodge) prot.push(`Dodge ${item.protection.dodge}`);
-    if (item.protection.qiShield) prot.push(`Qi Shield ${item.protection.qiShield}`);
-    if (prot.length) lines.push(`Protection: ${prot.join(', ')}`);
-  }
-  if (item.offense) {
-    const off = [];
-    if (item.offense.accuracy) off.push(`Accuracy ${item.offense.accuracy}`);
-    if (off.length) lines.push(`Offense: ${off.join(', ')}`);
-  }
-  if (item.modifiers && item.modifiers.length) {
-    const modLine = item.modifiers.map(k => MODIFIERS[k]?.desc || k).join(', ');
-    lines.push(`Modifiers: ${modLine}`);
-  }
-  if (item.bonuses) {
-    const bonusLines = Object.entries(item.bonuses).map(([k, v]) => {
-      let label = k;
-      switch (k) {
-        case 'foundationMult':
-          label = 'Foundation';
-          break;
-        case 'breakthroughBonus':
-          label = 'Breakthrough';
-          break;
-        case 'qiRegenMult':
-          label = 'Qi Regen';
-          break;
-        case 'dropRateMult':
-          label = 'Drop Rate';
-          break;
-      }
-      return `${label}: +${(v * 100).toFixed(0)}%`;
-    });
-    lines.push(...bonusLines);
-  }
-  return lines.join('\n');
-}
-
-let currentTooltip = null;
-let currentTooltipListener = null;
-
-function hideItemTooltip() {
-  if (currentTooltip) {
-    currentTooltip.remove();
-    currentTooltip = null;
-  }
-  if (currentTooltipListener) {
-    document.removeEventListener('pointerdown', currentTooltipListener);
-    currentTooltipListener = null;
-  }
-}
-
-function showItemTooltip(anchor, text) {
-  hideItemTooltip();
-  const tooltip = document.createElement('div');
-  tooltip.className = 'astral-tooltip';
-  tooltip.innerHTML = text.replace(/\n/g, '<br>');
-  document.body.appendChild(tooltip);
-  const rect = anchor.getBoundingClientRect();
-  const tRect = tooltip.getBoundingClientRect();
-  let left = rect.right + 8;
-  let top = rect.top + rect.height / 2 - tRect.height / 2;
-  if (left + tRect.width > window.innerWidth - 8) left = rect.left - tRect.width - 8;
-  if (left < 8) left = 8;
-  if (top < 8) top = 8;
-  if (top + tRect.height > window.innerHeight - 8) top = window.innerHeight - tRect.height - 8;
-  tooltip.style.left = `${left}px`;
-  tooltip.style.top = `${top}px`;
-  currentTooltip = tooltip;
-  function onDocPointerDown(e) {
-    if (!tooltip.contains(e.target)) {
-      hideItemTooltip();
-    }
-  }
-  document.addEventListener('pointerdown', onDocPointerDown);
-  currentTooltipListener = onDocPointerDown;
-}
-
-function showDetails(item, evt) {
-  let text = '';
-  if (item.type === 'weapon') {
-    text = weaponDetailsText(item);
-  } else if (['armor', 'foot', 'ring', 'talisman'].includes(item.type)) {
-    text = gearDetailsText(item);
-  } else {
-    text = item.name || item.key;
-  }
-  if (text && evt?.target) {
-    evt.stopPropagation();
-    showItemTooltip(evt.target, text);
-  }
-}
 
 function createInventoryRow(item) {
   const row = document.createElement('div');

--- a/src/features/loot/ui/lootTab.js
+++ b/src/features/loot/ui/lootTab.js
@@ -1,6 +1,7 @@
 import { S } from '../../../shared/state.js';
 import { getSessionLoot } from '../selectors.js';
 import { forfeitSessionLoot } from '../mutators.js';
+import { showItemDetails as showDetails } from '../../../shared/utils/itemTooltip.js';
 
 export function updateLootTab(state = S) {
   const list = document.getElementById('sessionLootList');
@@ -10,6 +11,7 @@ export function updateLootTab(state = S) {
     const row = document.createElement('div');
     row.className = 'loot-row';
     row.textContent = `${item.qty || 1} ${item.key}`;
+    row.addEventListener('click', (e) => showDetails(item, e));
     list.appendChild(row);
   });
 }

--- a/src/shared/utils/itemTooltip.js
+++ b/src/shared/utils/itemTooltip.js
@@ -1,0 +1,135 @@
+import { WEAPONS } from '../../features/weaponGeneration/data/weapons.js';
+import { MODIFIERS } from '../../features/gearGeneration/data/modifiers.js';
+
+let currentTooltip = null;
+let currentTooltipListener = null;
+
+export function hideItemTooltip() {
+  if (currentTooltip) {
+    currentTooltip.remove();
+    currentTooltip = null;
+  }
+  if (currentTooltipListener) {
+    document.removeEventListener('pointerdown', currentTooltipListener);
+    currentTooltipListener = null;
+  }
+}
+
+export function showItemTooltip(anchor, text) {
+  hideItemTooltip();
+  const tooltip = document.createElement('div');
+  tooltip.className = 'astral-tooltip';
+  tooltip.innerHTML = text.replace(/\n/g, '<br>');
+  document.body.appendChild(tooltip);
+  const rect = anchor.getBoundingClientRect();
+  const tRect = tooltip.getBoundingClientRect();
+  let left = rect.right + 8;
+  let top = rect.top + rect.height / 2 - tRect.height / 2;
+  if (left + tRect.width > window.innerWidth - 8) left = rect.left - tRect.width - 8;
+  if (left < 8) left = 8;
+  if (top < 8) top = 8;
+  if (top + tRect.height > window.innerHeight - 8) top = window.innerHeight - tRect.height - 8;
+  tooltip.style.left = `${left}px`;
+  tooltip.style.top = `${top}px`;
+  currentTooltip = tooltip;
+  function onDocPointerDown(e) {
+    if (!tooltip.contains(e.target)) {
+      hideItemTooltip();
+    }
+  }
+  document.addEventListener('pointerdown', onDocPointerDown);
+  currentTooltipListener = onDocPointerDown;
+}
+
+export function weaponDetailsText(item) {
+  const w = WEAPONS[item.key] || item;
+  if (!w) return '';
+  const baseRate = w.base ? (w.base.attackRate ?? w.base.rate) : null;
+  const base = w.base ? `${w.base.min}-${w.base.max} (${baseRate}/s)` : 'n/a';
+  const scales = Object.entries(w.scales || {})
+    .map(([k, v]) => `${k} ${(v * 100).toFixed(0)}%`)
+    .join(', ');
+  const reqs = w.reqs ? `Realm ${w.reqs.realmMin}, Proficiency ${w.reqs.proficiencyMin}` : 'None';
+  const quality = w.quality ?? 'basic';
+  const mods = (w.modifiers || []).map(k => MODIFIERS[k]?.desc || k);
+  const modLine = mods.length ? mods.join(', ') : 'None';
+  const imbLine = item.imbuement
+    ? `Imbue: ${item.imbuement.element} Tier ${item.imbuement.tier}`
+    : 'Imbue: None';
+  return [
+    w.displayName || w.name,
+    imbLine,
+    `Quality: ${quality}`,
+    `Modifiers: ${modLine}`,
+    `Rarity: ${w.rarity || 'normal'}`,
+    `Base: ${base}`,
+    `Scales: ${scales}`,
+    `Tags: ${(w.tags || []).join(', ')}`,
+    `Reqs: ${reqs}`,
+  ].join('\n');
+}
+
+export function gearDetailsText(item) {
+  const lines = [item.name || item.key];
+  if (item.quality) lines.push(`Quality: ${item.quality}`);
+  if (item.rarity) lines.push(`Rarity: ${item.rarity}`);
+  if (item.guardType) lines.push(`Guard: ${item.guardType}`);
+  if (item.element) lines.push(`Element: ${item.element}`);
+  if (item.imbuement) lines.push(`Imbue: ${item.imbuement.element} Tier ${item.imbuement.tier}`);
+  else lines.push('Imbue: None');
+  if (item.protection) {
+    const prot = [];
+    if (item.protection.armor) prot.push(`Armor ${item.protection.armor}`);
+    if (item.protection.dodge) prot.push(`Dodge ${item.protection.dodge}`);
+    if (item.protection.qiShield) prot.push(`Qi Shield ${item.protection.qiShield}`);
+    if (prot.length) lines.push(`Protection: ${prot.join(', ')}`);
+  }
+  if (item.offense) {
+    const off = [];
+    if (item.offense.accuracy) off.push(`Accuracy ${item.offense.accuracy}`);
+    if (off.length) lines.push(`Offense: ${off.join(', ')}`);
+  }
+  if (item.modifiers && item.modifiers.length) {
+    const modLine = item.modifiers.map(k => MODIFIERS[k]?.desc || k).join(', ');
+    lines.push(`Modifiers: ${modLine}`);
+  }
+  if (item.bonuses) {
+    const bonusLines = Object.entries(item.bonuses).map(([k, v]) => {
+      let label = k;
+      switch (k) {
+        case 'foundationMult':
+          label = 'Foundation';
+          break;
+        case 'breakthroughBonus':
+          label = 'Breakthrough';
+          break;
+        case 'qiRegenMult':
+          label = 'Qi Regen';
+          break;
+        case 'dropRateMult':
+          label = 'Drop Rate';
+          break;
+      }
+      return `${label}: +${(v * 100).toFixed(0)}%`;
+    });
+    lines.push(...bonusLines);
+  }
+  return lines.join('\n');
+}
+
+export function showItemDetails(item, evt) {
+  let text = '';
+  if (item.type === 'weapon') {
+    text = weaponDetailsText(item);
+  } else if (['armor', 'foot', 'ring', 'talisman'].includes(item.type)) {
+    text = gearDetailsText(item);
+  } else {
+    text = item.name || item.key;
+  }
+  const anchor = evt?.currentTarget || evt?.target;
+  if (text && anchor) {
+    evt.stopPropagation();
+    showItemTooltip(anchor, text);
+  }
+}
+


### PR DESCRIPTION
## Summary
- Centralize item tooltip handling in a shared utility
- Use shared tooltip logic in loot and inventory panels to keep gear/weapon details open until clicking elsewhere

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b5fd9d50d88326a8091a1fcf19095b