### PR TITLE
fix: clear all save data on hard reset

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -166,7 +166,19 @@ function initUI(){
   if (saveBtn) saveBtn.addEventListener('click', save);
   
   const resetBtn = qs('#resetBtn');
-  if (resetBtn) resetBtn.addEventListener('click', ()=>{ if(confirm('Hard reset?')){ setState(defaultState()); save(); location.reload(); }});
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      if (confirm('Hard reset?')) {
+        // Remove all known save slots so legacy data doesn't persist
+        localStorage.removeItem('woa-save');
+        localStorage.removeItem('woa:save:v1');
+
+        setState(defaultState());
+        save();
+        location.reload();
+      }
+    });
+  }
   const exportBtn = qs('#exportBtn');
   if (exportBtn) {
     exportBtn.addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- clear legacy and current save keys when pressing Hard reset

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violations, DOM usage)


------
https://chatgpt.com/codex/tasks/task_e_68b603ba95bc8326acb9a4992afdc78f