### PR TITLE
Avoid flicker in adventure tab icons

### DIFF
--- a/src/features/adventure/ui/zoneUI.js
+++ b/src/features/adventure/ui/zoneUI.js
@@ -2,53 +2,59 @@ import { ZONES } from '../data/zones.js';
 import { getAdventure } from '../selectors.js';
 import { selectZone, selectArea, updateActivityAdventure } from '../logic.js';
 
+let lastZoneHTML = '';
 export function updateZoneButtons() {
   const zoneContainer = document.getElementById('zoneButtons');
   const adventure = getAdventure();
   if (!zoneContainer || !adventure) return;
-  zoneContainer.innerHTML = '';
+  let html = '';
   ZONES.forEach((zone, index) => {
     if (index < (adventure.zonesUnlocked || 1)) {
-      const button = document.createElement('button');
-      button.className = 'btn zone-btn' + (index === (adventure.selectedZone || 0) ? ' active' : '');
-      button.textContent = zone.name;
-      button.onclick = () => {
-        if (selectZone(index)) updateActivityAdventure();
-      };
-      zoneContainer.appendChild(button);
+      const active = index === (adventure.selectedZone || 0) ? ' active' : '';
+      html += `<button class="btn zone-btn${active}">${zone.name}</button>`;
     }
+  });
+  if (html === lastZoneHTML) return;
+  lastZoneHTML = html;
+  zoneContainer.innerHTML = html;
+  Array.from(zoneContainer.children).forEach((btn, index) => {
+    btn.addEventListener('click', () => {
+      if (selectZone(index)) updateActivityAdventure();
+    });
   });
 }
 
+let lastAreaHTML = '';
 export function updateAreaGrid() {
   const areaContainer = document.getElementById('areaGrid');
   const adventure = getAdventure();
   if (!areaContainer || !adventure) return;
   const currentZone = ZONES[adventure.selectedZone || 0];
-  if (currentZone && currentZone.areas) {
-    areaContainer.innerHTML = '';
-    currentZone.areas.forEach((area, index) => {
-      const button = document.createElement('button');
-      const areaKey = `${adventure.selectedZone}-${index}`;
-      const isUnlocked = adventure.unlockedAreas[areaKey] || false;
-      const isActive = index === (adventure.selectedArea || 0);
-      const progress = adventure.areaProgress[areaKey] || { kills: 0, bossDefeated: false };
-
-      button.className = 'btn area-btn' + (isActive ? ' active' : '') + (!isUnlocked ? ' disabled' : '');
-      button.textContent = area.name;
-      button.disabled = !isUnlocked;
-
-      if (isUnlocked) {
-        const statusText = progress.bossDefeated ? ' ✓' : (progress.kills >= area.killReq ? ' 👹' : ` (${progress.kills}/${area.killReq})`);
-        button.textContent += statusText;
-        button.onclick = () => {
-          if (selectArea(index)) updateActivityAdventure();
-        };
-      } else {
-        button.textContent += ' 🔒';
-      }
-
-      areaContainer.appendChild(button);
-    });
-  }
+  if (!currentZone || !currentZone.areas) return;
+  let html = '';
+  const buttonData = [];
+  currentZone.areas.forEach((area, index) => {
+    const areaKey = `${adventure.selectedZone}-${index}`;
+    const isUnlocked = adventure.unlockedAreas[areaKey] || false;
+    const isActive = index === (adventure.selectedArea || 0);
+    const progress = adventure.areaProgress[areaKey] || { kills: 0, bossDefeated: false };
+    const cls = 'btn area-btn' + (isActive ? ' active' : '') + (!isUnlocked ? ' disabled' : '');
+    const base = `${area.name}`;
+    const status = isUnlocked
+      ? (progress.bossDefeated ? ' ✓' : (progress.kills >= area.killReq ? ' 👹' : ` (${progress.kills}/${area.killReq})`))
+      : ' 🔒';
+    html += `<button class="${cls}" ${!isUnlocked ? 'disabled' : ''}>${base}${status}</button>`;
+    buttonData.push({ isUnlocked, index });
+  });
+  if (html === lastAreaHTML) return;
+  lastAreaHTML = html;
+  areaContainer.innerHTML = html;
+  Array.from(areaContainer.children).forEach((btn, i) => {
+    const { isUnlocked, index } = buttonData[i];
+    if (isUnlocked) {
+      btn.addEventListener('click', () => {
+        if (selectArea(index)) updateActivityAdventure();
+      });
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- Cache zone and area button HTML to avoid unnecessary DOM refreshes
- Only rebuild adventure progress bar when state changes
- Cache ability bar markup to stop icon flicker

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation and DOM usage warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b605f767f48326b35879c8df7917a5