### PR TITLE
Optimize equipment panel rendering and preserve inventory tooltip

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -93,7 +93,7 @@ function renderEquipment() {
     const coloredNameHtml = rarityColor ? `<span style="color:${rarityColor}">${baseNameHtml}</span>` : baseNameHtml;
     const nameHtml = stars ? `${stars} ${coloredNameHtml}` : coloredNameHtml;
     el.querySelector('.slot-name').innerHTML = nameHtml;
-    el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory(); };
+    el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
     el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
     const element = item?.element || item?.imbuement?.element;
     el.style.backgroundColor = element ? (ELEMENT_BG_COLORS[element] || '') : '';
@@ -312,8 +312,8 @@ function canEquipToSlot(item, slot) {
   return false;
 }
 
-function renderInventory() {
-  hideItemTooltip();
+function renderInventory({ dismissTooltip = false } = {}) {
+  if (dismissTooltip) hideItemTooltip();
   const list = document.getElementById('inventoryList');
   if (!list) return;
   list.innerHTML = '';
@@ -322,7 +322,7 @@ function renderInventory() {
   const filterBtns = document.querySelectorAll('#inventoryFilters button');
   filterBtns.forEach(btn => {
     btn.classList.toggle('active', btn.dataset.filter === currentFilter);
-    btn.onclick = () => { currentFilter = btn.dataset.filter; slotFilter = null; renderInventory(); };
+    btn.onclick = () => { currentFilter = btn.dataset.filter; slotFilter = null; renderInventory({ dismissTooltip: true }); };
   });
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -83,6 +83,10 @@ import { usePill } from '../src/features/inventory/mutators.js';
 // Global variables
 const progressBars = {};
 
+// Track last known equipment/inventory state to avoid unnecessary re-renders
+let lastInventorySnapshot = JSON.stringify(S.inventory || []);
+let lastEquipmentSnapshot = JSON.stringify(S.equipment || {});
+
 // Activity Management System (delegates to feature)
 function selectActivity(activityType) { selectActivityMut(S, activityType); }
 function startActivity(activityName)  { startActivityMut(S, activityName); }
@@ -280,9 +284,16 @@ function updateActivityContent() {
     case 'adventure':
       updateActivityAdventure();
       break;
-    case 'character':
-      renderEquipmentPanel(); // EQUIP-CHAR-UI
+    case 'character': {
+      const invState = JSON.stringify(S.inventory || []);
+      const equipState = JSON.stringify(S.equipment || {});
+      if (invState !== lastInventorySnapshot || equipState !== lastEquipmentSnapshot) {
+        renderEquipmentPanel(); // EQUIP-CHAR-UI
+        lastInventorySnapshot = invState;
+        lastEquipmentSnapshot = equipState;
+      }
       break;
+    }
     case 'cooking':
       updateActivityCooking();
       break;


### PR DESCRIPTION
## Summary
- Render equipment panel only when inventory or equipment changes instead of every tick.
- Allow inventory tooltips to persist through refreshes unless explicitly dismissed.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b62a75eb2083269f5ba876e413655c