### PR TITLE
Separate materials into character tab card

### DIFF
--- a/index.html
+++ b/index.html
@@ -730,9 +730,12 @@
               <button class="btn small" data-filter="weapon">Weapons</button>
               <button class="btn small" data-filter="armor">Armor</button>
               <button class="btn small" data-filter="food">Food</button>
-              <button class="btn small" data-filter="mat">Materials</button>
             </div>
             <div class="inventory-list" id="inventoryList"></div>
+          </div>
+          <div class="card">
+            <h4>Materials</h4>
+            <div class="inventory-list" id="materialsList"></div>
           </div>
         </div>
       </section>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -33,6 +33,7 @@ export function renderEquipmentPanel() {
   recomputePlayerTotals(S);
   renderEquipment();
   renderInventory();
+  renderMaterials();
   renderStats();
   renderAbilitySlots();
 }
@@ -317,12 +318,24 @@ function renderInventory() {
   const list = document.getElementById('inventoryList');
   if (!list) return;
   list.innerHTML = '';
-  const items = (S.inventory || []).filter(it => currentFilter === 'all' || it.type === currentFilter);
+  const items = (S.inventory || []).filter(it => it.type !== 'mat' && (currentFilter === 'all' || it.type === currentFilter));
   items.forEach(it => list.appendChild(createInventoryRow(it)));
   const filterBtns = document.querySelectorAll('#inventoryFilters button');
   filterBtns.forEach(btn => {
     btn.classList.toggle('active', btn.dataset.filter === currentFilter);
     btn.onclick = () => { currentFilter = btn.dataset.filter; slotFilter = null; renderInventory(); };
+  });
+}
+
+function renderMaterials() {
+  const list = document.getElementById('materialsList');
+  if (!list) return;
+  list.innerHTML = '';
+  const mats = (S.inventory || []).filter(it => it.type === 'mat');
+  mats.forEach(it => {
+    const row = createInventoryRow(it);
+    row.classList.remove('muted');
+    list.appendChild(row);
   });
 }
 

--- a/validation.log
+++ b/validation.log
@@ -11,6 +11,7 @@
    • UI state violation: src/features/combat/ui/combatStats.js imports S from shared/state.js
    • UI state violation: src/features/cooking/ui/cookControls.js imports S from shared/state.js
    • UI state violation: src/features/cooking/ui/cookingDisplay.js imports S from shared/state.js
+   • UI state violation: src/features/forging/ui/forgingDisplay.js imports S from shared/state.js
    • UI state violation: src/features/inventory/ui/resourceDisplay.js imports S from shared/state.js
    • UI state violation: src/features/karma/ui/karmaHUD.js imports S from shared/state.js
    • UI state violation: src/features/loot/ui/lootTab.js imports S from shared/state.js


### PR DESCRIPTION
## Summary
- Move materials out of inventory filters into a dedicated Materials card
- Render material items separately from other inventory categories

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation and other warnings)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b62e4e69788326a28892c58d528514