### PR TITLE
Add item-type specific modifier pools

### DIFF
--- a/src/features/accessories/logic.js
+++ b/src/features/accessories/logic.js
@@ -1,7 +1,7 @@
 import { RINGS } from './data/rings.js';
-import { MODIFIERS, MODIFIER_KEYS } from '../gearGeneration/data/modifiers.js';
+import { MODIFIERS, MODIFIER_POOLS } from '../gearGeneration/data/modifiers.js';
 
-function rollMinorModifiers(rarity = 'normal') {
+function rollModifiers(itemType, rarity = 'normal') {
   const config = {
     normal: [0, 0],
     magic: [1, 2],
@@ -9,7 +9,7 @@ function rollMinorModifiers(rarity = 'normal') {
   };
   const [min, max] = config[rarity] || [0, 0];
   const count = Math.floor(Math.random() * (max - min + 1)) + min;
-  const keys = [...MODIFIER_KEYS];
+  const keys = [...(MODIFIER_POOLS[itemType] || [])];
   const mods = [];
   for (let i = 0; i < count && keys.length; i++) {
     const idx = Math.floor(Math.random() * keys.length);
@@ -46,7 +46,7 @@ export function generateRing(baseKey, rarity = 'normal') {
   const base = RINGS[baseKey];
   if (!base) throw new Error(`Unknown ring: ${baseKey}`);
   const ring = JSON.parse(JSON.stringify(base));
-  const mods = rollMinorModifiers(rarity);
+  const mods = rollModifiers('ring', rarity);
   applyRingModifiers(ring, mods);
   ring.modifiers = mods.map(m => m.key);
   ring.rarity = rarity;

--- a/src/features/gearGeneration/data/modifiers.js
+++ b/src/features/gearGeneration/data/modifiers.js
@@ -3,22 +3,42 @@ export const MODIFIERS = {
     lane: 'armor',
     value: 0.1,
     desc: '+10% Armor',
+    appliesTo: ['armor', 'ring'],
   },
   increasedDodge: {
     lane: 'dodge',
     value: 0.1,
     desc: '+10% Dodge',
+    appliesTo: ['armor', 'ring'],
   },
   increasedAccuracy: {
     lane: 'accuracy',
     value: 0.1,
     desc: '+10% Accuracy',
+    appliesTo: ['armor', 'ring'],
   },
   increasedDamage: {
     lane: 'damage',
     value: 0.1,
     desc: '+10% Damage',
+    appliesTo: ['weapon', 'ring'],
   },
 };
 
 export const MODIFIER_KEYS = Object.keys(MODIFIERS);
+
+export const WEAPON_MODIFIERS = MODIFIER_KEYS.filter(
+  k => MODIFIERS[k].appliesTo.includes('weapon')
+);
+export const ARMOR_MODIFIERS = MODIFIER_KEYS.filter(
+  k => MODIFIERS[k].appliesTo.includes('armor')
+);
+export const RING_MODIFIERS = MODIFIER_KEYS.filter(
+  k => MODIFIERS[k].appliesTo.includes('ring')
+);
+
+export const MODIFIER_POOLS = {
+  weapon: WEAPON_MODIFIERS,
+  armor: ARMOR_MODIFIERS,
+  ring: RING_MODIFIERS,
+};

--- a/src/features/gearGeneration/logic.js
+++ b/src/features/gearGeneration/logic.js
@@ -1,7 +1,7 @@
 import { GEAR_BASES } from './data/gearBases.js';
 import { MATERIALS_STUB } from '../weaponGeneration/data/materials.stub.js';
 import { getImbuementMultiplier, pickZoneElement } from './imbuement.js';
-import { MODIFIERS, MODIFIER_KEYS } from './data/modifiers.js';
+import { MODIFIERS, MODIFIER_POOLS } from './data/modifiers.js';
 
 /**
  * @typedef {{
@@ -29,7 +29,7 @@ export function generateGear({ baseKey, materialKey, qualityKey = 'basic', stage
   };
   const name = composeName(base.displayName, material?.displayName);
   /** roll and apply modifiers */
-  const mods = rollModifiers(rarity);
+  const mods = rollModifiers('armor', rarity);
   applyGearModifiers({ protection, offense }, mods);
 
   return {
@@ -70,7 +70,7 @@ function composeName(baseName, materialName) {
     : `${materialName} ${baseName}`;
 }
 
-function rollModifiers(rarity) {
+function rollModifiers(itemType, rarity) {
   const config = {
     normal: [0, 0],
     magic: [1, 2],
@@ -78,7 +78,7 @@ function rollModifiers(rarity) {
   };
   const [min, max] = config[rarity] || [0, 0];
   const count = Math.floor(Math.random() * (max - min + 1)) + min;
-  const keys = [...MODIFIER_KEYS];
+  const keys = [...(MODIFIER_POOLS[itemType] || [])];
   const mods = [];
   for (let i = 0; i < count && keys.length; i++) {
     const idx = Math.floor(Math.random() * keys.length);

--- a/src/features/weaponGeneration/logic.js
+++ b/src/features/weaponGeneration/logic.js
@@ -1,7 +1,7 @@
 import { WEAPON_TYPES } from './data/weaponTypes.js';
 import { MATERIALS_STUB } from './data/materials.stub.js';
 import { getImbuementMultiplier } from '../gearGeneration/imbuement.js';
-import { MODIFIERS, MODIFIER_KEYS } from '../gearGeneration/data/modifiers.js';
+import { MODIFIERS, MODIFIER_POOLS } from '../gearGeneration/data/modifiers.js';
 
 /** @typedef {{
  *  typeKey:string,
@@ -53,7 +53,7 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', sta
       )
     : undefined;
 
-  const mods = rollModifiers(rarity);
+  const mods = rollModifiers('weapon', rarity);
   applyWeaponModifiers({ base }, mods);
 
   /** @type {WeaponItem} */
@@ -77,7 +77,7 @@ function composeName({typeName, materialName}){
   return materialName ? `${materialName} ${typeName}` : typeName;
 }
 
-function rollModifiers(rarity) {
+function rollModifiers(itemType, rarity) {
   const config = {
     normal: [0, 0],
     magic: [1, 2],
@@ -85,7 +85,7 @@ function rollModifiers(rarity) {
   };
   const [min, max] = config[rarity] || [0, 0];
   const count = Math.floor(Math.random() * (max - min + 1)) + min;
-  const keys = [...MODIFIER_KEYS];
+  const keys = [...(MODIFIER_POOLS[itemType] || [])];
   const mods = [];
   for (let i = 0; i < count && keys.length; i++) {
     const idx = Math.floor(Math.random() * keys.length);


### PR DESCRIPTION
## Summary
- Tag modifiers with `appliesTo` item types and expose weapon, armor, and ring pools
- Filter rolled modifiers by item type in gear, weapon, and accessory generation

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b649d80b1c8326adf28c03f0229d43