### PR TITLE
fix: prevent card sub-tabs from overlapping content

### DIFF
--- a/style.css
+++ b/style.css
@@ -66,6 +66,16 @@ html,body{height:100%;overflow:hidden}
   margin-bottom:0;
 }
 
+/* Nested tab bars (like those inside cards) should sit at the top of
+   their container rather than sticking to the page header. Reset the
+   positioning so the subsequent content isn't overlapped. */
+.card .tab-bar{
+  position:static;
+  top:auto;
+  z-index:auto;
+  margin-bottom:var(--card-gap);
+}
+
 .tab-content{
   padding-top:var(--gap);
   display:flex;


### PR DESCRIPTION
## Summary
- ensure nested tab bars inside cards use static positioning so content isn't overlapped

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b64c3e3ffc832689c3642dad40642e