### PR TITLE
Clarify weapon damage modifier description

### DIFF
--- a/src/features/gearGeneration/data/modifiers.js
+++ b/src/features/gearGeneration/data/modifiers.js
@@ -20,8 +20,8 @@ export const MODIFIERS = {
   increasedDamage: {
     lane: 'damage',
     value: 0.1,
-    desc: '+10% Damage',
-    appliesTo: ['weapon', 'ring'],
+    desc: '+10% Weapon Damage',
+    appliesTo: ['weapon', 'ring'], // boosts base weapon damage only; spells use separate modifiers
   },
 };
 


### PR DESCRIPTION
## Summary
- clarify `+ damage` gear modifier as `+10% Weapon Damage`
- note that it boosts base weapon damage only and doesn't apply to spells

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b653ff992083269a79d67ddcb58953