### PR TITLE
feat: add junk system and merchant

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,6 +695,7 @@
             <div class="stat"><span>Attack Speed</span><span id="stat-attackSpeed">1.00</span></div>
             <div class="stat"><span>Cooldown Reduction</span><span id="stat-cooldownReduction">0%</span></div>
             <div class="stat"><span>Adventure Speed</span><span id="stat-adventureSpeed">1.00</span></div>
+            <div class="stat"><span>Coin</span><span id="stat-coin">0</span></div>
           </div>
           <div class="card">
             <h4>Equipment</h4>
@@ -736,6 +737,10 @@
           <div class="card">
             <h4>Materials</h4>
             <div class="inventory-list" id="materialsList"></div>
+          </div>
+          <div class="card">
+            <h4>Junk</h4>
+            <div class="inventory-list" id="junkList"></div>
           </div>
         </div>
       </section>

--- a/src/features/inventory/migrations.js
+++ b/src/features/inventory/migrations.js
@@ -67,5 +67,9 @@ export const migrations = [
     if (!hasPalmWraps && !equippedPalm) {
       save.inventory.push({ id: Date.now() + Math.random(), key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' });
     }
+  },
+  save => {
+    if (typeof save.coin === 'undefined') save.coin = 0;
+    if (!Array.isArray(save.junk)) save.junk = [];
   }
 ];

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -23,6 +23,30 @@ export function removeFromInventory(id, state = S) {
   return false;
 }
 
+export function moveToJunk(id, state = S) {
+  state.inventory = state.inventory || [];
+  state.junk = state.junk || [];
+  const idx = state.inventory.findIndex(it => it.id === id);
+  if (idx >= 0) {
+    const [item] = state.inventory.splice(idx, 1);
+    state.junk.push(item);
+    save?.();
+    return true;
+  }
+  return false;
+}
+
+export function sellJunk(state = S) {
+  state.junk = state.junk || [];
+  const total = state.junk.reduce((sum, it) => sum + (it.qty || 1), 0);
+  if (total > 0) {
+    state.coin = (state.coin || 0) + total;
+    state.junk = [];
+    save?.();
+  }
+  return total;
+}
+
 export function equipItem(item, slot = null, state = S) {
   const info = canEquip(item, slot, state);
   if (!info) return false;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -1,7 +1,7 @@
 import { S, save } from '../../../shared/state.js';
 import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
 import { WEAPON_ICONS } from '../../weaponGeneration/data/weaponIcons.js';
-import { equipItem, unequip, removeFromInventory } from '../mutators.js';
+import { equipItem, unequip, removeFromInventory, moveToJunk } from '../mutators.js';
 import { recomputePlayerTotals } from '../logic.js';
 import { ABILITIES } from '../../ability/data/abilities.js';
 import { MODIFIERS } from '../../gearGeneration/data/modifiers.js';
@@ -34,6 +34,7 @@ export function renderEquipmentPanel() {
   renderEquipment();
   renderInventory();
   renderMaterials();
+  renderJunk();
   renderStats();
   renderAbilitySlots();
 }
@@ -56,7 +57,8 @@ function renderStats() {
     { id: 'criticalChance', stat: 'criticalChance', format: v => `${(v * 100).toFixed(1)}%` },
     { id: 'attackSpeed', stat: 'attackSpeed', format: v => v.toFixed(2) },
     { id: 'cooldownReduction', stat: 'cooldownReduction', format: v => `${Math.round(v * 100)}%` },
-    { id: 'adventureSpeed', stat: 'adventureSpeed', format: v => v.toFixed(2) }
+    { id: 'adventureSpeed', stat: 'adventureSpeed', format: v => v.toFixed(2) },
+    { id: 'coin', value: () => S.coin || 0 }
   ];
   defs.forEach(d => {
     const el = document.getElementById(`stat-${d.id}`);
@@ -283,6 +285,11 @@ function createInventoryRow(item) {
       renderEquipmentPanel();
     };
     act.appendChild(scrapBtn);
+    const junkBtn = document.createElement('button');
+    junkBtn.className = 'btn small';
+    junkBtn.textContent = 'Junk';
+    junkBtn.onclick = () => { moveToJunk(item.id); renderEquipmentPanel(); };
+    act.appendChild(junkBtn);
     const detailsBtn = document.createElement('button');
     detailsBtn.className = 'btn small';
     detailsBtn.textContent = 'Details';
@@ -333,6 +340,29 @@ function renderMaterials() {
     row.classList.remove('muted');
     list.appendChild(row);
   });
+}
+
+function createJunkRow(item) {
+  const row = createInventoryRow(item);
+  row.classList.remove('muted');
+  const act = row.querySelector('.inv-actions');
+  if (act) {
+    act.innerHTML = '';
+    const detailsBtn = document.createElement('button');
+    detailsBtn.className = 'btn small';
+    detailsBtn.textContent = 'Details';
+    detailsBtn.onclick = (e) => showDetails(item, e);
+    act.appendChild(detailsBtn);
+  }
+  return row;
+}
+
+function renderJunk() {
+  const list = document.getElementById('junkList');
+  if (!list) return;
+  list.innerHTML = '';
+  const items = S.junk || [];
+  items.forEach(it => list.appendChild(createJunkRow(it)));
 }
 
 export function setupEquipmentTab() {

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -48,6 +48,7 @@ export const defaultState = () => {
   qiRegenMult: 0, // Qi regeneration multiplier from buildings/bonuses
   foundation: 0,
   astralPoints: 50,
+  coin: 0,
   ...initHp(baseHP),
   shield: { current: 0, max: 0 },
   autoFillShieldFromQi: true,
@@ -131,6 +132,7 @@ export const defaultState = () => {
 
   equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, food: null }, // EQUIP-CHAR-UI
   inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
+  junk: [],
   gearBonuses: {},
   sessionLoot: [], // EQUIP-CHAR-UI
   flags: { weaponsEnabled: true },

--- a/ui/index.js
+++ b/ui/index.js
@@ -78,7 +78,7 @@ import { getSelectedActivity } from '../src/features/activity/selectors.js';
 import { mountActivityUI, updateActivitySelectors, updateCurrentTaskDisplay } from '../src/features/activity/ui/activityUI.js';
 import { meditate } from '../src/features/progression/mutators.js';
 import { tickInsight } from '../src/features/progression/insight.js';
-import { usePill } from '../src/features/inventory/mutators.js';
+import { usePill, sellJunk } from '../src/features/inventory/mutators.js';
 
 // Global variables
 const progressBars = {};
@@ -691,6 +691,18 @@ window.addEventListener('load', ()=>{
   tick();
   log('Welcome, cultivator.');
   setInterval(tick, 1000);
+  setInterval(() => {
+    const junk = S.junk || [];
+    const total = junk.reduce((sum, it) => sum + (it.qty || 1), 0);
+    if (junk.length === 0) {
+      alert('A travelling merchant stops by, but you have no junk to sell.');
+      return;
+    }
+    if (confirm(`A travelling merchant arrives! Sell all junk for ${total} coin?`)) {
+      sellJunk(S);
+      renderEquipmentPanel();
+    }
+  }, 3600000);
 });
 
 // CHANGELOG: Added weapon HUD integration.


### PR DESCRIPTION
## Summary
- add junk inventory card and ability to move items to junk
- introduce coins to state and stats display
- spawn hourly merchant who buys all junk for coins

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: verification protocol violations)


------
https://chatgpt.com/codex/tasks/task_e_68b64dd4bc0483269f78f0519c8bc4f0