### PR TITLE
Show proficiency for all weapon types

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,10 +650,7 @@
             
             <!-- Proficiencies Tab -->
             <div id="proficienciesTab" class="adventure-tab-content tab-content" style="display: none;">
-              <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
-              <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
-              <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>
-              <div class="stat"><span>Bonus</span><span id="weaponBonus">1.00</span></div>
+              <div id="weaponProficiencyList"></div>
             </div>
           </div>
         </div>

--- a/src/features/proficiency/ui/weaponProficiencyDisplay.js
+++ b/src/features/proficiency/ui/weaponProficiencyDisplay.js
@@ -1,31 +1,32 @@
-import { S } from "../../../shared/state.js";
 import { on } from "../../../shared/events.js";
-import { getEquippedWeapon } from "../../inventory/selectors.js";
 import { getProficiency } from "../selectors.js";
 import { WEAPON_TYPES } from "../../weaponGeneration/data/weaponTypes.js";
 import { WEAPON_ICONS } from "../../weaponGeneration/data/weaponIcons.js";
-import { setText, setFill } from "../../../shared/utils/dom.js";
 
-export function updateWeaponProficiencyDisplay(state = S) {
-  const weapon = getEquippedWeapon(state);
-  const { value } = getProficiency(weapon.proficiencyKey, state);
-  const level = Math.floor(value / 100);
-  const progress = value % 100;
-  const type = WEAPON_TYPES[weapon.proficiencyKey];
-  let label = type?.displayName || weapon.proficiencyKey;
-  if (!label.endsWith('s')) label += 's';
-  const icon = WEAPON_ICONS[weapon.proficiencyKey];
-  const labelEl = document.getElementById('weaponLabel');
-  if (labelEl) {
-    const text = `${label} Level`;
-    labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
+export function updateWeaponProficiencyDisplay(state) {
+  if (!state) return;
+  const container = document.getElementById('weaponProficiencyList');
+  if (!container) return;
+  let html = '';
+  for (const key of Object.keys(WEAPON_ICONS)) {
+    const { value } = getProficiency(key, state);
+    const level = Math.floor(value / 100);
+    const progress = value % 100;
+    const type = WEAPON_TYPES[key];
+    let label = type?.displayName || key;
+    label = label.charAt(0).toUpperCase() + label.slice(1);
+    if (!label.endsWith('s')) label += 's';
+    const icon = WEAPON_ICONS[key];
+    const bonus = 1 + level * 0.01;
+    html += `
+      <div class="weapon-prof">
+        <div class="stat"><span>${icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ` : ''}${label} Level</span><span>${level}</span></div>
+        <div class="stat"><span>Experience</span><span>${progress.toFixed(0)}</span> / <span>100</span></div>
+        <div class="activity-progress-bar"><div class="progress-fill" style="width:${progress}%"></div></div>
+        <div class="stat"><span>Bonus</span><span>${bonus.toFixed(2)}</span></div>
+      </div>`;
   }
-  setText('weaponLevel', level);
-  setText('weaponExp', progress.toFixed(0));
-  setText('weaponExpMax', '100');
-  setFill('weaponExpFill', progress / 100);
-  const bonus = 1 + level * 0.01;
-  setText('weaponBonus', bonus.toFixed(2));
+  container.innerHTML = html;
 }
 
 export function mountProficiencyUI(state) {

--- a/ui/index.js
+++ b/ui/index.js
@@ -41,7 +41,6 @@ import {
   retreatFromCombat,
   instakillCurrentEnemy
 } from '../src/features/adventure/mutators.js';
-import { updateWeaponProficiencyDisplay } from '../src/features/proficiency/ui/weaponProficiencyDisplay.js';
 import { setupLootUI } from '../src/features/loot/ui/lootTab.js';
 import { renderEquipmentPanel, setupEquipmentTab } from '../src/features/inventory/ui/CharacterPanel.js'; // EQUIP-CHAR-UI
 import { ZONES } from '../src/features/adventure/data/zones.js'; // MAP-UI-UPDATE
@@ -53,6 +52,7 @@ import { advanceMining } from '../src/features/mining/logic.js';
 import { advanceForging } from '../src/features/forging/logic.js';
 import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
 import { mountForgingUI } from '../src/features/forging/ui/forgingDisplay.js';
+import { mountProficiencyUI } from '../src/features/proficiency/ui/weaponProficiencyDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
 import { mountSectUI } from '../src/features/sect/ui/sectScreen.js';
@@ -119,6 +119,7 @@ function initUI(){
   const mhName = WEAPONS[mhKey]?.displayName || (mhKey === 'fist' ? 'Fists' : mhKey);
   initializeWeaponChip({ key: mhKey, name: mhName });
   mountTrainingGameUI(S);
+  mountProficiencyUI(S);
   mountMiningUI(S);
   mountForgingUI(S);
   setupAbilityUI();


### PR DESCRIPTION
## Summary
- Render every weapon proficiency inside the Proficiencies tab
- Mount proficiency UI and avoid direct state imports

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations in existing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b6548ad7dc8326864f861e8862ccbb