### PR TITLE
Display all weapon proficiency levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,10 +650,7 @@
             
             <!-- Proficiencies Tab -->
             <div id="proficienciesTab" class="adventure-tab-content tab-content" style="display: none;">
-              <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
-              <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
-              <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>
-              <div class="stat"><span>Bonus</span><span id="weaponBonus">1.00</span></div>
+              <div id="weaponProficiencies"></div>
             </div>
           </div>
         </div>

--- a/src/features/proficiency/ui/weaponProficiencyDisplay.js
+++ b/src/features/proficiency/ui/weaponProficiencyDisplay.js
@@ -1,31 +1,33 @@
-import { S } from "../../../shared/state.js";
 import { on } from "../../../shared/events.js";
-import { getEquippedWeapon } from "../../inventory/selectors.js";
 import { getProficiency } from "../selectors.js";
 import { WEAPON_TYPES } from "../../weaponGeneration/data/weaponTypes.js";
 import { WEAPON_ICONS } from "../../weaponGeneration/data/weaponIcons.js";
-import { setText, setFill } from "../../../shared/utils/dom.js";
 
-export function updateWeaponProficiencyDisplay(state = S) {
-  const weapon = getEquippedWeapon(state);
-  const { value } = getProficiency(weapon.proficiencyKey, state);
-  const level = Math.floor(value / 100);
-  const progress = value % 100;
-  const type = WEAPON_TYPES[weapon.proficiencyKey];
-  let label = type?.displayName || weapon.proficiencyKey;
-  if (!label.endsWith('s')) label += 's';
-  const icon = WEAPON_ICONS[weapon.proficiencyKey];
-  const labelEl = document.getElementById('weaponLabel');
-  if (labelEl) {
-    const text = `${label} Level`;
-    labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
-  }
-  setText('weaponLevel', level);
-  setText('weaponExp', progress.toFixed(0));
-  setText('weaponExpMax', '100');
-  setFill('weaponExpFill', progress / 100);
-  const bonus = 1 + level * 0.01;
-  setText('weaponBonus', bonus.toFixed(2));
+export function updateWeaponProficiencyDisplay(state) {
+  const container = document.getElementById('weaponProficiencies');
+  if (!container) return;
+  container.innerHTML = '';
+  const keys = Object.keys(WEAPON_ICONS);
+  keys.forEach(key => {
+    const { value } = getProficiency(key, state);
+    const level = Math.floor(value / 100);
+    const progress = value % 100;
+    const type = WEAPON_TYPES[key];
+    let label = type?.displayName || key;
+    if (!label.endsWith('s')) label += 's';
+    const icon = WEAPON_ICONS[key];
+    const bonus = 1 + level * 0.01;
+    const el = document.createElement('div');
+    el.className = 'weapon-prof';
+    const iconHtml = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ` : '';
+    el.innerHTML = `
+      <div class="stat"><span>${iconHtml}${label} Level</span><span>${level}</span></div>
+      <div class="stat"><span>Experience</span><span>${progress.toFixed(0)}</span> / <span>100</span></div>
+      <div class="activity-progress-bar"><div class="progress-fill" style="width:${progress}%"></div></div>
+      <div class="stat"><span>Bonus</span><span>${bonus.toFixed(2)}</span></div>
+    `;
+    container.appendChild(el);
+  });
 }
 
 export function mountProficiencyUI(state) {


### PR DESCRIPTION
## Summary
- Add container for listing weapon proficiencies in the UI
- Render proficiency, experience, and bonus for every weapon type
- Drop direct usage of shared state in proficiency display

## Testing
- `npm test`
- `npm run validate` *(fails: UI state violations in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b65ad6783883268c8bfeab940361b7