### PR TITLE
feat: split weapon base into physical and elemental

### DIFF
--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -22,7 +22,7 @@ export function resolveAbilityHit(abilityKey, state) {
 
 function resolveFlowingPalm(state) {
   const weapon = getEquippedWeapon(state);
-  const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
+  const roll = Math.floor(Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)) + weapon.base.phys.min;
   return {
     attack: { amount: roll, type: 'physical', target: state.adventure.currentEnemy },
     stun: { mult: 2 },
@@ -31,7 +31,7 @@ function resolveFlowingPalm(state) {
 
 function resolvePowerSlash(state) {
   const weapon = getEquippedWeapon(state);
-  const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
+  const roll = Math.floor(Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)) + weapon.base.phys.min;
   const raw = Math.round(1.3 * roll);
   return {
     attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
@@ -50,7 +50,7 @@ function resolveFireball(state) {
 
 function resolvePalmStrike(state) {
   const weapon = getEquippedWeapon(state);
-  const roll = Math.floor(Math.random() * (weapon.base.max - weapon.base.min + 1)) + weapon.base.min;
+  const roll = Math.floor(Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)) + weapon.base.phys.min;
   const raw = Math.round(roll);
   return {
     attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -113,7 +113,7 @@ function weaponDetailsText(item) {
   const w = WEAPONS[item.key] || item;
   if (!w) return '';
   const baseRate = w.base ? (w.base.attackRate ?? w.base.rate) : null;
-  const base = w.base ? `${w.base.min}-${w.base.max} (${baseRate}/s)` : 'n/a';
+  const base = w.base ? `${w.base.phys.min}-${w.base.phys.max} (${baseRate}/s)` : 'n/a';
   const reqs = w.reqs ? `Realm ${w.reqs.realmMin}, Proficiency ${w.reqs.proficiencyMin}` : 'None';
   const quality = w.quality ?? 'basic';
   const mods = (w.modifiers || []).map(k => MODIFIERS[k]?.desc || k);

--- a/src/features/weaponGeneration/data/weapons.js
+++ b/src/features/weaponGeneration/data/weapons.js
@@ -39,7 +39,11 @@ function toLegacy(key, item){
     rarity: item.rarity,
     slot: 'mainhand',
     typeKey: item.typeKey,
-    base: { min: item.base.min, max: item.base.max, attackRate: item.base.rate },
+    base: {
+      phys: { min: item.base.phys.min, max: item.base.phys.max },
+      rate: item.base.rate,
+      elems: { ...item.base.elems }
+    },
     tags: [...item.tags],
     reqs: { realmMin: 1, proficiencyMin: 0 },
     proficiencyKey: item.typeKey,
@@ -57,7 +61,7 @@ const FIST = {
   modifiers: [],
   rarity: 'normal',
   slot: 'mainhand',
-  base: { min: 1, max: 3, attackRate: 1.0 },
+  base: { phys: { min: 1, max: 3 }, rate: 1.0, elems: {} },
   tags: ['melee'],
   reqs: { realmMin: 0, proficiencyMin: 0 },
   proficiencyKey: 'fist',
@@ -96,7 +100,7 @@ export const WEAPONS = {
   tameNunchaku: toLegacy('tameNunchaku', generateWeapon({ typeKey: 'tameNunchaku', materialKey: 'spiritwood', qualityKey: 'basic' })),
 };
 
-const FIST_BASE_MAX = FIST.base.max;
+const FIST_BASE_MAX = FIST.base.phys.max;
 export const WEAPON_FLAGS = Object.fromEntries(
   Object.keys(WEAPONS).map(key => [key, true])
 );
@@ -105,7 +109,7 @@ export const WEAPON_CONFIG = Object.fromEntries(
   Object.entries(WEAPONS).map(([key, weapon]) => [
     key,
     {
-      damageMultiplier: (weapon.base?.max ?? FIST_BASE_MAX) / FIST_BASE_MAX,
+      damageMultiplier: (weapon.base?.phys.max ?? FIST_BASE_MAX) / FIST_BASE_MAX,
       proficiencyBase: 0,
     },
   ])

--- a/src/features/weaponGeneration/logic.js
+++ b/src/features/weaponGeneration/logic.js
@@ -16,12 +16,17 @@ import { MODIFIERS, MODIFIER_POOLS } from '../gearGeneration/data/modifiers.js';
  *  name:string,
  *  typeKey:string,
  *  materialKey?:string,
- *  base:{min:number,max:number,rate:number},
+ *  base:{
+ *    phys:{min:number,max:number},
+ *    rate:number,
+ *    elems:Record<string,{min:number,max:number}>
+ *  },
  *  tags:('physical')[]|[],
  *  abilityKeys:string[],
  *  quality:string,
  *  modifiers:string[],
- *  stats?:Record<string,number>
+ *  stats?:Record<string,number>,
+ *  imbuement?:{element:string,tier:number}
  * }} WeaponItem */
 
 /** Compose final item. Minimal quality/affix support. */
@@ -41,9 +46,12 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', sta
   const name = composeName({ typeName: type.displayName, materialName: material?.displayName });
 
   const base = {
-    min: Math.round(type.base.min * qualityMult * stageMult * imbMult),
-    max: Math.round(type.base.max * qualityMult * stageMult * imbMult),
+    phys: {
+      min: Math.round(type.base.min * qualityMult * stageMult * imbMult),
+      max: Math.round(type.base.max * qualityMult * stageMult * imbMult),
+    },
     rate: type.base.rate,
+    elems: {},
   };
 
   const stats = type.implicitStats
@@ -100,8 +108,8 @@ function applyWeaponModifiers(target, mods) {
     const val = 1 + totals[lane];
     switch (lane) {
       case 'damage':
-        target.base.min = Math.round(target.base.min * val);
-        target.base.max = Math.round(target.base.max * val);
+        target.base.phys.min = Math.round(target.base.phys.min * val);
+        target.base.phys.max = Math.round(target.base.phys.max * val);
         break;
     }
   }


### PR DESCRIPTION
## Summary
- differentiate weapon physical and elemental base damage
- adapt abilities, UI, and weapon data to the new base structure

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b66205327883269c6770be2c504cc8