### PR TITLE
Display proficiency for all weapon classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,10 +650,7 @@
             
             <!-- Proficiencies Tab -->
             <div id="proficienciesTab" class="adventure-tab-content tab-content" style="display: none;">
-              <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
-              <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
-              <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>
-              <div class="stat"><span>Bonus</span><span id="weaponBonus">1.00</span></div>
+              <div id="weaponProficiencyList"></div>
             </div>
           </div>
         </div>

--- a/src/features/proficiency/ui/weaponProficiencyDisplay.js
+++ b/src/features/proficiency/ui/weaponProficiencyDisplay.js
@@ -1,34 +1,58 @@
 import { S } from "../../../shared/state.js";
 import { on } from "../../../shared/events.js";
-import { getEquippedWeapon } from "../../inventory/selectors.js";
 import { getProficiency } from "../selectors.js";
 import { WEAPON_TYPES } from "../../weaponGeneration/data/weaponTypes.js";
 import { WEAPON_ICONS } from "../../weaponGeneration/data/weaponIcons.js";
+import { WEAPONS } from "../../weaponGeneration/data/weapons.js";
 import { setText, setFill } from "../../../shared/utils/dom.js";
 
+// Proficiency is tracked per weapon class (e.g., 'nunchaku'), not per individual item
+const PROFICIENCY_CLASSES = Array.from(
+  new Set(Object.values(WEAPONS).map(w => w.proficiencyKey))
+);
+
+function formatLabel(key) {
+  const type = WEAPON_TYPES[key];
+  if (type?.displayName) return type.displayName;
+  return key.replace(/([A-Z])/g, ' $1').replace(/^./, c => c.toUpperCase());
+}
+
 export function updateWeaponProficiencyDisplay(state = S) {
-  const weapon = getEquippedWeapon(state);
-  const { value } = getProficiency(weapon.proficiencyKey, state);
-  const level = Math.floor(value / 100);
-  const progress = value % 100;
-  const type = WEAPON_TYPES[weapon.proficiencyKey];
-  let label = type?.displayName || weapon.proficiencyKey;
-  if (!label.endsWith('s')) label += 's';
-  const icon = WEAPON_ICONS[weapon.proficiencyKey];
-  const labelEl = document.getElementById('weaponLabel');
-  if (labelEl) {
-    const text = `${label} Level`;
-    labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
+  for (const key of PROFICIENCY_CLASSES) {
+    const { value } = getProficiency(key, state);
+    const level = Math.floor(value / 100);
+    const progress = value % 100;
+    const label = formatLabel(key);
+    const icon = WEAPON_ICONS[key];
+    const labelEl = document.getElementById(`weaponLabel-${key}`);
+    if (labelEl) {
+      const text = `${label} Level`;
+      labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
+    }
+    setText(`weaponLevel-${key}`, level);
+    setText(`weaponExp-${key}`, progress.toFixed(0));
+    setText(`weaponExpMax-${key}`, '100');
+    setFill(`weaponExpFill-${key}`, progress / 100);
+    const bonus = 1 + level * 0.01;
+    setText(`weaponBonus-${key}`, bonus.toFixed(2));
   }
-  setText('weaponLevel', level);
-  setText('weaponExp', progress.toFixed(0));
-  setText('weaponExpMax', '100');
-  setFill('weaponExpFill', progress / 100);
-  const bonus = 1 + level * 0.01;
-  setText('weaponBonus', bonus.toFixed(2));
 }
 
 export function mountProficiencyUI(state) {
+  const container = document.getElementById('weaponProficiencyList');
+  if (container) {
+    for (const key of PROFICIENCY_CLASSES) {
+      const row = document.createElement('div');
+      row.className = 'weapon-proficiency';
+      row.innerHTML = `
+        <div class="stat"><span id="weaponLabel-${key}"></span><span id="weaponLevel-${key}">0</span></div>
+        <div class="stat"><span>Experience</span><span id="weaponExp-${key}">0</span> / <span id="weaponExpMax-${key}">100</span></div>
+        <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill-${key}"></div></div>
+        <div class="stat"><span>Bonus</span><span id="weaponBonus-${key}">1.00</span></div>
+      `;
+      container.appendChild(row);
+    }
+  }
   function render() {
     updateWeaponProficiencyDisplay(state);
   }

--- a/src/features/weaponGeneration/data/weaponIcons.js
+++ b/src/features/weaponGeneration/data/weaponIcons.js
@@ -9,6 +9,7 @@ export const WEAPON_ICONS = {
   dimFocus: 'ri:focus-line',
   starFocus: 'ri:focus-line',
   crudeKnuckles: 'game-icons:knuckles',
+  nunchaku: 'game-icons:nunchaku',
   crudeNunchaku: 'game-icons:nunchaku',
   tameNunchaku: 'game-icons:nunchaku',
   fist: 'game-icons:fist',

--- a/src/features/weaponGeneration/data/weapons.js
+++ b/src/features/weaponGeneration/data/weapons.js
@@ -30,7 +30,13 @@ function defaultAnimationsForType(typeKey) {
   }
 }
 
+const PROFICIENCY_OVERRIDES = {
+  crudeNunchaku: 'nunchaku',
+  tameNunchaku: 'nunchaku',
+};
+
 function toLegacy(key, item){
+  const proficiencyKey = PROFICIENCY_OVERRIDES[item.typeKey] || item.typeKey;
   return {
     key,
     displayName: item.name,
@@ -42,7 +48,7 @@ function toLegacy(key, item){
     base: { min: item.base.min, max: item.base.max, attackRate: item.base.rate },
     tags: [...item.tags],
     reqs: { realmMin: 1, proficiencyMin: 0 },
-    proficiencyKey: item.typeKey,
+    proficiencyKey,
     abilityKeys: [...item.abilityKeys],
     stats: item.stats ? { ...item.stats } : undefined,
     animations: defaultAnimationsForType(item.typeKey),


### PR DESCRIPTION
## Summary
- Group weapon proficiency by class (e.g., nunchaku) instead of individual weapon items
- Render proficiency rows for each weapon class with icons and proper labels
- Add shared nunchaku proficiency and icon

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b65ad6783883268c8bfeab940361b7