### PR TITLE
Classify stackables as materials

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -673,14 +673,14 @@ function defeatEnemy() {
   const area = zone?.areas?.[S.adventure.currentArea];
   const lootEntries = enemy.loot ? Object.entries(enemy.loot) : [];
   lootEntries.forEach(([item, qty]) => {
-    addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'mat', qty, source: area?.name });
+    addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'material', qty, source: area?.name });
   });
 
   if (enemy.drops) {
     const dropMult = 1 + (S.gearBonuses?.dropRateMult || 0);
     Object.entries(enemy.drops).forEach(([item, chance]) => {
       if (Math.random() < Math.min(1, chance * dropMult)) {
-        addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'mat', qty: 1, source: area?.name });
+        addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'material', qty: 1, source: area?.name });
         lootEntries.push([item, 1]);
       }
     });
@@ -690,7 +690,7 @@ function defeatEnemy() {
     const tableKey = toLootTableKey(area?.id || zone?.id);
     const drop = rollLoot(tableKey);
     if (drop) {
-      addSessionLoot({ key: drop, type: WEAPONS[drop] ? 'weapon' : 'mat', qty: 1, source: area?.name });
+      addSessionLoot({ key: drop, type: WEAPONS[drop] ? 'weapon' : 'material', qty: 1, source: area?.name });
       lootEntries.push([drop, 1]);
     }
 

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -321,7 +321,7 @@ function renderInventory({ dismissTooltip = false } = {}) {
   const list = document.getElementById('inventoryList');
   if (!list) return;
   list.innerHTML = '';
-  const items = (S.inventory || []).filter(it => it.type !== 'mat' && (currentFilter === 'all' || it.type === currentFilter));
+  const items = (S.inventory || []).filter(it => it.type !== 'material' && (currentFilter === 'all' || it.type === currentFilter));
   items.forEach(it => list.appendChild(createInventoryRow(it)));
   const filterBtns = document.querySelectorAll('#inventoryFilters button');
   filterBtns.forEach(btn => {
@@ -334,7 +334,7 @@ function renderMaterials() {
   const list = document.getElementById('materialsList');
   if (!list) return;
   list.innerHTML = '';
-  const mats = (S.inventory || []).filter(it => it.type === 'mat');
+  const mats = (S.inventory || []).filter(it => it.type === 'material');
   mats.forEach(it => {
     const row = createInventoryRow(it);
     row.classList.remove('muted');

--- a/src/features/loot/mutators.js
+++ b/src/features/loot/mutators.js
@@ -2,7 +2,7 @@ import { S, save } from '../../shared/state.js';
 import { addToInventory } from '../inventory/mutators.js';
 
 // Item types that should be consolidated in the session loot list
-const STACKABLE_TYPES = new Set(['mat']);
+const STACKABLE_TYPES = new Set(['material']);
 
 // EQUIP-CHAR-UI: session loot helpers
 export function addSessionLoot(item, state = S) {
@@ -30,8 +30,12 @@ export function claimSessionLoot(state = S) {
   state.sessionLoot = state.sessionLoot || [];
   const count = state.sessionLoot.length;
   state.sessionLoot.forEach(item => {
-    if (item.type === 'mat') {
-      state[item.key] = (state[item.key] || 0) + (item.qty || 1);
+    if (item.type === 'material') {
+      if (Object.prototype.hasOwnProperty.call(state, item.key)) {
+        state[item.key] = (state[item.key] || 0) + (item.qty || 1);
+      } else {
+        addToInventory(item);
+      }
     } else {
       addToInventory(item);
     }


### PR DESCRIPTION
## Summary
- Treat stackable loot items as `material`
- Render material items in their own character panel card
- Track unconfigured materials in the main inventory

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f0dc72d4832681fc5e8742850f31