### PR TITLE
Fix forge item labels and migrate missing names

### DIFF
--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -2,6 +2,18 @@ import { S } from '../../../shared/state.js';
 import { setText } from '../../../shared/utils/dom.js';
 import { on } from '../../../shared/events.js';
 import { startForging } from '../mutators.js';
+import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
+import { GEAR_BASES } from '../../gearGeneration/data/gearBases.js';
+
+function displayName(it) {
+  if (!it) return '';
+  return (
+    it.name ||
+    WEAPONS[it.key]?.displayName ||
+    GEAR_BASES[it.key]?.displayName ||
+    it.id
+  );
+}
 
 function updateForgingActivity(state = S) {
   if (!state.forging) return;
@@ -30,7 +42,7 @@ function updateForgeInventory(state = S) {
     .forEach(it => {
       const card = document.createElement('div');
       card.className = 'forge-item-card';
-      card.textContent = it.name || it.id;
+      card.textContent = displayName(it);
       if (String(state.forging.slot) === String(it.id)) card.classList.add('selected');
       card.onclick = () => {
         state.forging.slot = it.id;
@@ -54,7 +66,7 @@ function updateForgeSlot(state = S) {
     return;
   }
   const item = state.inventory?.find(it => String(it.id) === String(state.forging.slot));
-  slot.textContent = item?.name || item?.id;
+  slot.textContent = displayName(item);
   opts.innerHTML = '';
   const tier = item?.tier || 0;
   const woodCost = (tier + 1) * 10;

--- a/src/features/inventory/migrations.js
+++ b/src/features/inventory/migrations.js
@@ -1,3 +1,6 @@
+import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { GEAR_BASES } from '../gearGeneration/data/gearBases.js';
+
 export const migrations = [
   save => {
     if(!save.inventory){
@@ -71,5 +74,40 @@ export const migrations = [
   save => {
     if (typeof save.coin === 'undefined') save.coin = 0;
     if (!Array.isArray(save.junk)) save.junk = [];
+  },
+  save => {
+    if (!Array.isArray(save.inventory)) save.inventory = [];
+    save.inventory.forEach(it => {
+      if (it && typeof it === 'object' && !it.name && it.key) {
+        it.name =
+          WEAPONS[it.key]?.displayName ||
+          GEAR_BASES[it.key]?.displayName ||
+          it.key;
+      }
+    });
+    if (save.equipment && typeof save.equipment === 'object') {
+      Object.values(save.equipment).forEach(it => {
+        if (it && typeof it === 'object' && !it.name && it.key) {
+          it.name =
+            WEAPONS[it.key]?.displayName ||
+            GEAR_BASES[it.key]?.displayName ||
+            it.key;
+        }
+      });
+    }
+    const hasPalmWraps = save.inventory.some(it =>
+      typeof it === 'string' ? it === 'palmWraps' : it.key === 'palmWraps'
+    );
+    const equippedPalm =
+      typeof save.equipment?.mainhand === 'object' &&
+      save.equipment.mainhand?.key === 'palmWraps';
+    if (!hasPalmWraps && !equippedPalm) {
+      save.inventory.push({
+        id: Date.now() + Math.random(),
+        key: 'palmWraps',
+        name: 'Palm Wraps',
+        type: 'weapon'
+      });
+    }
   }
 ];


### PR DESCRIPTION
## Summary
- Show weapon/gear display names in the forge UI instead of raw IDs
- Add migration to backfill item names and restore lost Palm Wraps

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f1133fdc83268c2d26f51b705a0d