### PR TITLE
fix: allow equipping foot gear

### DIFF
--- a/src/features/gearGeneration/data/gearBases.js
+++ b/src/features/gearGeneration/data/gearBases.js
@@ -51,14 +51,14 @@ export const GEAR_BASES = {
   iron_boots: {
     key: 'iron_boots',
     displayName: 'Iron Boots',
-    slot: 'feet',
+    slot: 'foot',
     guardType: 'armor',
     baseProtection: { armor: 15 },
   },
   leather_boots: {
     key: 'leather_boots',
     displayName: 'Leather Boots',
-    slot: 'feet',
+    slot: 'foot',
     guardType: 'dodge',
     baseProtection: { dodge: 10 },
     baseOffense: { accuracy: 5 },
@@ -66,7 +66,7 @@ export const GEAR_BASES = {
   cotton_sandals: {
     key: 'cotton_sandals',
     displayName: 'Cotton Sandals',
-    slot: 'feet',
+    slot: 'foot',
     guardType: 'qiShield',
     baseProtection: { qiShield: 20 },
   },

--- a/src/features/gearGeneration/logic.js
+++ b/src/features/gearGeneration/logic.js
@@ -32,10 +32,15 @@ export function generateGear({ baseKey, materialKey, qualityKey = 'basic', stage
   const mods = rollModifiers('armor', rarity);
   applyGearModifiers({ protection, offense }, mods);
 
+  // Map the base slot to the item type/equipment slot. Foot gear should use
+  // the dedicated "foot" type/slot rather than being treated as armor.
+  const slot = base.slot === 'feet' ? 'foot' : base.slot;
+  const type = slot === 'foot' ? 'foot' : 'armor';
+
   return {
     key: base.key,
-    type: 'armor',
-    slot: base.slot,
+    type,
+    slot,
     name,
     guardType: base.guardType,
     protection,


### PR DESCRIPTION
## Summary
- treat boots as `foot` type gear and map to the foot slot
- define foot gear bases with correct `foot` slot

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)


------
https://chatgpt.com/codex/tasks/task_e_68b6f12a0c108326b2eeae9d56f82d98