### PR TITLE
Support multi-element weapon abilities

### DIFF
--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -1,6 +1,21 @@
 import { getEquippedWeapon } from '../inventory/selectors.js';
 import { S } from '../../shared/state.js';
 
+function buildWeaponAttacks(weapon, mult, target) {
+  const attacks = [];
+  const physRoll = Math.floor(
+    Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)
+  ) + weapon.base.phys.min;
+  attacks.push({ amount: Math.round(mult * physRoll), type: 'physical', target });
+  for (const [elem, range] of Object.entries(weapon.base.elems || {})) {
+    const elemRoll = Math.floor(Math.random() * (range.max - range.min + 1)) + range.min;
+    if (elemRoll > 0) {
+      attacks.push({ amount: Math.round(mult * elemRoll), type: elem, target });
+    }
+  }
+  return attacks;
+}
+
 export function resolveAbilityHit(abilityKey, state) {
   switch (abilityKey) {
     case 'powerSlash':
@@ -22,19 +37,18 @@ export function resolveAbilityHit(abilityKey, state) {
 
 function resolveFlowingPalm(state) {
   const weapon = getEquippedWeapon(state);
-  const roll = Math.floor(Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)) + weapon.base.phys.min;
+  const attacks = buildWeaponAttacks(weapon, 1, state.adventure.currentEnemy);
   return {
-    attack: { amount: roll, type: 'physical', target: state.adventure.currentEnemy },
+    attacks,
     stun: { mult: 2 },
   };
 }
 
 function resolvePowerSlash(state) {
   const weapon = getEquippedWeapon(state);
-  const roll = Math.floor(Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)) + weapon.base.phys.min;
-  const raw = Math.round(1.3 * roll);
+  const attacks = buildWeaponAttacks(weapon, 1.3, state.adventure.currentEnemy);
   return {
-    attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
+    attacks,
     healOnHit: 5,
   };
 }
@@ -43,17 +57,16 @@ function resolveFireball(state) {
   const level = S.mind?.manualProgress?.fireballManual?.level || 0;
   const damage = 40 + level * 20;
   return {
-    attack: { amount: damage, type: 'fire', target: state.adventure.currentEnemy },
+    attacks: [{ amount: damage, type: 'fire', target: state.adventure.currentEnemy }],
 
    };
 }
 
 function resolvePalmStrike(state) {
   const weapon = getEquippedWeapon(state);
-  const roll = Math.floor(Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)) + weapon.base.phys.min;
-  const raw = Math.round(roll);
+  const attacks = buildWeaponAttacks(weapon, 1, state.adventure.currentEnemy);
   return {
-    attack: { amount: raw, type: 'physical', target: state.adventure.currentEnemy },
+    attacks,
   };
 }
 

--- a/src/features/ability/selectors.js
+++ b/src/features/ability/selectors.js
@@ -43,9 +43,9 @@ export function getAbilityDamage(abilityKey, state = S) {
   const ability = ABILITIES[abilityKey];
   if (!ability) return null;
   const res = resolveAbilityHit(abilityKey, state);
-  const attack = res?.attack;
-  if (!attack) return null;
-  let amount = attack.amount;
+  const attacks = res?.attacks || (res?.attack ? [res.attack] : []);
+  if (!attacks.length) return null;
+  let amount = attacks.reduce((sum, a) => sum + a.amount, 0);
   const mods = state.abilityMods?.[abilityKey] || {};
   if (mods.damagePct) amount = Math.round(amount * (1 + mods.damagePct / 100));
   if (ability.tags?.includes('spell')) {


### PR DESCRIPTION
## Summary
- Allow weapon abilities to roll elemental damage for each element on the weapon
- Process multiple attack rolls per ability and aggregate damage
- Include elemental damage in ability damage previews

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b71e8aebd48326a7f1070d382cbb6a