### PR TITLE
Display proficiency for all weapons

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,10 +650,7 @@
             
             <!-- Proficiencies Tab -->
             <div id="proficienciesTab" class="adventure-tab-content tab-content" style="display: none;">
-              <div class="stat"><span id="weaponLabel">Fists Level</span><span id="weaponLevel">1</span></div>
-              <div class="stat"><span>Experience</span><span id="weaponExp">0</span> / <span id="weaponExpMax">100</span></div>
-              <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill"></div></div>
-              <div class="stat"><span>Bonus</span><span id="weaponBonus">1.00</span></div>
+              <div id="weaponProficiencyList"></div>
             </div>
           </div>
         </div>

--- a/src/features/proficiency/ui/weaponProficiencyDisplay.js
+++ b/src/features/proficiency/ui/weaponProficiencyDisplay.js
@@ -1,34 +1,51 @@
 import { S } from "../../../shared/state.js";
 import { on } from "../../../shared/events.js";
-import { getEquippedWeapon } from "../../inventory/selectors.js";
 import { getProficiency } from "../selectors.js";
 import { WEAPON_TYPES } from "../../weaponGeneration/data/weaponTypes.js";
 import { WEAPON_ICONS } from "../../weaponGeneration/data/weaponIcons.js";
+import { WEAPONS } from "../../weaponGeneration/data/weapons.js";
 import { setText, setFill } from "../../../shared/utils/dom.js";
 
+const PROFICIENCY_KEYS = Array.from(new Set(Object.values(WEAPONS).map(w => w.proficiencyKey)));
+
 export function updateWeaponProficiencyDisplay(state = S) {
-  const weapon = getEquippedWeapon(state);
-  const { value } = getProficiency(weapon.proficiencyKey, state);
-  const level = Math.floor(value / 100);
-  const progress = value % 100;
-  const type = WEAPON_TYPES[weapon.proficiencyKey];
-  let label = type?.displayName || weapon.proficiencyKey;
-  if (!label.endsWith('s')) label += 's';
-  const icon = WEAPON_ICONS[weapon.proficiencyKey];
-  const labelEl = document.getElementById('weaponLabel');
-  if (labelEl) {
-    const text = `${label} Level`;
-    labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
+  for (const key of PROFICIENCY_KEYS) {
+    const { value } = getProficiency(key, state);
+    const level = Math.floor(value / 100);
+    const progress = value % 100;
+    const type = WEAPON_TYPES[key];
+    let label = type?.displayName || key;
+    if (!label.endsWith('s')) label += 's';
+    const icon = WEAPON_ICONS[key];
+    const labelEl = document.getElementById(`weaponLabel-${key}`);
+    if (labelEl) {
+      const text = `${label} Level`;
+      labelEl.innerHTML = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${text}` : text;
+    }
+    setText(`weaponLevel-${key}`, level);
+    setText(`weaponExp-${key}`, progress.toFixed(0));
+    setText(`weaponExpMax-${key}`, '100');
+    setFill(`weaponExpFill-${key}`, progress / 100);
+    const bonus = 1 + level * 0.01;
+    setText(`weaponBonus-${key}`, bonus.toFixed(2));
   }
-  setText('weaponLevel', level);
-  setText('weaponExp', progress.toFixed(0));
-  setText('weaponExpMax', '100');
-  setFill('weaponExpFill', progress / 100);
-  const bonus = 1 + level * 0.01;
-  setText('weaponBonus', bonus.toFixed(2));
 }
 
 export function mountProficiencyUI(state) {
+  const container = document.getElementById('weaponProficiencyList');
+  if (container) {
+    for (const key of PROFICIENCY_KEYS) {
+      const row = document.createElement('div');
+      row.className = 'weapon-proficiency';
+      row.innerHTML = `
+        <div class="stat"><span id="weaponLabel-${key}"></span><span id="weaponLevel-${key}">0</span></div>
+        <div class="stat"><span>Experience</span><span id="weaponExp-${key}">0</span> / <span id="weaponExpMax-${key}">100</span></div>
+        <div class="activity-progress-bar"><div class="progress-fill" id="weaponExpFill-${key}"></div></div>
+        <div class="stat"><span>Bonus</span><span id="weaponBonus-${key}">1.00</span></div>
+      `;
+      container.appendChild(row);
+    }
+  }
   function render() {
     updateWeaponProficiencyDisplay(state);
   }


### PR DESCRIPTION
## Summary
- Show proficiency levels for all weapons in proficiency tab
- Generate proficiency rows dynamically from weapon data

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b65ad6783883268c8bfeab940361b7