### PR TITLE
Redesign gear and weapon tooltips

### DIFF
--- a/style.css
+++ b/style.css
@@ -4724,6 +4724,55 @@ html.reduce-motion .log-sheet{transition:none;}
   cursor:pointer;
 }
 
+.item-tooltip{
+  width:340px;
+  max-width:360px;
+  padding:12px;
+  line-height:1.33;
+  font-size:13px;
+  background:rgba(32,28,24,0.93);
+  color:#f8f8f8;
+  border:1px solid rgba(255,255,255,0.1);
+  border-radius:8px;
+  white-space:normal;
+  box-shadow:0 2px 6px rgba(0,0,0,0.5),0 0 6px rgba(255,255,255,0.1);
+}
+
+.item-tooltip .tooltip-header{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  font-size:16px;
+}
+
+.item-tooltip .tooltip-name{
+  font-weight:bold;
+  flex:1;
+}
+
+.item-tooltip .quality-stars{
+  margin-left:auto;
+  color:#ffd700;
+}
+
+.item-tooltip .core-stats{margin-top:4px;}
+.item-tooltip .stat-row{display:flex;justify-content:space-between;margin-top:2px;}
+.item-tooltip .stat-row.dps .stat-value{font-size:17px;}
+.item-tooltip .stat-label{display:flex;align-items:center;gap:2px;}
+.item-tooltip .stat-value{text-align:right;}
+
+.item-tooltip .core-line{display:grid;grid-template-columns:auto 1fr auto 1fr;column-gap:4px;margin-top:2px;}
+.item-tooltip .core-line .stat-value{text-align:right;}
+
+.item-tooltip .imbue-row{margin-top:4px;}
+.item-tooltip .imbue-icon{margin:0 4px;}
+
+.item-tooltip .mods-block{border-top:1px solid rgba(59,130,246,0.4);margin-top:6px;padding-top:6px;}
+.item-tooltip .mod-chip{display:inline-block;background:rgba(59,130,246,0.15);border:1px solid rgba(59,130,246,0.4);border-radius:4px;padding:2px 4px;margin:2px 4px 0 0;font-size:12px;}
+
+.item-tooltip .tooltip-footer{margin-top:6px;font-size:12px;color:#ccc;}
+.item-tooltip .tooltip-footer div{margin-top:2px;}
+
 /* Sequence memory puzzle */
 .sequence-memory-card .memory-runes{
   display:flex;


### PR DESCRIPTION
## Summary
- Implement structured HTML tooltips for gear and weapons including header icon, DPS, damage/speed stats, imbue glyph, modifiers chips, and footer requirements/tags
- Add element glyph and color maps with styling for dark translucent panels, right-aligned numbers, and quality stars

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b71e590cfc83269c75566a18a2c4b4