### PR TITLE
Refine weapon proficiency bonuses into multipliers

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -735,7 +735,7 @@ function updateAll() {
 **Purpose**: Read-only helpers to derive proficiency data and bonuses.
 **Key Functions**:
 - `getProficiency(key, state)` – get stored proficiency and bonus.
-- `getWeaponProficiencyBonuses(state)` – compute damage and speed bonuses for the equipped weapon.
+- `getWeaponProficiencyBonuses(state)` – compute damage and speed multipliers for the equipped weapon.
 
 #### `src/features/proficiency/ui/weaponProficiencyDisplay.js` - Proficiency HUD
 **Purpose**: Updates HUD elements showing weapon proficiency levels and progress.

--- a/src/features/proficiency/selectors.js
+++ b/src/features/proficiency/selectors.js
@@ -15,5 +15,5 @@ export function getWeaponProficiencyBonuses(state = proficiencyState) {
   const weapon = WEAPONS[key] || WEAPONS.fist;
   const { value } = getProficiency(weapon.classKey, state);
   const level = Math.floor(value / 100);
-  return { damage: level, speed: level * 0.01 };
+  return { damageMult: 1 + level * 0.02, speedMult: 1 + level * 0.01 };
 }

--- a/src/features/proficiency/ui/weaponProficiencyDisplay.js
+++ b/src/features/proficiency/ui/weaponProficiencyDisplay.js
@@ -24,8 +24,9 @@ export function updateWeaponProficiencyDisplay(state = S) {
   setText('weaponExp', progress.toFixed(0));
   setText('weaponExpMax', '100');
   setFill('weaponExpFill', progress / 100);
-  const bonus = 1 + level * 0.01;
-  setText('weaponBonus', bonus.toFixed(2));
+  const damageMult = 1 + level * 0.02;
+  const speedMult = 1 + level * 0.01;
+  setText('weaponBonus', `DMG x${damageMult.toFixed(2)}, SPD x${speedMult.toFixed(2)}`);
 }
 
 export function mountProficiencyUI(state) {

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -113,12 +113,12 @@ export function calcAtk(state = progressionState){
   const baseAtk = Number(realm.atk) || 0;
   const stageBonus = Math.floor(baseAtk * (stage - 1) * 0.08);
   const lawBonuses = getLawBonuses(state);
-  const profBonus = Number(getWeaponProficiencyBonuses(state).damage) || 0;
+  const profMult = Number(getWeaponProficiencyBonuses(state).damageMult) || 1;
   const building = Number(getBuildingBonuses(state).atkBase) || 0;
   const base = Number(state.atkBase) || 0;
   const temp = Number(state.tempAtk) || 0;
   const karma = Number(karmaAtkBonus(state)) || 0;
-  return Math.floor((base + building + profBonus + temp + baseAtk + stageBonus + karma) * (lawBonuses.atk || 1));
+  return Math.floor((base + building + temp + baseAtk + stageBonus + karma) * profMult * (lawBonuses.atk || 1));
 }
 
 export function calcArmor(state = progressionState){
@@ -171,17 +171,17 @@ export function calculatePlayerCombatAttack(state = progressionState) {
   const tier = state?.realm?.tier ?? 0;
   const stage = Number(state?.realm?.stage) || 0;
   const realmAtk = Number(REALMS[tier]?.atk) || 0;
-  const profBonus = Number(getWeaponProficiencyBonuses(state).damage) || 0;
-  return baseAttack + profBonus + realmAtk * stage;
+  const dmgMult = Number(getWeaponProficiencyBonuses(state).damageMult) || 1;
+  return (baseAttack + realmAtk * stage) * dmgMult;
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {
   const baseRate = 1.0;
   const dex = Number(state.stats?.dexterity) || 10;
   const attackSpeedBonus = Number(state.stats?.attackSpeed) || 0;
-  const profBonus = Number(getWeaponProficiencyBonuses(state).speed) || 0;
+  const speedMult = Number(getWeaponProficiencyBonuses(state).speedMult) || 1;
   const dexterityBonus = (dex - 10) * 0.05;
-  return baseRate + dexterityBonus + attackSpeedBonus / 100 + profBonus;
+  return (baseRate + dexterityBonus + attackSpeedBonus / 100) * speedMult;
 }
 
 export function breakthroughChance(state = progressionState){


### PR DESCRIPTION
## Summary
- Return damage and speed multipliers from `getWeaponProficiencyBonuses`
- Apply weapon proficiency multipliers in attack and attack-rate calculations
- Show damage/speed multipliers in weapon proficiency UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and DOM usage warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b76cd3aecc8326bebf61ac903839a9