### PR TITLE
feat(combat): add ailments registry

### DIFF
--- a/src/features/combat/data/ailments.js
+++ b/src/features/combat/data/ailments.js
@@ -1,0 +1,77 @@
+/** @typedef {{
+ *  key: string,
+ *  element: string|null,
+ *  baseDurationSec: number,
+ *  maxStacks: number,
+ *  tickRate: number,
+ *  scaleStat?: string,
+ *  scaleFactor?: number,
+ *  onApply?: (ctx: any) => void,
+ *  onExpire?: (ctx: any) => void,
+ * }} AilmentDef */
+
+/** @type {Record<string, AilmentDef>} */
+export const AILMENTS = {
+  poison: {
+    key: 'poison',
+    element: 'wood',
+    baseDurationSec: 6,
+    maxStacks: 20,
+    tickRate: 1,
+    scaleStat: 'mind',
+  },
+  burn: {
+    key: 'burn',
+    element: 'fire',
+    baseDurationSec: 4,
+    maxStacks: 1,
+    tickRate: 1,
+    scaleStat: 'mind',
+  },
+  chill: {
+    key: 'chill',
+    element: 'water',
+    baseDurationSec: 8,
+    maxStacks: 5,
+    tickRate: 0,
+    scaleStat: 'mind',
+    onApply: ({ target, stack }) => {
+      if (stack >= 5 && target) target.frozen = true;
+    },
+    onExpire: ({ target }) => {
+      if (target) target.frozen = false;
+    },
+  },
+  entomb: {
+    key: 'entomb',
+    element: 'earth',
+    baseDurationSec: 5,
+    maxStacks: 1,
+    tickRate: 0,
+    onApply: ({ target }) => {
+      if (target) target.immobilized = true;
+    },
+    onExpire: ({ target }) => {
+      if (target) target.immobilized = false;
+    },
+  },
+  ionize: {
+    key: 'ionize',
+    element: 'metal',
+    baseDurationSec: 5,
+    maxStacks: 1,
+    tickRate: 0,
+    onApply: ({ target }) => {
+      if (target) target.armorModifier = (target.armorModifier ?? 0) - 0.1;
+    },
+    onExpire: ({ target }) => {
+      if (target) target.armorModifier = (target.armorModifier ?? 0) + 0.1;
+    },
+  },
+};
+
+export const AILMENT_KEYS = Object.keys(AILMENTS);
+
+export function getAilment(key) {
+  return AILMENTS[key];
+}


### PR DESCRIPTION
## Summary
- add AILMENTS registry for common combat effects
- expose helper AILMENT_KEYS and getAilment

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b76f5cb2d4832692b12c3f8ef7a754