### PR TITLE
feat: add combat ailment utilities

### DIFF
--- a/src/features/combat/statusEngine.js
+++ b/src/features/combat/statusEngine.js
@@ -1,4 +1,5 @@
 import { STATUSES } from './data/status.js';
+import { AILMENTS } from './data/ailments.js';
 
 export function applyStatus(target, key, power, state, options = {}) { // STATUS-REFORM
   const def = STATUSES[key];
@@ -15,4 +16,31 @@ export function applyStatus(target, key, power, state, options = {}) { // STATUS
   duration *= 1 - (targetStats.ccResist || 0);
   current.duration = duration;
   target.statuses[key] = current;
+}
+
+export function applyAilment(attacker, target, key, power, nowMs) {
+  const def = AILMENTS[key];
+  if (!def || !target) return false;
+  const attackerStats = attacker?.stats || {};
+  const targetStats = target?.stats || {};
+  let finalChance = power;
+  finalChance *= 1 + (attackerStats.ailmentChancePct || 0) / 100;
+  finalChance *= 1 + (attackerStats[`${key}ChancePct`] || 0) / 100;
+  finalChance /= 1 + (targetStats.ailmentResistPct || 0) / 100;
+  finalChance /= 1 + (targetStats[`${key}ResistPct`] || 0) / 100;
+  if (Math.random() >= finalChance) return false;
+  if (!target.ailments) target.ailments = {};
+  const current = target.ailments[key] || { stacks: 0, expires: 0 };
+  current.stacks = Math.min(def.maxStacks ?? Infinity, current.stacks + 1);
+  current.expires = nowMs + def.baseDurationSec * 1000;
+  target.ailments[key] = current;
+  return true;
+}
+
+export function hasAilment(target, key) {
+  return !!target?.ailments?.[key];
+}
+
+export function clearAilment(target, key) {
+  if (target?.ailments) delete target.ailments[key];
 }


### PR DESCRIPTION
## Summary
- add applyAilment to compute and apply time-based status ailments
- expose helpers to query or clear ailments on combat targets

## Testing
- `npm test`
- `npm run validate` (fails: UNDOCUMENTED FILE: src/features/combat/data/ailments.js)


------
https://chatgpt.com/codex/tasks/task_e_68b771bd649c832686074c7ff97f9d2a