### PR TITLE
Convert imbuement base damage to element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Peaceful Lands, Forest Edge, and Meadow Path can now drop these sample weapons at low rates for testing.
 - Generalized weapon proficiency to all weapon types with enemy HP–based XP gains (max HP ÷ 30 per attack).
 - Each weapon level now grants +1 damage and +1% attack speed; 100 XP required per level.
+- Imbued weapon drops now convert their base damage to the imbued element, producing elemental attacks.

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -3,10 +3,18 @@ import { S } from '../../shared/state.js';
 
 function buildWeaponAttacks(weapon, mult, target) {
   const attacks = [];
-  const physRoll = Math.floor(
-    Math.random() * (weapon.base.phys.max - weapon.base.phys.min + 1)
-  ) + weapon.base.phys.min;
-  attacks.push({ amount: Math.round(mult * physRoll), type: 'physical', target });
+  const phys = weapon.base.phys || { min: 0, max: 0 };
+  if ((phys.max ?? 0) > 0 || (phys.min ?? 0) > 0) {
+    const physRoll =
+      Math.floor(Math.random() * (phys.max - phys.min + 1)) + phys.min;
+    if (physRoll > 0) {
+      attacks.push({
+        amount: Math.round(mult * physRoll),
+        type: 'physical',
+        target,
+      });
+    }
+  }
   for (const [elem, range] of Object.entries(weapon.base.elems || {})) {
     const elemRoll = Math.floor(Math.random() * (range.max - range.min + 1)) + range.min;
     if (elemRoll > 0) {

--- a/src/features/weaponGeneration/logic.js
+++ b/src/features/weaponGeneration/logic.js
@@ -64,6 +64,19 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', sta
   const mods = rollModifiers('weapon', rarity);
   applyWeaponModifiers({ base }, mods);
 
+  const tags = [...type.tags];
+  if (imbuement?.element) {
+    const elem = imbuement.element;
+    const existing = base.elems[elem] || { min: 0, max: 0 };
+    existing.min += base.phys.min;
+    existing.max += base.phys.max;
+    base.elems[elem] = existing;
+    base.phys = { min: 0, max: 0 };
+    const idx = tags.indexOf('physical');
+    if (idx !== -1) tags.splice(idx, 1);
+    if (!tags.includes(elem)) tags.push(elem);
+  }
+
   /** @type {WeaponItem} */
   return {
     name,
@@ -71,7 +84,7 @@ export function generateWeapon({ typeKey, materialKey, qualityKey = 'basic', sta
     classKey: type.classKey,
     materialKey: material?.key,
     base,
-    tags: [...type.tags],       // only 'physical' or []
+    tags,
     abilityKeys,                // e.g., ['powerSlash'] for swords
     quality: qualityKey,
     rarity,


### PR DESCRIPTION
## Summary
- imbued weapon drops now convert their physical base damage into their imbued element and adjust tags
- skip adding zero-value physical attacks so imbued weapons deal only elemental damage
- update changelog

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI and documentation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b771504a688326a5d41abd9bd3fd77