### PR TITLE
Add implicit weapon modifiers and tooltip support

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -47,6 +47,22 @@ const ELEMENT_COLORS = {
   fire: '#ff4500'
 };
 
+const IMPLICIT_STAT_LABELS = {
+  accuracy: 'Accuracy',
+  criticalChance: 'Critical Chance',
+  attackSpeed: 'Attack Speed',
+  stunBuildMult: 'Stun Strength',
+  stunDurationMult: 'Stun Duration',
+  mind: 'Mind',
+  qiCostPct: 'Qi Cost Reduction',
+  qiConversionPct: 'Qi Conversion',
+  comboDamagePct: 'Combo Multiplier',
+  ailmentChancePct: 'Ailment Chance',
+  repeatBasicChancePct: 'Repeat Attack Chance',
+  damageTransferPct: 'Damage Transfer',
+  physDamagePct: 'Physical Damage',
+};
+
 export function renderEquipmentPanel() {
   recomputePlayerTotals(S);
   renderEquipment();
@@ -149,6 +165,16 @@ function weaponDetailsHTML(item) {
   const imbColor = ELEMENT_COLORS[imbEl] || ELEMENT_COLORS.physical;
   const imbue = `<div class="tooltip-imbue"><span class="element-icon" style="color:${imbColor}">${imbIcon}</span> — T${imbTier}</div>`;
 
+  const pctStats = new Set(['criticalChance','attackSpeed','stunBuildMult','stunDurationMult','qiCostPct','qiConversionPct','comboDamagePct','ailmentChancePct','repeatBasicChancePct','damageTransferPct','physDamagePct']);
+  const implicitLines = w.stats
+    ? Object.entries(w.stats).map(([k,v]) => {
+        const label = IMPLICIT_STAT_LABELS[k] || k;
+        const val = pctStats.has(k) ? `${v >= 0 ? '+' : ''}${(v*100).toFixed(0)}%` : v;
+        return `<div class="stat-row"><span class="label">${label}</span><span class="value">${val}</span></div>`;
+      }).join('')
+    : '';
+  const implicitHtml = implicitLines ? `<div class="tooltip-implicit">${implicitLines}</div>` : '';
+
   const mods = (w.modifiers || []).map(k => MODIFIERS[k]?.desc || k);
   const modsHtml = mods.length ? `<div class="tooltip-mods">${mods.map(m => `<span class="mod-chip">${m}</span>`).join('')}</div>` : '';
 
@@ -157,7 +183,7 @@ function weaponDetailsHTML(item) {
   const tags = (w.tags || []).join(', ');
   const footer = `<div class="tooltip-footer"><div class="req">Req: Realm ${reqRealm} • Prof ${reqProf}</div>${tags ? `<div class="tags">Tags: ${tags}</div>` : ''}</div>`;
 
-  return header + core + imbue + modsHtml + footer;
+  return header + core + imbue + implicitHtml + modsHtml + footer;
 }
 
 function gearDetailsHTML(item) {

--- a/src/features/weaponGeneration/data/weaponTypes.js
+++ b/src/features/weaponGeneration/data/weaponTypes.js
@@ -53,7 +53,7 @@ export const WEAPON_TYPES = {
     slot: 'mainhand',
       base: { min: 5, max: 8, rate: 0.85 },
     tags: ['physical'],
-    implicitStats: { stunDurationMult: 0.1 },
+    implicitStats: { damageTransferPct: 0.1 },
   },
   crudeAxe: {
     key: 'crudeAxe',
@@ -62,7 +62,7 @@ export const WEAPON_TYPES = {
     slot: 'mainhand',
       base: { min: 6, max: 10, rate: 0.85 },
     tags: ['physical'],
-    implicitStats: { criticalChance: 0.03 },
+    implicitStats: { physDamagePct: 0.1 },
   },
   spear: {
     key: 'spear',
@@ -82,7 +82,7 @@ export const WEAPON_TYPES = {
       base: { min: 1, max: 3, rate: 1.1 },
     tags: [],
     signatureAbilityKey: 'mindSpike',
-    implicitStats: { mind: 2 },
+    implicitStats: { qiCostPct: -0.05 },
   },
   starFocus: {
     key: 'starFocus',
@@ -92,7 +92,7 @@ export const WEAPON_TYPES = {
       base: { min: 2, max: 4, rate: 1.15 },
     tags: [],
     signatureAbilityKey: 'mindSpike',
-    implicitStats: { mind: 3, criticalChance: 0.01 },
+    implicitStats: { qiConversionPct: 0.05 },
   },
   crudeKnuckles: {
     key: 'crudeKnuckles',
@@ -101,7 +101,7 @@ export const WEAPON_TYPES = {
     slot: 'mainhand',
       base: { min: 1, max: 3, rate: 1.2 },
     tags: ['physical'],
-    implicitStats: { stunBuildMult: 0.05 },
+    implicitStats: { comboDamagePct: 0.1 },
   },
   crudeNunchaku: {
     key: 'crudeNunchaku',
@@ -111,7 +111,7 @@ export const WEAPON_TYPES = {
       base: { min: 1, max: 3, rate: 1.5 },
     tags: ['physical'],
     signatureAbilityKey: 'flurryStrike',
-    implicitStats: { attackSpeed: 0.1 },
+    implicitStats: { ailmentChancePct: 0.1 },
   },
   tameNunchaku: {
     key: 'tameNunchaku',
@@ -121,6 +121,6 @@ export const WEAPON_TYPES = {
       base: { min: 2, max: 4, rate: 1.6 },
     tags: ['physical'],
     signatureAbilityKey: 'flurryStrike',
-    implicitStats: { attackSpeed: 0.15 },
+    implicitStats: { repeatBasicChancePct: 0.1 },
   },
 };

--- a/style.css
+++ b/style.css
@@ -4780,6 +4780,12 @@ html.reduce-motion .log-sheet{transition:none;}
   gap:4px;
 }
 
+.item-tooltip .tooltip-implicit{
+  border-top:1px solid rgba(255,255,255,0.1);
+  padding-top:4px;
+  margin-top:4px;
+}
+
 .item-tooltip .tooltip-mods{
   border-top:1px solid rgba(59,130,246,0.3);
   padding-top:4px;


### PR DESCRIPTION
## Summary
- define implicit modifiers for hammer, bludgeon, axe, focus, knuckles, and nunchaku weapon bases
- display implicit modifiers in weapon tooltips
- style implicit modifier section

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b776aecacc8326b64804c5af829afe