### PR TITLE
Add cast progress bar and block actions while casting

### DIFF
--- a/index.html
+++ b/index.html
@@ -581,9 +581,11 @@
                 </svg>
                 <div class="combatant player">
                   <div class="sprite player-sprite"></div>
+                  <div class="cast-bar" id="playerCastBar"><div class="fill" id="playerCastFill"></div></div>
                 </div>
                 <div class="combatant enemy">
                   <div class="sprite enemy-sprite"></div>
+                  <div class="cast-bar" id="enemyCastBar"><div class="fill" id="enemyCastFill"></div></div>
                 </div>
               </div>
 

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -101,6 +101,32 @@ on('ABILITY:FX', ({ abilityKey }) => {
   }
 });
 
+function showCastBar(castTimeMs) {
+  const bar = document.getElementById('playerCastBar');
+  const fill = document.getElementById('playerCastFill');
+  const enemyBar = document.getElementById('enemyCastBar');
+  if (enemyBar) enemyBar.style.display = 'none';
+  if (!bar || !fill) return;
+  bar.style.display = 'block';
+  fill.style.transition = 'none';
+  fill.style.width = '0%';
+  void fill.offsetWidth;
+  fill.style.transition = `width ${castTimeMs}ms linear`;
+  fill.style.width = '100%';
+}
+
+function hideCastBar() {
+  const bar = document.getElementById('playerCastBar');
+  const fill = document.getElementById('playerCastFill');
+  if (!bar || !fill) return;
+  fill.style.transition = 'none';
+  fill.style.width = '0%';
+  bar.style.display = 'none';
+}
+
+on('CAST:START', ({ castTimeMs }) => showCastBar(castTimeMs));
+on('CAST:END', hideCastBar);
+
 // Subtle red-and-break visual on death
 function triggerDeathBreak(target) {
   const sel = target === 'enemy' ? '.combatant.enemy' : '.combatant.player';
@@ -485,7 +511,7 @@ export function updateAdventureCombat() {
     if (regen) {
       S.adventure.enemyHP = Math.min(S.adventure.enemyMaxHP, S.adventure.enemyHP + regen * S.adventure.enemyMaxHP);
     }
-    if (now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
+    if (!S.currentCast && now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
       S.adventure.lastPlayerAttack = now;
       const enemyDodge = (S.adventure.currentEnemy?.stats?.dodge ?? S.adventure.currentEnemy?.dodge ?? 0) + DODGE_BASE;
       const hitP = chanceToHit(S.stats?.accuracy || 0, enemyDodge);

--- a/style.css
+++ b/style.css
@@ -4235,6 +4235,8 @@ tr:last-child td {
 .sprite-stage .sprite::after{content:"";position:absolute;top:100%;left:50%;transform:translate(-50%,-40%);width:60%;height:8px;background:rgba(0,0,0,.25);border-radius:50%;filter:blur(2px)}
 .sprite-stage .player-sprite{background-color:hsl(200,50%,60%)}
 .sprite-stage .enemy-sprite{background-color:hsl(0,50%,60%)}
+.sprite-stage .cast-bar{position:absolute;top:100%;left:50%;transform:translateX(-50%);width:72px;height:6px;background:rgba(255,255,255,.3);border-radius:3px;overflow:hidden;display:none;margin-top:4px}
+.sprite-stage .cast-bar .fill{height:100%;width:0%;background:linear-gradient(90deg,#f59e0b,#d97706)}
 @keyframes sprite-bob{from{transform:translateY(0)}to{transform:translateY(-4px)}}
 @media (prefers-reduced-motion:reduce){.sprite-stage .sprite{animation:none}}
 html.reduce-motion .sprite-stage .sprite{animation:none}


### PR DESCRIPTION
## Summary
- add cast bar elements beneath player and enemy sprites
- track active casts and display progress
- pause basic attacks and new abilities while casting
- animate cast bar smoothly over cast duration

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI changes blocked until validation passes)*

------
https://chatgpt.com/codex/tasks/task_e_68b77330c7a48326be05735c5fd1fedc