### PR TITLE
Add gear icons to inventory UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Generalized weapon proficiency to all weapon types with enemy HP–based XP gains (max HP ÷ 30 per attack).
 - Each weapon level now grants +1 damage and +1% attack speed; 100 XP required per level.
 - Imbued weapon drops now convert their base damage to the imbued element, producing elemental attacks.
+- Added icons for non-weapon gear items.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -279,6 +279,7 @@ way-of-ascension/
 │   │   │   ├── data/
 │   │   │   │   ├── _balance.contract.js
 │   │   │   │   ├── gearBases.js
+│   │   │   │   ├── gearIcons.js
 │   │   │   │   └── modifiers.js
 │   │   │   ├── imbuement.js
 │   │   │   ├── logic.js
@@ -1042,6 +1043,7 @@ Paths added:
 - `src/features/gearGeneration/selectors.js` – Rolls zone gear drops using gear loot tables.
 - `src/features/gearGeneration/imbuement.js` – Defines imbuement tiers, multipliers, and zone element themes.
 - `src/features/gearGeneration/data/gearBases.js` – Base armor definitions (body, head, feet).
+- `src/features/gearGeneration/data/gearIcons.js` – Icon mappings for gear slots.
 - `src/features/gearGeneration/data/_balance.contract.js` – Balance contract placeholder for gear generation.
 - `src/features/gearGeneration/data/modifiers.js` – Modifier definitions used by gear and weapon generation.
 

--- a/src/features/gearGeneration/data/gearIcons.js
+++ b/src/features/gearGeneration/data/gearIcons.js
@@ -1,0 +1,8 @@
+export const GEAR_ICONS = {
+  head: 'mdi:helmet',
+  body: 'mdi:shield',
+  foot: 'mdi:shoe-print',
+  ring: 'mdi:ring',
+  talisman: 'mdi:yin-yang',
+  food: 'mdi:food-apple',
+};

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -5,6 +5,7 @@ import { equipItem, unequip, removeFromInventory, moveToJunk } from '../mutators
 import { recomputePlayerTotals } from '../logic.js';
 import { ABILITIES } from '../../ability/data/abilities.js';
 import { MODIFIERS } from '../../gearGeneration/data/modifiers.js';
+import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 
 // Consolidated equipment/inventory panel
 let currentFilter = 'all';
@@ -119,8 +120,9 @@ function renderEquipment() {
     if (!el) return;
     const item = S.equipment[s.key];
     const name = item?.name || (item?.key ? (WEAPONS[item.key]?.displayName || item.key) : 'Empty');
-    const iconKey = item?.key ? WEAPONS[item.key]?.classKey : null;
-    const icon = iconKey ? WEAPON_ICONS[iconKey] : null;
+    const icon = item?.type === 'weapon'
+      ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
+      : GEAR_ICONS[item?.slot || item?.type];
     const stars = QUALITY_STARS[item?.quality] || '';
     const rarity = item?.rarity;
     const rarityColor = RARITY_COLORS[rarity] || '';
@@ -190,7 +192,8 @@ function gearDetailsHTML(item) {
   const stars = QUALITY_STARS[item.quality] || '';
   const rarityColor = RARITY_COLORS[item.rarity] || '';
   const name = item.name || item.key;
-  const header = `<div class="tooltip-header"><span class="tooltip-name" style="color:${rarityColor}">${stars ? stars + ' ' : ''}${name}</span></div>`;
+  const icon = GEAR_ICONS[item.slot || item.type];
+  const header = `<div class="tooltip-header">${icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon>` : ''}<span class="tooltip-name" style="color:${rarityColor}">${stars ? stars + ' ' : ''}${name}</span></div>`;
 
   const coreLines = [];
   if (item.protection?.armor) coreLines.push({ label: 'Armor', value: item.protection.armor });
@@ -277,8 +280,9 @@ function createInventoryRow(item) {
   if (element) {
     row.style.backgroundColor = ELEMENT_BG_COLORS[element] || '';
   }
-  const iconKey = item.type === 'weapon' ? WEAPONS[item.key]?.classKey : null;
-  const icon = iconKey ? WEAPON_ICONS[iconKey] : null;
+  const icon = item.type === 'weapon'
+    ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
+    : GEAR_ICONS[item.slot || item.type];
   const rarity = item.rarity;
   const rarityColor = RARITY_COLORS[rarity] || '';
   const rarityPrefix = rarity && rarity !== 'normal' ? `${rarity[0].toUpperCase()}${rarity.slice(1)} ` : '';


### PR DESCRIPTION
## Summary
- add `GEAR_ICONS` mapping for head, body, foot, rings, talismans, and food
- show gear icons in equipment slots, inventory list, and tooltips
- document new gear icon file and update changelog

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UNDOCUMENTED FILE: src/features/combat/data/ailments.js; multiple UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b77ce382688326b5fb35b530accca8