### PR TITLE
Show fireball above combatants and widen explosion

### DIFF
--- a/src/features/combat/ui/fx.js
+++ b/src/features/combat/ui/fx.js
@@ -164,7 +164,7 @@ export function playFireball(svg, from, to, duration = 600) {
       requestAnimationFrame(animate);
     } else {
       svg.removeChild(circle);
-      playRingShockwave(svg, to, 6);
+      playRingShockwave(svg, to, 6 * 1.05);
     }
   }
   if (!reduceMotion && active < MAX_FX) {

--- a/style.css
+++ b/style.css
@@ -4240,7 +4240,7 @@ tr:last-child td {
 @keyframes sprite-bob{from{transform:translateY(0)}to{transform:translateY(-4px)}}
 @media (prefers-reduced-motion:reduce){.sprite-stage .sprite{animation:none}}
 html.reduce-motion .sprite-stage .sprite{animation:none}
-.fx-layer{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;--fx-a:#fff;--fx-b:#fff}
+.fx-layer{position:absolute;inset:0;width:100%;height:100%;pointer-events:none;z-index:1;--fx-a:#fff;--fx-b:#fff}
 .fx-stroke,.fx-thrust,.fx-beam{fill:none;stroke:url(#fx-gradient);filter:url(#soft-glow);stroke-linecap:round}
 .fx-stroke{stroke-width:2;stroke-dasharray:100;stroke-dashoffset:100;animation:fx-draw .35s linear forwards}
 .fx-thrust{stroke-width:2;stroke-dasharray:60;stroke-dashoffset:60;animation:fx-draw .25s linear forwards}


### PR DESCRIPTION
## Summary
- Render combat FX above combatants so fireball is never obscured
- Expand fireball explosion ring by five percent for a bigger impact

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b77d072a94832681362ab73cb0173b