### PR TITLE
Use applyAilment for elemental and ability status effects

### DIFF
--- a/src/features/combat/attack.js
+++ b/src/features/combat/attack.js
@@ -1,5 +1,5 @@
 import { STATUSES_BY_ELEMENT } from './data/statusesByElement.js';
-import { applyStatus } from './mutators.js';
+import { applyAilment, applyStatus } from './mutators.js';
 import { mergeStats } from '../../shared/utils/stats.js';
 
 export function performAttack(attacker, target, options = {}, state) { // STATUS-REFORM
@@ -7,13 +7,15 @@ export function performAttack(attacker, target, options = {}, state) { // STATUS
 
   const attackerStats = mergeStats(attacker?.stats, weapon?.stats);
   const targetStats = target?.stats || {};
+  const attackerCtx = { ...(attacker || {}), stats: attackerStats };
+  const now = Date.now();
 
   if (ability && ability.status) { // STATUS-REFORM
     const { key, power } = ability.status;
     const chance = isCrit ? 1 : power;
     if (Math.random() < chance) {
       console.log(`[status] ${key} applied ${isCrit ? '(crit)' : '(roll)'}`); // STATUS-REFORM
-      applyStatus(target, key, power, state, { attackerStats, targetStats }); // STATUS-REFORM
+      applyAilment(attackerCtx, target, key, power, now);
     } else {
       console.log(`[status] ${key} failed (roll)`); // STATUS-REFORM
     }
@@ -22,7 +24,7 @@ export function performAttack(attacker, target, options = {}, state) { // STATUS
     const chance = isCrit ? 1 : power;
     if (Math.random() < chance) {
       console.log(`[status] ${key} applied ${isCrit ? '(crit)' : '(roll)'}`); // STATUS-REFORM
-      applyStatus(target, key, power, state, { attackerStats, targetStats }); // STATUS-REFORM
+      applyAilment(attackerCtx, target, key, power, now);
     } else {
       console.log(`[status] ${key} failed (roll)`); // STATUS-REFORM
     }

--- a/src/features/combat/mutators.js
+++ b/src/features/combat/mutators.js
@@ -1,9 +1,13 @@
 import { S } from '../../shared/state.js';
 import { initializeFight as baseInitializeFight, processAttack as baseProcessAttack } from './logic.js';
-import { applyStatus as baseApplyStatus } from './statusEngine.js';
+import { applyStatus as baseApplyStatus, applyAilment as baseApplyAilment } from './statusEngine.js';
 
 export function applyStatus(target, key, power, state = S, options) {
   return baseApplyStatus(target, key, power, state, options);
+}
+
+export function applyAilment(attacker, target, key, power, nowMs) {
+  return baseApplyAilment(attacker, target, key, power, nowMs);
 }
 
 export function initializeFight(enemy, state = S) {


### PR DESCRIPTION
## Summary
- wrap `applyAilment` in combat mutators for reuse
- route ability- and element-based status checks through `applyAilment`
- keep stun and interrupt logic using existing status system

## Testing
- ❌ `npm test` (no tests specified)
- ✅ `npm run lint:balance`
- ⚠️ `npm run validate` (warnings about project structure)


------
https://chatgpt.com/codex/tasks/task_e_68b782888154832684b187e32151bb68