### PR TITLE
fix: allow equipping weapons not in registry

### DIFF
--- a/src/features/inventory/selectors.js
+++ b/src/features/inventory/selectors.js
@@ -17,5 +17,9 @@ export function getEquippedWeapon(state = S) {
   if (!state.flags?.weaponsEnabled) return WEAPONS.fist;
   const eq = state.equipment?.mainhand;
   const key = typeof eq === 'string' ? eq : eq?.key;
-  return WEAPONS[key] || WEAPONS.fist;
+  if (WEAPONS[key]) return WEAPONS[key];
+  if (eq && typeof eq === 'object') {
+    return { ...eq, key, displayName: eq.displayName || eq.name || key };
+  }
+  return WEAPONS.fist;
 }


### PR DESCRIPTION
## Summary
- ensure `getEquippedWeapon` returns equipped item when it's not in the weapon registry

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification protocol: undocumented file and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b78fe92ecc8326abfaf620490688d6