### PR TITLE
Handle multi-component combat attacks

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -108,21 +108,26 @@ function applyAbilityResult(abilityKey, res, state) {
       const { type, target: atkTarget } = atk;
       let amount = atk.amount;
 
+      let mult = 1;
       if (mods?.damagePct) {
-        amount = Math.round(amount * (1 + mods.damagePct / 100));
+        mult *= 1 + mods.damagePct / 100;
       }
 
       if (isSpell) {
         if (weapon.classKey === 'focus') {
-          amount = Math.round(amount * getWeaponProficiencyBonuses(state).damageMult);
+          mult *= getWeaponProficiencyBonuses(state).damageMult;
         }
         const { spellPowerMult } = getStatEffects(state);
         const spellDamage = state.stats?.spellDamage || 0;
         const treeMult = 1 + (state.astralTreeBonuses?.spellDamagePct || 0) / 100;
-        amount = Math.round(amount * spellPowerMult * (1 + spellDamage / 100) * treeMult);
+        mult *= spellPowerMult * (1 + spellDamage / 100) * treeMult;
       }
 
-      const dealt = processAttack(amount, { target: atkTarget, type, attacker: state, nowMs: now }, state);
+      const dealt = processAttack(
+        [{ amount, type, mult }],
+        { target: atkTarget, attacker: state, nowMs: now, weapon: weapon.key },
+        state
+      );
       totalDealt += dealt;
       logs?.push(`You used ${ability.displayName} for ${dealt} ${type === 'physical' ? 'Physical ' : ''}damage.`);
 

--- a/src/features/combat/mutators.js
+++ b/src/features/combat/mutators.js
@@ -22,7 +22,7 @@ export function initializeFight(enemy, state = S) {
   return { enemyHP, enemyMax, atk, def };
 }
 
-export function processAttack(damage, options = {}, state = S) {
+export function processAttack(attacks, options = {}, state = S) {
   let dealt = 0;
   const target = options.target || state.adventure?.currentEnemy;
   let currentHP;
@@ -37,7 +37,7 @@ export function processAttack(damage, options = {}, state = S) {
     currentHP = state.adventure.enemyHP;
   }
 
-  const newHP = baseProcessAttack(currentHP, damage, {
+  const newHP = baseProcessAttack(currentHP, attacks, {
     ...options,
     target,
     onDamage: d => (dealt = d),


### PR DESCRIPTION
## Summary
- Refactor `processAttack` to handle arrays of attacks and apply per-hit armor/resists
- Apply weapon multipliers and proficiency/tree bonuses after internal mitigation
- Update ability and adventure logic to use new damage processing API

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b796bd3b748326afc2ef43cdfd7604