### PR TITLE
Use unified attack calculation in adventure combat

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -518,11 +518,10 @@ export function updateAdventureCombat() {
       if (Math.random() < hitP) {
         const critChance = S.stats?.criticalChance || 0;
         const isCrit = Math.random() < critChance;
-        const profMult = getWeaponProficiencyBonuses(S).damageMult;
-        const playerAttackBase = (Number(calculatePlayerCombatAttack(S)) || 0) / profMult;
+        const playerAttackBase = Number(calculatePlayerCombatAttack(S)) || 0;
         let dmg = Math.max(1, Math.round(isCrit ? playerAttackBase * 2 : playerAttackBase));
         let attackType = 'physical';
-        let externalMult = profMult;
+        let externalMult = 1;
         if (S.lightningStep) {
           externalMult *= S.lightningStep.damageMult;
           attackType = 'metal';
@@ -543,8 +542,8 @@ export function updateAdventureCombat() {
         if (enemyEl) {
           showFloatingText({ targetEl: enemyEl, result: isCrit ? 'crit' : 'hit', amount: dealt });
         }
-          S.adventure.enemyStunBar = S.adventure.currentEnemy.stun?.value || 0; // STATUS-REFORM
-          performAttack(S, S.adventure.currentEnemy, { weapon }, S); // STATUS-REFORM
+        S.adventure.enemyStunBar = S.adventure.currentEnemy.stun?.value || 0; // STATUS-REFORM
+        performAttack(S, S.adventure.currentEnemy, { weapon }, S); // STATUS-REFORM
         const pos = getCombatPositions();
         if (pos) {
           setFxTint(pos.svg, weapon.animations?.tint || 'auto');

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -167,12 +167,7 @@ export function getStatEffects(state = progressionState) {
 }
 
 export function calculatePlayerCombatAttack(state = progressionState) {
-  const baseAttack = 5;
-  const tier = state?.realm?.tier ?? 0;
-  const stage = Number(state?.realm?.stage) || 0;
-  const realmAtk = Number(REALMS[tier]?.atk) || 0;
-  const dmgMult = Number(getWeaponProficiencyBonuses(state).damageMult) || 1;
-  return (baseAttack + realmAtk * stage) * dmgMult;
+  return calcAtk(state);
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {


### PR DESCRIPTION
## Summary
- Use `calcAtk` for player combat attack calculation
- Simplify adventure auto-attack to use direct attack value without proficiency adjustments

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation; documentation update required)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a6e287e48326a029291b0942adf5