### PR TITLE
Apply astral tree damage bonuses to attacks

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -113,6 +113,7 @@ way-of-ascension/
 │   │   │   ├── attack.js
 │   │   │   ├── data/
 │   │   │   │   ├── _balance.contract.js
+│   │   │   │   ├── ailments.js
 │   │   │   │   ├── status.js
 │   │   │   │   └── statusesByElement.js
 │   │   │   ├── hit.js
@@ -968,6 +969,7 @@ Paths added:
 - `src/features/combat/statusEngine.js` – Internal status effect stacking and duration handler.
 - `src/features/combat/data/status.js` – Definitions for all status effects.
 - `src/features/combat/data/statusesByElement.js` – Maps elements to their default status applications.
+- `src/features/combat/data/ailments.js` – Ailment definitions and their effects.
 - `src/features/combat/ui/combatStats.js` – Displays player and enemy combat statistics.
 
 ### Karma Feature (`src/features/karma/`)

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -113,19 +113,23 @@ function applyAbilityResult(abilityKey, res, state) {
         mult *= 1 + mods.damagePct / 100;
       }
 
+      let treeMult = 1;
       if (isSpell) {
         if (weapon.classKey === 'focus') {
           mult *= getWeaponProficiencyBonuses(state).damageMult;
         }
         const { spellPowerMult } = getStatEffects(state);
         const spellDamage = state.stats?.spellDamage || 0;
-        const treeMult = 1 + (state.astralTreeBonuses?.spellDamagePct || 0) / 100;
-        mult *= spellPowerMult * (1 + spellDamage / 100) * treeMult;
+        const spellTreeMult = 1 + (state.astralTreeBonuses?.spellDamagePct || 0) / 100;
+        mult *= spellPowerMult * (1 + spellDamage / 100) * spellTreeMult;
+      } else {
+        const bonusKey = type === 'physical' ? 'physicalDamagePct' : `${type}DamagePct`;
+        treeMult = 1 + (state.astralTreeBonuses?.[bonusKey] || 0) / 100;
       }
 
       const dealt = processAttack(
         [{ amount, type, mult }],
-        { target: atkTarget, attacker: state, nowMs: now, weapon: weapon.key },
+        { target: atkTarget, attacker: state, nowMs: now, weapon: weapon.key, treeMult },
         state
       );
       totalDealt += dealt;

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -530,9 +530,19 @@ export function updateAdventureCombat() {
             S.abilityCooldowns.lightningStep = Math.max(0, cd - 1_000);
           }
         }
+        const bonusKey =
+          attackType === 'physical' ? 'physicalDamagePct' : `${attackType}DamagePct`;
+        const treeMult =
+          1 + (S.astralTreeBonuses?.[bonusKey] || 0) / 100;
         const dealt = processAttack(
           [{ amount: dmg, type: attackType, mult: externalMult }],
-          { attacker: S, target: S.adventure.currentEnemy, nowMs: now, weapon: weapon.key },
+          {
+            attacker: S,
+            target: S.adventure.currentEnemy,
+            nowMs: now,
+            weapon: weapon.key,
+            treeMult,
+          },
           S
         );
         gainProficiencyFromEnemy(weapon.classKey, S.adventure.enemyMaxHP, S); // WEAPONS-INTEGRATION


### PR DESCRIPTION
## Summary
- Factor in astral tree damage bonuses for basic attacks and non-spell abilities
- Document combat ailments module in project structure

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations reported)*

------
https://chatgpt.com/codex/tasks/task_e_68b7aa570b5483269de86ddbc0520d2a