### PR TITLE
Fix elemental attack handling and weapon scaling

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -4,6 +4,7 @@ import { progressionState } from './state.js';
 import { getWeaponProficiencyBonuses } from '../proficiency/selectors.js';
 import { getBuildingBonuses } from '../sect/selectors.js';
 import { karmaQiRegenBonus, karmaAtkBonus, karmaArmorBonus } from '../karma/logic.js';
+import { getEquippedWeapon } from '../inventory/selectors.js';
 import { getSuccessBonus as getAlchemySuccessBonus } from '../alchemy/selectors.js';
 import { getCookingSuccessBonus } from '../cooking/selectors.js';
 export const clamp = (v,min,max)=>Math.max(min,Math.min(max,v));
@@ -167,7 +168,21 @@ export function getStatEffects(state = progressionState) {
 }
 
 export function calculatePlayerCombatAttack(state = progressionState) {
-  return calcAtk(state);
+  const weapon = getEquippedWeapon(state);
+  const base = calcAtk(state);
+  const physBase = weapon?.base?.phys || { min: 0, max: 0 };
+  const physAvg = (Number(physBase.min) + Number(physBase.max)) / 2;
+  const phys = base * physAvg;
+  const elems = {};
+  const baseElems = weapon?.base?.elems || {};
+  for (const [elem, mult] of Object.entries(baseElems)) {
+    const avg =
+      typeof mult === 'object'
+        ? (Number(mult.min) + Number(mult.max)) / 2
+        : Number(mult);
+    elems[elem] = base * avg;
+  }
+  return { phys, elems };
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {

--- a/src/features/progression/selectors.js
+++ b/src/features/progression/selectors.js
@@ -59,7 +59,13 @@ export function getStatEffects(state = progressionState) {
 }
 
 export function calculatePlayerCombatAttack(state = progressionState) {
-  return calcPlayerCombatAttack(state) * getTunable('combat.damageMult', 1);
+  const profile = calcPlayerCombatAttack(state);
+  const mult = getTunable('combat.damageMult', 1);
+  const scaledElems = {};
+  for (const [elem, val] of Object.entries(profile.elems || {})) {
+    scaledElems[elem] = val * mult;
+  }
+  return { phys: profile.phys * mult, elems: scaledElems };
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {


### PR DESCRIPTION
## Summary
- compute elemental attack averages to avoid NaN damage
- fall back to elemental damage when no physical base is present
- prevent double weapon scaling by bypassing weapon multipliers

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b7b2fa7b008326b7940ca59eb4c079