### PR TITLE
Refactor attack calc to weapon damage profile

### DIFF
--- a/src/features/progression/selectors.js
+++ b/src/features/progression/selectors.js
@@ -59,7 +59,14 @@ export function getStatEffects(state = progressionState) {
 }
 
 export function calculatePlayerCombatAttack(state = progressionState) {
-  return calcPlayerCombatAttack(state) * getTunable('combat.damageMult', 1);
+  const profile = calcPlayerCombatAttack(state);
+  const mult = getTunable('combat.damageMult', 1);
+  return {
+    phys: profile.phys * mult,
+    elems: Object.fromEntries(
+      Object.entries(profile.elems).map(([k, v]) => [k, v * mult])
+    ),
+  };
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {


### PR DESCRIPTION
## Summary
- compute combat attack from equipped weapon producing physical and elemental breakdown
- propagate attack profile through selectors and adventure logic
- handle attack profile during combat and display updates

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation, DOM usage, UI timer warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd7c38d08326920ea8e03d49882b