### PR TITLE
Refactor combat damage processing

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -127,9 +127,15 @@ function applyAbilityResult(abilityKey, res, state) {
         treeMult = 1 + (state.astralTreeBonuses?.[bonusKey] || 0) / 100;
       }
 
+      const profile =
+        type === 'physical'
+          ? { phys: amount, elems: {} }
+          : { phys: 0, elems: { [type]: amount } };
+      const typeMults = { [type === 'physical' ? 'physical' : type]: treeMult };
       const dealt = processAttack(
-        [{ amount, type, mult }],
-        { target: atkTarget, attacker: state, nowMs: now, weapon: weapon.key, treeMult },
+        profile,
+        weapon,
+        { target: atkTarget, attacker: state, nowMs: now, typeMults, globalMult: mult },
         state
       );
       totalDealt += dealt;

--- a/src/features/combat/logic.js
+++ b/src/features/combat/logic.js
@@ -1,6 +1,7 @@
 import { initHp } from '../../shared/utils/hp.js';
-import { WEAPONS, WEAPON_CONFIG, WEAPON_FLAGS } from '../weaponGeneration/data/weapons.js'; // WEAPONS-INTEGRATION
+import { WEAPONS, WEAPON_CONFIG } from '../weaponGeneration/data/weapons.js'; // WEAPONS-INTEGRATION
 import { onPhysicalHit } from '../../engine/combat/stun.js';
+import { MODIFIERS } from '../gearGeneration/data/modifiers.js';
 
 /** Tunables */
 export const ARMOR_K = 10;           // how "strong" armor is vs damage size
@@ -61,12 +62,67 @@ export function initializeFight(enemy) {
   return { enemyHP, enemyMax, atk, armor };
 }
 
-export function applyWeaponDamage(base, weapon = 'fist') {
-  if (!WEAPON_FLAGS[weapon] || weapon === 'fist') return base;
-  const config = WEAPON_CONFIG[weapon];
-  const modified = Math.round(base * (config.damageMultiplier ?? 1));
-  console.log('[weapon]', 'damage', { weapon, base, modified });
-  return modified;
+export function applyWeaponDamage(profile = {}, weapon = WEAPONS.fist, attacker = {}, typeMults = {}) {
+  const result = {
+    phys: Number(profile.phys) || 0,
+    elems: { ...(profile.elems || {}) },
+  };
+
+  const w = weapon && weapon.key ? weapon : WEAPONS[weapon] || WEAPONS.fist;
+  const config = WEAPON_CONFIG[w.key] || {};
+  const baseMult = config.damageMultiplier ?? 1;
+
+  result.phys *= baseMult;
+  for (const k in result.elems) {
+    result.elems[k] *= baseMult;
+  }
+
+  for (const key of w.modifiers || []) {
+    const mod = MODIFIERS[key];
+    if (!mod) continue;
+    if (mod.lane === 'damage' && typeof mod.value === 'number') {
+      result.phys *= 1 + mod.value;
+      for (const k in result.elems) result.elems[k] *= 1 + mod.value;
+    } else if (mod.lane === 'physPct' && typeof mod.value === 'number') {
+      result.phys *= 1 + mod.value;
+    } else if (mod.lane === 'physFlat' && mod.range) {
+      const avg = (mod.range.min + mod.range.max) / 2;
+      result.phys += avg;
+    } else if (mod.element && mod.lane.endsWith('Pct') && typeof mod.value === 'number') {
+      const elem = mod.element;
+      result.elems[elem] = (result.elems[elem] || 0) * (1 + mod.value);
+    } else if (mod.element && mod.lane.endsWith('Flat') && mod.range) {
+      const elem = mod.element;
+      const avg = (mod.range.min + mod.range.max) / 2;
+      result.elems[elem] = (result.elems[elem] || 0) + avg;
+    }
+  }
+
+  const getMult = key =>
+    (typeMults && typeMults[key]) ||
+    attacker?.stats?.[`${key}DamageMult`] ||
+    attacker?.[`${key}DamageMult`] ||
+    1;
+
+  result.phys *= getMult('physical');
+  for (const k in result.elems) {
+    result.elems[k] *= getMult(k);
+  }
+
+  const classMult =
+    attacker?.stats?.[`${w.classKey}DamageMult`] ||
+    attacker?.[`${w.classKey}DamageMult`] ||
+    1;
+  const typeMult =
+    attacker?.stats?.[`${w.typeKey}DamageMult`] ||
+    attacker?.[`${w.typeKey}DamageMult`] ||
+    1;
+
+  const weaponMult = classMult * typeMult;
+  result.phys *= weaponMult;
+  for (const k in result.elems) result.elems[k] *= weaponMult;
+
+  return result;
 }
 
 export function applyResists(damage, element, target) {
@@ -76,57 +132,48 @@ export function applyResists(damage, element, target) {
   return dmg * (1 - resist);
 }
 
-export function processAttack(currentHP, attacks, options = {}) {
-  let cur = Number(currentHP);
-  if (!Number.isFinite(cur)) cur = 0;
-
+export function processAttack(profile, weapon, options = {}) {
   const {
     target,
     onDamage,
     attacker,
     nowMs,
-    weapon: defaultWeapon,
+    typeMults = {},
+    globalMult = 1,
     treeMult = 1,
     proficiencyMult = 1,
+    manualMult = 1,
+    tempMult = 1,
   } = options;
 
-  const list = Array.isArray(attacks) ? attacks : [attacks];
-  let total = 0;
+  const scaled = applyWeaponDamage(profile, weapon, attacker, typeMults);
 
-  for (const entry of list) {
-    const atk = typeof entry === 'number' ? { amount: entry } : entry || {};
-    const {
-      amount = 0,
-      type: atkType = options.type,
-      mult: atkMult = 1,
-      weapon: atkWeapon,
-    } = atk;
+  const components = { phys: 0, elems: {} };
 
-    const element = atkType && atkType !== 'physical' ? atkType : undefined;
-    let adjusted = applyResists(amount, element, target);
-
-    if (atkType === 'physical') {
-      const armor = Number(target?.stats?.armor ?? target?.armor ?? 0) || 0;
-      adjusted = applyArmor(adjusted, armor);
+  if (scaled.phys > 0) {
+    let amt = applyArmor(scaled.phys, Number(target?.stats?.armor ?? target?.armor ?? 0) || 0);
+    amt = routeDamageThroughQiShield(amt, target);
+    components.phys = Math.max(0, Math.round(amt));
+    if (components.phys > 0) {
+      onPhysicalHit(attacker, target, components.phys, nowMs || Date.now());
     }
-
-    adjusted = routeDamageThroughQiShield(adjusted, target);
-
-    let final = Math.max(0, Math.round(adjusted));
-    if (!Number.isFinite(final)) final = 0;
-
-    final = applyWeaponDamage(final, atkWeapon || defaultWeapon || 'fist');
-
-    final = Math.round(final * atkMult * treeMult * proficiencyMult);
-
-    if (atkType === 'physical' && final > 0) {
-      onPhysicalHit(attacker, target, final, nowMs || Date.now());
-    }
-
-    total += final;
   }
 
-  if (typeof onDamage === 'function') onDamage(total);
-  return Math.max(0, Math.round(cur - total));
+  for (const [elem, val] of Object.entries(scaled.elems)) {
+    let amt = applyResists(val, elem, target);
+    amt = routeDamageThroughQiShield(amt, target);
+    components.elems[elem] = Math.max(0, Math.round(amt));
+  }
+
+  let total = components.phys;
+  for (const v of Object.values(components.elems)) total += v;
+
+  total = Math.round(
+    total * globalMult * treeMult * proficiencyMult * manualMult * tempMult
+  );
+
+  if (typeof onDamage === 'function') onDamage(total, components);
+
+  return { total, components };
 }
 

--- a/src/features/combat/mutators.js
+++ b/src/features/combat/mutators.js
@@ -22,7 +22,7 @@ export function initializeFight(enemy, state = S) {
   return { enemyHP, enemyMax, atk, def };
 }
 
-export function processAttack(attacks, options = {}, state = S) {
+export function processAttack(profile, weapon, options = {}, state = S) {
   let dealt = 0;
   const target = options.target || state.adventure?.currentEnemy;
   let currentHP;
@@ -37,11 +37,13 @@ export function processAttack(attacks, options = {}, state = S) {
     currentHP = state.adventure.enemyHP;
   }
 
-  const newHP = baseProcessAttack(currentHP, attacks, {
+  const { total } = baseProcessAttack(profile, weapon, {
     ...options,
     target,
-    onDamage: d => (dealt = d),
+    onDamage: (t) => (dealt = t),
   });
+
+  const newHP = Math.max(0, Math.round(currentHP - dealt));
 
   if (target === state || target === S) {
     state.adventure.playerHP = newHP;


### PR DESCRIPTION
## Summary
- Refactor combat damage to operate on attack profiles and weapon objects
- Apply per-type and weapon multipliers with armor/resist checks before global scaling
- Update ability and adventure systems to use new combat damage API

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and AI verification enforcement)*

------
https://chatgpt.com/codex/tasks/task_e_68b82372ec788326be1bca777d403676