### PR TITLE
Refactor combat for multi-component damage

### DIFF
--- a/src/features/combat/attack.js
+++ b/src/features/combat/attack.js
@@ -3,7 +3,18 @@ import { applyAilment, applyStatus } from './mutators.js';
 import { mergeStats } from '../../shared/utils/stats.js';
 
 export function performAttack(attacker, target, options = {}, state) { // STATUS-REFORM
-  const { ability, attackElement, attackIsPhysical, physDamageDealt = 0, isCrit = false, weapon } = options;
+  const { ability, isCrit = false, weapon, profile } = options;
+
+  let attackElement;
+  let attackIsPhysical = false;
+  if (profile) {
+    attackIsPhysical = (profile.phys || 0) > 0;
+    const elems = profile.elems || {};
+    attackElement = Object.keys(elems).reduce(
+      (best, elem) => (elems[elem] > (elems[best] || 0) ? elem : best),
+      undefined
+    );
+  }
 
   const attackerStats = mergeStats(attacker?.stats, weapon?.stats);
   const targetStats = target?.stats || {};

--- a/src/features/combat/mutators.js
+++ b/src/features/combat/mutators.js
@@ -23,7 +23,6 @@ export function initializeFight(enemy, state = S) {
 }
 
 export function processAttack(profile, weapon, options = {}, state = S) {
-  let dealt = 0;
   const target = options.target || state.adventure?.currentEnemy;
   let currentHP;
 
@@ -37,13 +36,12 @@ export function processAttack(profile, weapon, options = {}, state = S) {
     currentHP = state.adventure.enemyHP;
   }
 
-  const { total } = baseProcessAttack(profile, weapon, {
+  const result = baseProcessAttack(profile, weapon, {
     ...options,
     target,
-    onDamage: (t) => (dealt = t),
   });
 
-  const newHP = Math.max(0, Math.round(currentHP - dealt));
+  const newHP = Math.max(0, Math.round(currentHP - result.total));
 
   if (target === state || target === S) {
     state.adventure.playerHP = newHP;
@@ -54,6 +52,6 @@ export function processAttack(profile, weapon, options = {}, state = S) {
     target.hp = newHP;
   }
 
-  return dealt;
+  return result;
 }
 


### PR DESCRIPTION
## Summary
- store player attack profile at combat start
- log and apply damage by type, passing attack profiles to combat helpers
- return component damage from `processAttack`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js)


------
https://chatgpt.com/codex/tasks/task_e_68b8294d56c48326b46fb5b87d70fcc9