### PR TITLE
feat: apply weapon stats to attacks

### DIFF
--- a/src/features/combat/logic.js
+++ b/src/features/combat/logic.js
@@ -146,7 +146,21 @@ export function processAttack(profile, weapon, options = {}) {
     tempMult = 1,
   } = options;
 
-  const scaled = applyWeaponDamage(profile, weapon, attacker, typeMults);
+  const w = weapon && weapon.key ? weapon : WEAPONS[weapon] || WEAPONS.fist;
+  const scaled = applyWeaponDamage(profile, w, attacker, typeMults);
+
+  const stats = w?.stats || {};
+  if (typeof stats.physDamagePct === 'number') {
+    scaled.phys *= 1 + stats.physDamagePct;
+  }
+  if (typeof stats.damageTransferPct === 'number') {
+    const elem = stats.damageTransferElement;
+    if (elem) {
+      const transferred = scaled.phys * stats.damageTransferPct;
+      scaled.phys -= transferred;
+      scaled.elems[elem] = (scaled.elems[elem] || 0) + transferred;
+    }
+  }
 
   const components = { phys: 0, elems: {} };
 


### PR DESCRIPTION
## Summary
- apply `physDamagePct` and `damageTransferPct` weapon stats when processing attacks
- support converting some physical damage to an elemental type based on weapon stats

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b82f2c399c83268b6d7da4d6042f7c