### PR TITLE
feat: support manual damage bonuses

### DIFF
--- a/src/features/combat/logic.js
+++ b/src/features/combat/logic.js
@@ -148,6 +148,13 @@ export function processAttack(profile, weapon, options = {}) {
 
   const scaled = applyWeaponDamage(profile, weapon, attacker, typeMults);
 
+  const baseDamageMult = 1 + ((attacker?.stats?.damagePct || 0) / 100);
+  const physDamageMult = 1 + ((attacker?.stats?.physDamagePct || 0) / 100);
+  scaled.phys *= baseDamageMult * physDamageMult;
+  for (const elem in scaled.elems) {
+    scaled.elems[elem] *= baseDamageMult;
+  }
+
   const components = { phys: 0, elems: {} };
 
   if (scaled.phys > 0) {

--- a/src/features/mind/logic.js
+++ b/src/features/mind/logic.js
@@ -122,6 +122,8 @@ export function applyManualEffects(player, manual, level) {
         player.stats[stat] = (player.stats[stat] || 0) * (1 + val / 100);
       } else if (stat in player) {
         player[stat] = (player[stat] || 0) * (1 + val / 100);
+      } else {
+        player.stats[key] = (player.stats[key] || 0) + val;
       }
     } else if (key in player.stats) {
       player.stats[key] = (player.stats[key] || 0) + val;


### PR DESCRIPTION
## Summary
- accumulate fields like `damagePct` and `physDamagePct` from manual rewards
- apply `damagePct` and `physDamagePct` to outgoing damage in `processAttack`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and AI changes blocked warning)*

------
https://chatgpt.com/codex/tasks/task_e_68b82f40127c8326b57fb8a9b96945b9