### PR TITLE
Show combat ailments

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,6 +517,7 @@
                       <div class="qi-fill" id="playerQiFill"></div>
                       <span class="qi-text" id="playerQiText">0/0</span>
                     </div>
+                    <div class="status-ailments" id="playerAilments"></div>
                   </div>
                   <div class="stat-icons">
                     <span class="icon" id="playerAttack" title="ATK">⚔️</span>
@@ -540,6 +541,7 @@
                       <span class="qi-text" id="enemyQiText">--</span>
                     </div>
                     <div class="enemy-affixes" id="enemyAffixes"></div>
+                    <div class="status-ailments" id="enemyAilments"></div>
                   </div>
                   <div class="stat-icons">
                     <span class="icon" id="enemyAttack" title="ATK">⚔️</span>

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -44,6 +44,16 @@ import { updateFoodSlots } from '../cooking/ui/cookControls.js';
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 
 const loggedResistTypes = new Set();
+const AILMENT_ICONS = {
+  poison: '☠️',
+  burn: '🔥',
+  chill: '❄️',
+  entomb: '🪨',
+  ionize: '⚡',
+  enfeeble: '💀',
+  stun: '💢',
+  interrupt: '⚡'
+};
 function logEnemyResists(enemy) {
   if (enemy && !loggedResistTypes.has(enemy.type)) {
     console.log('[resist]', enemy.type, enemy.resists);
@@ -159,6 +169,29 @@ export function ensureAdventure() {
   if (!S.adventure.unlockedAreas) S.adventure.unlockedAreas = { "0-0": true };
 }
 
+function renderAilments(entity, id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const now = Date.now();
+  const pieces = [];
+  if (entity?.statuses) {
+    for (const [key, inst] of Object.entries(entity.statuses)) {
+      const icon = AILMENT_ICONS[key] || '❔';
+      const dur = inst.duration ?? 0;
+      pieces.push(`<div class="ailment" title="${key}"><span class="icon">${icon}</span><span class="stack">${inst.stacks || 1}</span><span class="duration">${dur.toFixed(1)}s</span></div>`);
+    }
+  }
+  if (entity?.ailments) {
+    for (const [key, inst] of Object.entries(entity.ailments)) {
+      const icon = AILMENT_ICONS[key] || '❔';
+      let remaining = inst.expires;
+      if (remaining > 1e6) remaining = (remaining - now) / 1000;
+      pieces.push(`<div class="ailment" title="${key}"><span class="icon">${icon}</span><span class="stack">${inst.stacks || 1}</span><span class="duration">${remaining.toFixed(1)}s</span></div>`);
+    }
+  }
+  el.innerHTML = pieces.join('');
+}
+
 // MAP-UI-UPDATE: Area selection by ID with save persistence
 export function selectAreaById(zoneId, areaId, areaIndex) {
   const zone = getZoneById(zoneId);
@@ -251,6 +284,7 @@ export function updateBattleDisplay() {
   if (rateEl) rateEl.title = `Rate: ${playerAttackRate.toFixed(1)}/s`;
   setText('combatAttackRate', `${playerAttackRate.toFixed(1)}/s`);
   setText('qiShield', `${S.shield?.current || 0}/${S.shield?.max || 0}`);
+  renderAilments(S, 'playerAilments');
 
   // Calculate physical mitigation against the strongest enemy in the current zone
   let mitPct = 0;
@@ -312,6 +346,7 @@ export function updateBattleDisplay() {
         affixEl.innerHTML = '';
       }
     }
+    renderAilments(enemy, 'enemyAilments');
     const enemyHealthFill = document.getElementById('enemyHealthFill');
     if (enemyHealthFill && enemyMaxHP > 0) {
       const enemyHealthPct = (enemyHP / enemyMaxHP) * 100;
@@ -357,6 +392,8 @@ export function updateBattleDisplay() {
     if (enemyQiFill) enemyQiFill.style.width = '0%';
     const affixEl = document.getElementById('enemyAffixes');
     if (affixEl) affixEl.innerHTML = '';
+    const enemyAilEl = document.getElementById('enemyAilments');
+    if (enemyAilEl) enemyAilEl.innerHTML = '';
     const enemyStunFill = document.getElementById('enemyStunFill');
     if (enemyStunFill) {
       enemyStunFill.style.width = '0%';

--- a/src/features/combat/statusEngine.js
+++ b/src/features/combat/statusEngine.js
@@ -64,6 +64,12 @@ export function tickAilments(entity, dtSec, state) {
 
     if (inst._lastStack !== inst.stacks) {
       def.onApply?.({ target: entity, stack: inst.stacks });
+      if (state?.adventure) {
+        state.adventure.combatLog = state.adventure.combatLog || [];
+        const targetName = entity === state ? 'You' : entity.name || 'Enemy';
+        const stackText = inst.stacks > 1 ? ` x${inst.stacks}` : '';
+        state.adventure.combatLog.push(`${targetName} afflicted with ${key}${stackText}`);
+      }
       inst._lastStack = inst.stacks;
     }
 
@@ -76,6 +82,11 @@ export function tickAilments(entity, dtSec, state) {
 
     if (inst.expires <= 0) {
       def.onExpire?.({ target: entity });
+      if (state?.adventure) {
+        state.adventure.combatLog = state.adventure.combatLog || [];
+        const targetName = entity === state ? 'You' : entity.name || 'Enemy';
+        state.adventure.combatLog.push(`${key} on ${targetName} expired`);
+      }
       delete entity.ailments[key];
     }
   }

--- a/style.css
+++ b/style.css
@@ -4229,6 +4229,10 @@ tr:last-child td {
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
 .combat-hud .player-name{font-size:.75rem;font-weight:600}
+.status-ailments{display:flex;gap:4px;margin-top:2px}
+.status-ailments .ailment{position:relative;width:20px;height:20px;font-size:16px;line-height:20px}
+.status-ailments .ailment .stack{position:absolute;bottom:-2px;right:-2px;font-size:10px;color:#fff;text-shadow:0 0 2px #000}
+.status-ailments .ailment .duration{position:absolute;top:-4px;left:50%;transform:translateX(-50%);font-size:9px;color:#fff;text-shadow:0 0 2px #000}
 .sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
 .sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}


### PR DESCRIPTION
## Summary
- display player and enemy ailments with stacks and remaining time
- style ailment icons and overlay text
- log ailment applications and expirations to combat log

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b82f5edda483269becaa9586723261