### PR TITLE
Show combat ailments

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,6 +517,7 @@
                       <div class="qi-fill" id="playerQiFill"></div>
                       <span class="qi-text" id="playerQiText">0/0</span>
                     </div>
+                    <div class="status-ailments" id="playerAilments"></div>
                   </div>
                   <div class="stat-icons">
                     <span class="icon" id="playerAttack" title="ATK">⚔️</span>
@@ -540,6 +541,7 @@
                       <span class="qi-text" id="enemyQiText">--</span>
                     </div>
                     <div class="enemy-affixes" id="enemyAffixes"></div>
+                    <div class="status-ailments" id="enemyAilments"></div>
                   </div>
                   <div class="stat-icons">
                     <span class="icon" id="enemyAttack" title="ATK">⚔️</span>

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -44,6 +44,16 @@ import { updateFoodSlots } from '../cooking/ui/cookControls.js';
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 
 const loggedResistTypes = new Set();
+const AILMENT_ICONS = {
+  poison: '☠️',
+  burn: '🔥',
+  chill: '❄️',
+  entomb: '🪨',
+  ionize: '⚡',
+  enfeeble: '💀',
+  stun: '💢',
+  interrupt: '🚫'
+};
 function logEnemyResists(enemy) {
   if (enemy && !loggedResistTypes.has(enemy.type)) {
     console.log('[resist]', enemy.type, enemy.resists);
@@ -159,6 +169,30 @@ export function ensureAdventure() {
   if (!S.adventure.unlockedAreas) S.adventure.unlockedAreas = { "0-0": true };
 }
 
+function renderAilments(entity, id) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const now = Date.now();
+  const pieces = [];
+  if (entity?.statuses) {
+    for (const [key, inst] of Object.entries(entity.statuses)) {
+      const dur = inst.duration ?? 0;
+      if (dur <= 0) continue;
+      const icon = AILMENT_ICONS[key] || '❔';
+      pieces.push(`<div class="ailment" title="${key}"><span class="icon">${icon}</span><span class="stack">${inst.stacks || 1}</span><span class="duration">${dur.toFixed(1)}s</span></div>`);
+    }
+  }
+  if (entity?.ailments) {
+    for (const [key, inst] of Object.entries(entity.ailments)) {
+      const icon = AILMENT_ICONS[key] || '❔';
+      let remaining = inst.expires;
+      if (remaining > 1e6) remaining = (remaining - now) / 1000;
+      pieces.push(`<div class="ailment" title="${key}"><span class="icon">${icon}</span><span class="stack">${inst.stacks || 1}</span><span class="duration">${remaining.toFixed(1)}s</span></div>`);
+    }
+  }
+  el.innerHTML = pieces.join('');
+}
+
 // MAP-UI-UPDATE: Area selection by ID with save persistence
 export function selectAreaById(zoneId, areaId, areaIndex) {
   const zone = getZoneById(zoneId);
@@ -251,6 +285,7 @@ export function updateBattleDisplay() {
   if (rateEl) rateEl.title = `Rate: ${playerAttackRate.toFixed(1)}/s`;
   setText('combatAttackRate', `${playerAttackRate.toFixed(1)}/s`);
   setText('qiShield', `${S.shield?.current || 0}/${S.shield?.max || 0}`);
+  renderAilments(S, 'playerAilments');
 
   // Calculate physical mitigation against the strongest enemy in the current zone
   let mitPct = 0;
@@ -357,6 +392,8 @@ export function updateBattleDisplay() {
     if (enemyQiFill) enemyQiFill.style.width = '0%';
     const affixEl = document.getElementById('enemyAffixes');
     if (affixEl) affixEl.innerHTML = '';
+    const enemyAilEl = document.getElementById('enemyAilments');
+    if (enemyAilEl) enemyAilEl.innerHTML = '';
     const enemyStunFill = document.getElementById('enemyStunFill');
     if (enemyStunFill) {
       enemyStunFill.style.width = '0%';
@@ -697,6 +734,10 @@ export function updateAdventureCombat() {
         }
       }
     }
+  }
+  renderAilments(S, 'playerAilments');
+  if (S.adventure.currentEnemy) {
+    renderAilments(S.adventure.currentEnemy, 'enemyAilments');
   }
 }
 

--- a/src/features/combat/index.js
+++ b/src/features/combat/index.js
@@ -1,5 +1,5 @@
 import { combatState } from "./state.js";
-import { tickAilments } from "./statusEngine.js";
+import { tickAilments, tickStatuses } from "./statusEngine.js";
 import { registerFeature } from "../registry.js";
 
 export const CombatFeature = {
@@ -13,7 +13,11 @@ registerFeature({
   tick: (state, stepMs) => {
     const dtSec = stepMs / 1000;
     tickAilments(state, dtSec, state);
+    tickStatuses(state, dtSec, state);
     const enemy = state.adventure?.currentEnemy;
-    if (enemy) tickAilments(enemy, dtSec, state);
+    if (enemy) {
+      tickAilments(enemy, dtSec, state);
+      tickStatuses(enemy, dtSec, state);
+    }
   },
 });

--- a/style.css
+++ b/style.css
@@ -4229,6 +4229,10 @@ tr:last-child td {
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
 .combat-hud .player-name{font-size:.75rem;font-weight:600}
+.status-ailments{display:flex;gap:4px;margin-top:2px}
+.status-ailments .ailment{position:relative;width:20px;height:20px;font-size:16px;line-height:20px}
+.status-ailments .ailment .stack{position:absolute;bottom:-2px;right:-2px;font-size:10px;color:#fff;text-shadow:0 0 2px #000}
+.status-ailments .ailment .duration{position:absolute;top:-4px;left:50%;transform:translateX(-50%);font-size:9px;color:#fff;text-shadow:0 0 2px #000}
 .sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
 .sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}


### PR DESCRIPTION
## Summary
- display player and enemy ailments with stacks and remaining time
- style ailment icons and overlay text
- log ailment applications and expirations to combat log
- tick status durations and refresh HUD each combat frame

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b82f5edda483269becaa9586723261