### PR TITLE
Show combat ailments

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,6 +517,7 @@
                       <div class="qi-fill" id="playerQiFill"></div>
                       <span class="qi-text" id="playerQiText">0/0</span>
                     </div>
+                    <div class="status-ailments" id="playerAilments"></div>
                   </div>
                   <div class="stat-icons">
                     <span class="icon" id="playerAttack" title="ATK">⚔️</span>
@@ -540,6 +541,7 @@
                       <span class="qi-text" id="enemyQiText">--</span>
                     </div>
                     <div class="enemy-affixes" id="enemyAffixes"></div>
+                    <div class="status-ailments" id="enemyAilments"></div>
                   </div>
                   <div class="stat-icons">
                     <span class="icon" id="enemyAttack" title="ATK">⚔️</span>

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -147,14 +147,12 @@ function applyAbilityResult(abilityKey, res, state) {
       const compText = parts.length ? ` (${parts.join(', ')})` : '';
       logs?.push(`You used ${ability.displayName} for ${dealt} damage${compText}.`);
 
-      performAttack(state, atkTarget, { weapon, profile }, state);
+      performAttack(state, atkTarget, { weapon, profile, physDamage: components.phys }, state);
     }
 
     if (ability.status) {
       const { key, power } = ability.status;
-      if (Math.random() < power) {
-        applyAilment(attackerCtx, target, key, power, now);
-      }
+      applyAilment(attackerCtx, target, key, power, now);
     }
 
     if (res.stun) {

--- a/src/features/combat/data/status.js
+++ b/src/features/combat/data/status.js
@@ -41,6 +41,7 @@ export const STATUSES = {
   interrupt: { // STATUS-REFORM
     element: null,
     duration: 0.1,
+    maxStacks: 1,
   },
 };
 

--- a/src/features/combat/index.js
+++ b/src/features/combat/index.js
@@ -1,5 +1,5 @@
 import { combatState } from "./state.js";
-import { tickAilments } from "./statusEngine.js";
+import { tickAilments, tickStatuses } from "./statusEngine.js";
 import { registerFeature } from "../registry.js";
 
 export const CombatFeature = {
@@ -13,7 +13,11 @@ registerFeature({
   tick: (state, stepMs) => {
     const dtSec = stepMs / 1000;
     tickAilments(state, dtSec, state);
+    tickStatuses(state, dtSec, state);
     const enemy = state.adventure?.currentEnemy;
-    if (enemy) tickAilments(enemy, dtSec, state);
+    if (enemy) {
+      tickAilments(enemy, dtSec, state);
+      tickStatuses(enemy, dtSec, state);
+    }
   },
 });

--- a/src/features/combat/statusEngine.js
+++ b/src/features/combat/statusEngine.js
@@ -5,6 +5,7 @@ export function applyStatus(target, key, power, state, options = {}) { // STATUS
   const def = STATUSES[key];
   if (!def) return;
   const { attackerStats = {}, targetStats = {} } = options;
+  if (key === 'interrupt' && target.statuses?.[key]) return;
   if (!target.statuses) target.statuses = {};
   const current = target.statuses[key] || { stacks: 0, duration: 0 };
   current.stacks = Math.min(def.maxStacks ?? Infinity, current.stacks + 1);
@@ -16,6 +17,12 @@ export function applyStatus(target, key, power, state, options = {}) { // STATUS
   duration *= 1 - (targetStats.ccResist || 0);
   current.duration = duration;
   target.statuses[key] = current;
+  if (state?.adventure) {
+    state.adventure.combatLog = state.adventure.combatLog || [];
+    const targetName = target === state ? 'You' : target.name || 'Enemy';
+    const stackText = current.stacks > 1 ? ` x${current.stacks}` : '';
+    state.adventure.combatLog.push(`${targetName} afflicted with ${key}${stackText}`);
+  }
 }
 
 export function applyAilment(attacker, target, key, power, nowMs) {
@@ -64,6 +71,12 @@ export function tickAilments(entity, dtSec, state) {
 
     if (inst._lastStack !== inst.stacks) {
       def.onApply?.({ target: entity, stack: inst.stacks });
+      if (state?.adventure) {
+        state.adventure.combatLog = state.adventure.combatLog || [];
+        const targetName = entity === state ? 'You' : entity.name || 'Enemy';
+        const stackText = inst.stacks > 1 ? ` x${inst.stacks}` : '';
+        state.adventure.combatLog.push(`${targetName} afflicted with ${key}${stackText}`);
+      }
       inst._lastStack = inst.stacks;
     }
 
@@ -76,7 +89,34 @@ export function tickAilments(entity, dtSec, state) {
 
     if (inst.expires <= 0) {
       def.onExpire?.({ target: entity });
+      if (state?.adventure) {
+        state.adventure.combatLog = state.adventure.combatLog || [];
+        const targetName = entity === state ? 'You' : entity.name || 'Enemy';
+        state.adventure.combatLog.push(`${key} on ${targetName} expired`);
+      }
       delete entity.ailments[key];
+    }
+  }
+}
+
+export function tickStatuses(entity, dtSec, state) {
+  if (!entity?.statuses) return;
+  for (const key of Object.keys(entity.statuses)) {
+    const inst = entity.statuses[key];
+    const def = STATUSES[key];
+    if (!def) {
+      delete entity.statuses[key];
+      continue;
+    }
+    inst.duration -= dtSec;
+    if (inst.duration <= 0) {
+      def.onExpire?.({ target: entity });
+      if (state?.adventure) {
+        state.adventure.combatLog = state.adventure.combatLog || [];
+        const targetName = entity === state ? 'You' : entity.name || 'Enemy';
+        state.adventure.combatLog.push(`${key} on ${targetName} expired`);
+      }
+      delete entity.statuses[key];
     }
   }
 }

--- a/style.css
+++ b/style.css
@@ -4229,6 +4229,10 @@ tr:last-child td {
 .combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
 .combat-hud .player-name{font-size:.75rem;font-weight:600}
+.status-ailments{display:flex;gap:4px;margin-top:2px}
+.status-ailments .ailment{position:relative;width:20px;height:20px;font-size:16px;line-height:20px}
+.status-ailments .ailment .stack{position:absolute;bottom:-2px;right:-2px;font-size:10px;color:#fff;text-shadow:0 0 2px #000}
+.status-ailments .ailment .duration{position:absolute;top:-4px;left:50%;transform:translateX(-50%);font-size:9px;color:#fff;text-shadow:0 0 2px #000}
 .sprite-stage{position:relative;flex:0 0 auto;min-height:120px;display:flex;align-items:flex-start;justify-content:center;gap:24px;padding:8px}
 .sprite-stage .combatant{flex:0 0 auto;display:flex;align-items:flex-end;justify-content:center;position:relative}
 .sprite-stage .sprite{position:relative;width:72px;height:72px;border-radius:50%;background:radial-gradient(circle,rgba(255,255,255,.9)0%,rgba(255,255,255,.6)60%,rgba(255,255,255,0)70%),hsl(0,0%,80%);box-shadow:0 0 8px rgba(255,255,255,.6);animation:sprite-bob 2s ease-in-out infinite alternate}


### PR DESCRIPTION
## Summary
- display player and enemy ailments with stacks and remaining time
- style ailment icons and overlay text
- log ailment applications and expirations to combat log
- tick status durations and refresh HUD each combat frame
- scale physical interrupt chance with damage % of target max HP, ignoring <2% hits and preventing stacks
- remove extra RNG on elemental/ability ailments so effects like chill can trigger and show their icons

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b82f5edda483269becaa9586723261