### PR TITLE
Color floating combat damage by element

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -606,7 +606,24 @@ export function updateAdventureCombat() {
         S.adventure.combatLog.push(`You deal ${dealt} damage to ${S.adventure.currentEnemy.name}${compText}`);
         const enemyEl = document.querySelector('.combatant.enemy');
         if (enemyEl) {
-          showFloatingText({ targetEl: enemyEl, result: isCrit ? 'crit' : 'hit', amount: dealt });
+          if (components.phys) {
+            showFloatingText({
+              targetEl: enemyEl,
+              result: isCrit ? 'crit' : 'hit',
+              amount: components.phys,
+              element: 'phys',
+            });
+          }
+          for (const [elem, val] of Object.entries(components.elems)) {
+            if (val) {
+              showFloatingText({
+                targetEl: enemyEl,
+                result: isCrit ? 'crit' : 'hit',
+                amount: val,
+                element: elem,
+              });
+            }
+          }
         }
         S.adventure.enemyStunBar = S.adventure.currentEnemy.stun?.value || 0; // STATUS-REFORM
         performAttack(S, S.adventure.currentEnemy, { weapon, profile, isCrit, physDamage: components.phys }, S); // STATUS-REFORM
@@ -689,7 +706,24 @@ export function updateAdventureCombat() {
           S.adventure.combatLog.push(`${S.adventure.currentEnemy.name} deals ${taken} damage to you${compText}`);
           const playerEl = document.querySelector('.combatant.player');
           if (playerEl) {
-            showFloatingText({ targetEl: playerEl, result: isCrit ? 'crit' : 'hit', amount: taken });
+            if (components.phys) {
+              showFloatingText({
+                targetEl: playerEl,
+                result: isCrit ? 'crit' : 'hit',
+                amount: components.phys,
+                element: 'phys',
+              });
+            }
+            for (const [elem, val] of Object.entries(components.elems)) {
+              if (val) {
+                showFloatingText({
+                  targetEl: playerEl,
+                  result: isCrit ? 'crit' : 'hit',
+                  amount: val,
+                  element: elem,
+                });
+              }
+            }
           }
           performAttack(S.adventure.currentEnemy, S, { profile, isCrit, physDamage: components.phys }, S); // STATUS-REFORM
           S.adventure.playerStunBar = S.stun?.value || 0; // STATUS-REFORM

--- a/src/features/combat/ui/floatingText.js
+++ b/src/features/combat/ui/floatingText.js
@@ -39,7 +39,7 @@ export function setFloatingTextEnabled(v) {
   enabled = v;
 }
 
-export function showFloatingText({ targetEl, result, amount = 0 }) {
+export function showFloatingText({ targetEl, result, amount = 0, element }) {
   if (!enabled || !targetEl) return;
 
   const rect = targetEl.getBoundingClientRect();
@@ -53,7 +53,8 @@ export function showFloatingText({ targetEl, result, amount = 0 }) {
   if (result === 'miss') text = 'Miss';
   else text = result === 'crit' ? `${amount}!` : String(amount);
   node.textContent = text;
-  node.className = `fct fct-${result}`;
+  const elemClass = element ? ` fct-${element}` : '';
+  node.className = `fct fct-${result}${elemClass}`;
   node.style.visibility = 'hidden';
   document.body.appendChild(node);
 

--- a/style.css
+++ b/style.css
@@ -4530,13 +4530,20 @@ html.reduce-motion .log-sheet{transition:none;}
   will-change:transform,opacity;
 }
 .fct-crit{
-  color:#ffd700;
   font-weight:700;
 }
 .fct-miss{
   color:#9ab;
   font-style:italic;
 }
+.fct-phys{color:#fff;}
+.fct-fire{color:#f44336;}
+.fct-water{color:#2196f3;}
+.fct-wood{color:#4caf50;}
+.fct-earth{color:#795548;}
+.fct-metal{color:#c0c0c0;}
+.fct-cold{color:#80d8ff;}
+.fct-lightning{color:#ffeb3b;}
 
 /* Astral Skill Tree overlay */
 .astral-skill-tree{


### PR DESCRIPTION
## Summary
- Show floating combat text per damage component and tint by element
- Add elemental color classes and use them for crits and hits
- Adjust adventure combat to display each damage type separately

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(UI state violations and warnings; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ef0b26883268e6837c542261019