### PR TITLE
Trigger ailment effects on application

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -152,7 +152,7 @@ function applyAbilityResult(abilityKey, res, state) {
 
     if (ability.status) {
       const { key, power } = ability.status;
-      applyAilment(attackerCtx, target, key, power, now);
+      applyAilment(attackerCtx, target, key, power, now, state);
     }
 
     if (res.stun) {

--- a/src/features/combat/attack.js
+++ b/src/features/combat/attack.js
@@ -23,11 +23,11 @@ export function performAttack(attacker, target, options = {}, state) { // STATUS
 
   if (ability && ability.status) { // STATUS-REFORM
     const { key, power } = ability.status;
-    const applied = applyAilment(attackerCtx, target, key, isCrit ? 1 : power, now);
+    const applied = applyAilment(attackerCtx, target, key, isCrit ? 1 : power, now, state);
     console.log(`[status] ${key} ${applied ? 'applied' : 'failed'} ${isCrit ? '(crit)' : ''}`); // STATUS-REFORM
   } else if (attackElement && STATUSES_BY_ELEMENT[attackElement]) { // STATUS-REFORM
     const { key, power } = STATUSES_BY_ELEMENT[attackElement];
-    const applied = applyAilment(attackerCtx, target, key, isCrit ? 1 : power, now);
+    const applied = applyAilment(attackerCtx, target, key, isCrit ? 1 : power, now, state);
     console.log(`[status] ${key} ${applied ? 'applied' : 'failed'} ${isCrit ? '(crit)' : ''}`); // STATUS-REFORM
   }
 

--- a/src/features/combat/mutators.js
+++ b/src/features/combat/mutators.js
@@ -6,8 +6,8 @@ export function applyStatus(target, key, power, state = S, options) {
   return baseApplyStatus(target, key, power, state, options);
 }
 
-export function applyAilment(attacker, target, key, power, nowMs) {
-  return baseApplyAilment(attacker, target, key, power, nowMs);
+export function applyAilment(attacker, target, key, power, nowMs, state = S) {
+  return baseApplyAilment(attacker, target, key, power, nowMs, state);
 }
 
 export function initializeFight(enemy, state = S) {

--- a/src/features/combat/statusEngine.js
+++ b/src/features/combat/statusEngine.js
@@ -25,7 +25,7 @@ export function applyStatus(target, key, power, state, options = {}) { // STATUS
   }
 }
 
-export function applyAilment(attacker, target, key, power, nowMs) {
+export function applyAilment(attacker, target, key, power, nowMs, state) {
   const def = AILMENTS[key];
   if (!def || !target) return false;
   const attackerStats = attacker?.stats || {};
@@ -41,6 +41,17 @@ export function applyAilment(attacker, target, key, power, nowMs) {
   current.stacks = Math.min(def.maxStacks ?? Infinity, current.stacks + 1);
   current.expires = nowMs + def.baseDurationSec * 1000;
   target.ailments[key] = current;
+
+  def.onApply?.({ target, stack: current.stacks });
+  current._lastStack = current.stacks;
+
+  if (state?.adventure) {
+    state.adventure.combatLog = state.adventure.combatLog || [];
+    const targetName = target === state ? 'You' : target.name || 'Enemy';
+    const stackText = current.stacks > 1 ? ` x${current.stacks}` : '';
+    state.adventure.combatLog.push(`${targetName} afflicted with ${key}${stackText}`);
+  }
+
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Call `onApply` when ailments are inflicted and log the effect
- Plumb combat state through ailment helpers
- Update calls to pass state for logging

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: VERIFICATION FAILED - AI changes blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b87295fc3c8326823ec9f43eb28d6a