### PR TITLE
feat: add wood gathering activity

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -351,6 +351,14 @@ way-of-ascension/
 ├── src/features/combat/index.js
 ├── src/features/karma/index.js
 ├── src/features/mining/index.js
+├── src/features/gathering/index.js
+├── src/features/gathering/logic.js
+├── src/features/gathering/migrations.js
+├── src/features/gathering/mutators.js
+├── src/features/gathering/selectors.js
+├── src/features/gathering/state.js
+├── src/features/gathering/ui/
+│   └── gatheringDisplay.js
 ├── src/features/forging/index.js
 ├── src/features/physique/index.js
 └── style.css
@@ -1010,6 +1018,14 @@ Paths added:
 - `src/features/mining/selectors.js` – Provides accessors for mining state and derived rates.
 - `src/features/mining/ui/miningDisplay.js` – Updates mining activity and sidebar displays.
 
+### Gathering Feature (`src/features/gathering/`)
+- `src/features/gathering/index.js` – Gathering feature descriptor.
+- `src/features/gathering/state.js` – Tracks gathering level, experience, unlocked resources and yields.
+- `src/features/gathering/logic.js` – Handles wood gathering rates, resource gains and spirit wood chance.
+- `src/features/gathering/mutators.js` – External wrappers to modify gathering state and listeners for `ACTIVITY:START`.
+- `src/features/gathering/selectors.js` – Provides accessors for gathering state and derived rates.
+- `src/features/gathering/migrations.js` – Save migrations for gathering slice (currently none).
+- `src/features/gathering/ui/gatheringDisplay.js` – Updates gathering activity and sidebar displays.
 
 
 ### Forging Feature (`src/features/forging/`)

--- a/index.html
+++ b/index.html
@@ -443,6 +443,42 @@
         </div>
       </section>
 
+      <section id="activity-gathering" class="activity-content tab-content" style="display:none;">
+        <h2> Gathering</h2>
+        <div class="cards">
+          <div class="card">
+            <h4>Gathering Status</h4>
+            <div class="stat"><span>Gathering Level</span><span id="gatheringLevelActivity">1</span></div>
+            <div class="stat"><span>Experience</span><span><span id="gatheringExpActivity">0</span>/<span id="gatheringExpMaxActivity">100</span></span></div>
+            <div class="bar"><div class="fill" id="gatheringFillActivity"></div></div>
+            <div class="stat"><span>Currently Gathering</span><span id="currentlyGathering">Nothing</span></div>
+            <button class="btn primary" id="startGatheringActivity"> Start Gathering</button>
+          </div>
+
+          <div class="card">
+            <h4>Resource Selection</h4>
+            <p class="muted">Select which resource to gather. Gathering is passive - resources are gained automatically over time.</p>
+            <div class="mining-resources" id="gatheringResourceSelection">
+              <div class="resource-option" data-resource="wood">
+                <input type="radio" name="gatheringResource" id="gatherWood" value="wood" checked>
+                <label for="gatherWood">
+                  <span class="resource-icon"></span>
+                  <span class="resource-name">Wood</span>
+                  <span class="resource-rate" id="woodRate">+2-4/sec</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" id="gatheringStatsCard" style="display:none;">
+            <h4> Gathering Progress</h4>
+            <div class="stat"><span>Wood Collected</span><span id="gatheredWood">0</span></div>
+            <div class="stat"><span>Gathering Rate</span><span id="currentGatheringRate">0/sec</span></div>
+            <div class="muted" style="margin-top:8px">Gathering grants experience over time</div>
+          </div>
+        </div>
+      </section>
+
       <section id="activity-forging" class="activity-content tab-content" style="display:none;">
         <h2>⚒️ Forging</h2>
         <div class="cards">

--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -19,6 +19,7 @@ export function mountActivityUI(root) {
   document.getElementById('cultivationSelector')?.addEventListener('click', () => handle('cultivation'));
   document.getElementById('physiqueSelector')?.addEventListener('click', () => handle('physique'));
   document.getElementById('miningSelector')?.addEventListener('click', () => handle('mining'));
+  document.getElementById('gatheringSelector')?.addEventListener('click', () => handle('gathering'));
   document.getElementById('adventureSelector')?.addEventListener('click', () => handle('adventure'));
   document.getElementById('sectSelector')?.addEventListener('click', () => handle('sect'));
 
@@ -31,6 +32,7 @@ export function updateActivitySelectors(root) {
   // Ensure minimal slices exist for UI reads
   root.physique ??= { level: 1, exp: 0, expMax: 100 };
   root.mining   ??= { level: 1, exp: 0, expMax: 100 };
+  root.gathering ??= { level: 1, exp: 0, expMax: 100 };
 
   const selected = root.ui?.selectedActivity || 'cultivation';
 
@@ -89,6 +91,18 @@ export function updateActivitySelectors(root) {
     miningInfo.textContent = root.activities?.mining ? 'Mining...' : `Level ${root.mining.level}`;
   }
 
+  // Gathering
+  const gatheringSel = document.getElementById('gatheringSelector');
+  const gatheringFill = document.getElementById('gatheringSelectorFill');
+  const gatheringInfo = document.getElementById('gatheringInfo');
+  gatheringSel?.classList.toggle('active', selected === 'gathering');
+  gatheringSel?.classList.toggle('running', root.activities?.gathering);
+  if (gatheringFill && gatheringInfo) {
+    const expPct = (root.gathering.exp / root.gathering.expMax) * 100;
+    gatheringFill.style.width = `${expPct}%`;
+    gatheringInfo.textContent = root.activities?.gathering ? 'Gathering...' : `Level ${root.gathering.level}`;
+  }
+
   // Adventure
   const advSel = document.getElementById('adventureSelector');
   const advInfo = document.getElementById('adventureInfo');
@@ -113,6 +127,7 @@ export function updateCurrentTaskDisplay(root) {
     cultivation: 'Cultivating',
     physique: 'Physique Training',
     mining: 'Mining',
+    gathering: 'Gathering',
     forging: 'Forging',
     adventure: 'Adventuring',
     cooking: 'Cooking',

--- a/src/features/gathering/index.js
+++ b/src/features/gathering/index.js
@@ -1,0 +1,5 @@
+import { gatheringState } from "./state.js";
+export const GatheringFeature = {
+  key: "gathering",
+  initialState: () => ({ ...gatheringState, _v: 0 }),
+};

--- a/src/features/gathering/logic.js
+++ b/src/features/gathering/logic.js
@@ -1,0 +1,42 @@
+import { S } from '../../shared/state.js';
+import { log } from '../../shared/utils/dom.js';
+
+export function getGatheringRate(resource, state = S) {
+  const baseRates = {
+    wood: 3,
+  };
+  const levelBonus = state.gathering?.level ? state.gathering.level * 0.1 : 0;
+  return (baseRates[resource] || 1) * (1 + levelBonus);
+}
+
+export function selectResource(resource, state = S) {
+  if (!state.gathering) return;
+  if (state.gathering.unlockedResources?.includes(resource)) {
+    state.gathering.selectedResource = resource;
+    state.gathering.resourcesGained = 0;
+    log?.(`Switched gathering to ${resource}`, 'good');
+  }
+}
+
+export function advanceGathering(state = S) {
+  if (!state.activities?.gathering || !state.gathering?.selectedResource) return;
+  const totalRate = getGatheringRate(state.gathering.selectedResource, state);
+  switch (state.gathering.selectedResource) {
+    case 'wood':
+      state.wood = (state.wood || 0) + totalRate;
+      if (Math.random() < 0.05) {
+        state.spiritWood = (state.spiritWood || 0) + 1;
+        log?.('You found Spirit Wood!', 'good');
+      }
+      break;
+  }
+  state.gathering.resourcesGained = (state.gathering.resourcesGained || 0) + totalRate;
+  const expGain = 0.5;
+  state.gathering.exp += expGain;
+  if (state.gathering.exp >= state.gathering.expMax) {
+    state.gathering.level++;
+    state.gathering.exp = 0;
+    state.gathering.expMax = Math.floor(state.gathering.expMax * 1.3);
+    log?.(`Gathering level up! Level ${state.gathering.level}`, 'good');
+  }
+}

--- a/src/features/gathering/migrations.js
+++ b/src/features/gathering/migrations.js
@@ -1,0 +1,1 @@
+export const migrations = [];

--- a/src/features/gathering/mutators.js
+++ b/src/features/gathering/mutators.js
@@ -1,0 +1,22 @@
+import { S } from '../../shared/state.js';
+import { on } from '../../shared/events.js';
+import { gatheringState } from './state.js';
+import { selectResource as logicSelectResource, advanceGathering as logicAdvanceGathering } from './logic.js';
+
+// Initialize defaults when gathering starts
+on('ACTIVITY:START', ({ root, name }) => {
+  if (name !== 'gathering') return;
+  root.gathering ??= {
+    ...gatheringState,
+    unlockedResources: [...gatheringState.unlockedResources],
+    selectedResource: root.gathering?.selectedResource || gatheringState.selectedResource,
+  };
+});
+
+export function selectResource(resource, state = S) {
+  logicSelectResource(resource, state);
+}
+
+export function advanceGathering(state = S) {
+  logicAdvanceGathering(state);
+}

--- a/src/features/gathering/selectors.js
+++ b/src/features/gathering/selectors.js
@@ -1,0 +1,17 @@
+import { S } from '../../shared/state.js';
+import { getGatheringRate as logicGetGatheringRate } from './logic.js';
+
+export function getGatheringState(state = S) {
+  return state.gathering || {
+    level: 1,
+    exp: 0,
+    expMax: 100,
+    unlockedResources: ['wood'],
+    selectedResource: 'wood',
+    resourcesGained: 0,
+  };
+}
+
+export function getGatheringRate(resource, state = S) {
+  return logicGetGatheringRate(resource, state);
+}

--- a/src/features/gathering/state.js
+++ b/src/features/gathering/state.js
@@ -1,0 +1,8 @@
+export const gatheringState = {
+  level: 1,
+  exp: 0,
+  expMax: 100,
+  unlockedResources: ['wood'],
+  selectedResource: 'wood',
+  resourcesGained: 0,
+};

--- a/src/features/gathering/ui/gatheringDisplay.js
+++ b/src/features/gathering/ui/gatheringDisplay.js
@@ -1,0 +1,75 @@
+import { S } from '../../../shared/state.js';
+import { setText, log } from '../../../shared/utils/dom.js';
+import { on } from '../../../shared/events.js';
+import { getGatheringRate } from '../logic.js';
+
+export function updateActivityGathering(state = S) {
+  if (!state.gathering) return;
+  setText('gatheringLevelActivity', state.gathering.level);
+  setText('gatheringExpActivity', Math.floor(state.gathering.exp));
+  setText('gatheringExpMaxActivity', state.gathering.expMax);
+
+  const current = state.activities.gathering ? 'Wood' : 'Nothing';
+  setText('currentlyGathering', current);
+
+  const gatheringFillActivity = document.getElementById('gatheringFillActivity');
+  if (gatheringFillActivity) {
+    gatheringFillActivity.style.width = (state.gathering.exp / state.gathering.expMax * 100) + '%';
+  }
+
+  const startBtn = document.getElementById('startGatheringActivity');
+  if (startBtn) {
+    startBtn.textContent = state.activities.gathering ? '🛑 Stop Gathering' : '🪓 Start Gathering';
+    startBtn.onclick = () => state.activities.gathering ? window.stopActivity('gathering') : window.startActivity('gathering');
+  }
+
+  const selectedRadio = document.querySelector(`input[name="gatheringResource"][value="${state.gathering.selectedResource}"]`);
+  if (selectedRadio) selectedRadio.checked = true;
+
+  const gatheringStatsCard = document.getElementById('gatheringStatsCard');
+  if (gatheringStatsCard) gatheringStatsCard.style.display = state.activities.gathering ? 'block' : 'none';
+
+  if (state.activities.gathering) {
+    setText('gatheredWood', state.gathering.resourcesGained || 0);
+    const baseRate = getGatheringRate('wood', state);
+    setText('currentGatheringRate', `${baseRate.toFixed(1)}/sec`);
+  }
+
+  updateGatheringRateDisplays(state);
+}
+
+function updateGatheringRateDisplays(state = S) {
+  const woodRate = getGatheringRate('wood', state);
+  setText('woodRate', `+${woodRate.toFixed(1)}/sec`);
+}
+
+export function updateGatheringSidebar(state = S) {
+  if (!state.gathering) return;
+  setText('gatheringLevel', `Level ${state.gathering.level}`);
+  const fill = document.getElementById('gatheringProgressFill');
+  if (fill) {
+    const progressPct = Math.floor(state.gathering.exp / state.gathering.expMax * 100);
+    fill.style.width = progressPct + '%';
+    setText('gatheringProgressText', progressPct + '%');
+  }
+}
+
+export function mountGatheringUI(state = S) {
+  on('RENDER', () => {
+    updateActivityGathering(state);
+    updateGatheringSidebar(state);
+  });
+
+  const gatheringResourceInputs = document.querySelectorAll('input[name="gatheringResource"]');
+  gatheringResourceInputs.forEach(input => {
+    input.addEventListener('change', e => {
+      if (!state.gathering) return;
+      state.gathering.selectedResource = e.target.value;
+      state.gathering.resourcesGained = 0;
+      log(`Switched gathering to ${e.target.value === 'wood' ? 'Wood' : e.target.value}`, 'good');
+    });
+  });
+
+  updateActivityGathering(state);
+  updateGatheringSidebar(state);
+}

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -8,6 +8,7 @@ import { mountAlchemyUI } from "./alchemy/ui/alchemyDisplay.js";
 import { mountCookingUI } from "./cooking/ui/cookingDisplay.js";
 import { mountLawDisplay } from "./progression/ui/lawDisplay.js";
 import { mountMiningUI } from "./mining/ui/miningDisplay.js";
+import { mountGatheringUI } from "./gathering/ui/gatheringDisplay.js";
 import { mountPhysiqueUI } from "./physique/ui/physiqueDisplay.js";
 import { mountMindReadingUI } from "./mind/ui/mindReadingTab.js";
 import { mountAstralTreeUI } from "./progression/ui/astralTree.js";
@@ -24,6 +25,7 @@ export function mountAllFeatureUIs(state) {
   mountAlchemyUI(state);
   mountCookingUI(state);
   mountMiningUI(state);
+  mountGatheringUI(state);
   mountForgingUI(state);
   mountPhysiqueUI(state);
   mountLawDisplay(state);

--- a/src/features/inventory/ui/resourceDisplay.js
+++ b/src/features/inventory/ui/resourceDisplay.js
@@ -9,6 +9,7 @@ export function updateResourceDisplay(state = S) {
   setText('herbVal', fmt(state.herbs));
   setText('oreVal', fmt(state.ore));
   setText('woodVal', fmt(state.wood));
+  setText('spiritWoodVal', fmt(state.spiritWood));
   setText('coreVal', fmt(state.cores));
   setText('pillQi', state.pills.qi);
   setText('pillBody', state.pills.body);

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -7,6 +7,7 @@ import { karmaState } from '../features/karma/state.js';
 import { miningState } from '../features/mining/state.js';
 import { physiqueState } from '../features/physique/state.js';
 import { forgingState } from '../features/forging/state.js';
+import { gatheringState } from '../features/gathering/state.js';
 
 export function loadSave(){
   try{
@@ -54,7 +55,7 @@ export const defaultState = () => {
   autoFillShieldFromQi: true,
   stunBar: 0, // STATUS-REFORM player stun accumulation
   realm: { tier: 0, stage: 1 },
-  wood:0, cores:0,
+  wood:0, spiritWood:0, cores:0,
   pills:{qi:0, body:0, ward:0},
   atkBase:5, armorBase:2, tempAtk:0, tempArmor:0,
   // Expanded Stat System
@@ -80,6 +81,7 @@ export const defaultState = () => {
     cultivation: false,
     physique: false,
     mining: false,
+    gathering: false,
     adventure: false,
     cooking: false,
     alchemy: false,
@@ -88,6 +90,7 @@ export const defaultState = () => {
   // Activity data containers
   physique: structuredClone(physiqueState),
   mining: structuredClone(miningState),
+  gathering: structuredClone(gatheringState),
   forging: structuredClone(forgingState),
   cooking: {
     level: 1,
@@ -195,7 +198,7 @@ recalculateBuildingBonuses(S);
 // single source of truth for all items.  These properties are not
 // serialized directly; instead their values are derived from the
 // corresponding entries in `S.inventory`.
-['stones', 'ore', 'herbs', 'wood'].forEach(key => {
+['stones', 'ore', 'herbs', 'wood', 'spiritWood'].forEach(key => {
   const initial = S[key] || 0;
   Object.defineProperty(S, key, {
     get() {

--- a/src/ui/sidebar.js
+++ b/src/ui/sidebar.js
@@ -34,6 +34,17 @@ export function renderSidebarActivities() {
       cost: {}
     },
     {
+      id: 'gathering',
+      label: 'Gathering',
+      icon: '<iconify-icon icon="mdi:axe" class="ui-icon" width="20"></iconify-icon>',
+      group: 'leveling',
+      levelId: 'gatheringLevel',
+      initialLevel: 'Level 1',
+      progressFillId: 'gatheringProgressFill',
+      progressTextId: 'gatheringProgressText',
+      cost: {},
+    },
+    {
       id: 'forging',
       label: 'Forging',
       icon: '<iconify-icon icon="mdi:anvil" class="ui-icon" width="20"></iconify-icon>',

--- a/style.css
+++ b/style.css
@@ -3899,6 +3899,11 @@ tr:last-child td {
   width: 0%;
 }
 
+#gatheringProgressFill {
+  background: linear-gradient(90deg, #22c55e, #16a34a) !important; /* Green for gathering */
+  width: 0%;
+}
+
 #cookingProgressFillSidebar {
   background: linear-gradient(90deg, #22c55e, #16a34a) !important; /* Green for cooking */
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -50,8 +50,10 @@ import { tickAbilityCooldowns } from '../src/features/ability/mutators.js';
 import { setupAbilityUI } from '../src/features/ability/ui.js';
 import { recomputePlayerTotals } from '../src/features/inventory/logic.js';
 import { advanceMining } from '../src/features/mining/logic.js';
+import { advanceGathering } from '../src/features/gathering/logic.js';
 import { advanceForging } from '../src/features/forging/logic.js';
 import { mountMiningUI } from '../src/features/mining/ui/miningDisplay.js';
+import { mountGatheringUI } from '../src/features/gathering/ui/gatheringDisplay.js';
 import { mountForgingUI } from '../src/features/forging/ui/forgingDisplay.js';
 import { mountAlchemyUI } from '../src/features/alchemy/ui/alchemyDisplay.js';
 import { mountKarmaUI } from '../src/features/karma/ui/karmaDisplay.js';
@@ -120,6 +122,7 @@ function initUI(){
   initializeWeaponChip({ key: mhKey, name: mhName });
   mountTrainingGameUI(S);
   mountMiningUI(S);
+  mountGatheringUI(S);
   mountForgingUI(S);
   setupAbilityUI();
 
@@ -476,6 +479,7 @@ function tick(){
   
   // Passive mining progression
   advanceMining(S);
+  advanceGathering(S);
   advanceForging(S);
   
   // Physique training progression


### PR DESCRIPTION
## Summary
- add gathering feature for collecting wood with a chance for spirit wood
- hook gathering UI and progression into activity system and sidebar
- document new gathering files in project structure

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation)


------
https://chatgpt.com/codex/tasks/task_e_68b8b9aba278832690987be9920e4036