### PR TITLE
feat: add agility training system with obstacle courses

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,73 @@
         </div>
       </section>
 
+      <section id="activity-agility" class="activity-content tab-content" style="display:none;">
+        <h2> Agility Training</h2>
+        <div class="cards">
+          <div class="card">
+            <h4>Training Status</h4>
+            <div class="stat"><span>Agility Level</span><span id="agilityLevelActivity">1</span></div>
+            <div class="stat"><span>Experience</span><span><span id="agilityExpActivity">0</span>/<span id="agilityExpMaxActivity">100</span></span></div>
+            <div class="bar"><div class="fill" id="agilityFillActivity"></div></div>
+            <div class="stat"><span>Stamina</span><span><span id="agilityCurrentStamina">100</span>/<span id="agilityMaxStamina">100</span></span></div>
+            <div class="bar"><div class="fill" id="agilityStaminaFill"></div></div>
+            <button class="btn primary" id="startAgilityActivity"> Start Training</button>
+          </div>
+
+          <div class="card" id="agilityActiveTrainingCard" style="display:none;">
+            <h4> Training Session</h4>
+            <p class="muted">Start a training session! Stamina drains during training. Hit the perfect zone for maximum XP!</p>
+
+            <div class="training-interface">
+              <div class="session-controls" id="agilitySessionControls">
+                <button class="btn primary" id="startAgilityTrainingSession"> Start Training Session</button>
+                <div class="muted" style="margin-top:8px">Sessions drain stamina continuously. Hit the green zone for best results!</div>
+              </div>
+
+              <div class="training-game" id="agilityTrainingGame" style="display:none;">
+                <div class="timing-bar-container">
+                  <div class="timing-bar" id="agilityTimingBar">
+                    <div class="perfect-zone" id="agilityPerfectZone"></div>
+                    <div class="timing-cursor" id="agilityTimingCursor"></div>
+                  </div>
+                </div>
+
+                <div class="game-controls">
+                  <button class="btn primary large" id="agilityHitButton"> HIT!</button>
+                  <div class="session-info">
+                    <div class="stat"><span>Session Stamina</span><span id="agilitySessionStamina">100</span></div>
+                    <div class="stat"><span>Hits This Session</span><span id="agilitySessionHits">0</span></div>
+                    <div class="stat"><span>Session XP</span><span id="agilitySessionXP">0</span></div>
+                  </div>
+                </div>
+
+                <div class="muted" style="margin-top:8px">
+                  Perfect (Green): 15-25 XP | Good (Yellow): 8-12 XP | Poor (Red): 3-5 XP
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card" id="agilityCoursesCard" style="display:none;">
+            <h4> Obstacle Courses</h4>
+            <div class="stat"><span>Courses Built</span><span id="obstacleCourseCount">0</span></div>
+            <div class="stat"><span>XP Bonus</span><span id="agilityXpMult">+0% XP</span></div>
+            <div class="stat"><span>Next Cost</span><span id="obstacleCourseCost">50 stone, 50 wood</span></div>
+            <button class="btn primary" id="buildObstacleCourse">Build Course</button>
+          </div>
+
+          <div class="card" id="agilityEffectsCard" style="display:none;">
+            <h4> Agility Effects</h4>
+            <p class="muted">Current bonuses from your agility stat:</p>
+            <div class="stat"><span>Current Agility</span><span id="currentAgilityStat">10</span></div>
+            <div class="stat"><span>Accuracy Bonus</span><span id="agilityAccuracyStat">+0</span></div>
+            <div class="stat"><span>Dodge Bonus</span><span id="agilityDodgeStat">+0</span></div>
+            <div class="stat"><span>Forge Speed</span><span id="agilityForgeSpeedStat">+0%</span></div>
+            <div class="muted" style="margin-top:8px">Higher agility improves accuracy, dodge, and forging speed</div>
+          </div>
+        </div>
+      </section>
+
       <section id="activity-mining" class="activity-content tab-content" style="display:none;">
         <h2> Mining</h2>
         <div class="cards">

--- a/src/features/activity/index.js
+++ b/src/features/activity/index.js
@@ -3,6 +3,7 @@ export const ActivityFeature = {
   initialState: () => ({
     cultivation: false,
     physique: false,
+    agility: false,
     mining: false,
     adventure: false,
     cooking: false,

--- a/src/features/activity/state.js
+++ b/src/features/activity/state.js
@@ -4,6 +4,7 @@ export function ensureActivities(root) {
     root.activities = {
       cultivation: false,
       physique: false,
+      agility: false,
       mining: false,
       adventure: false,
       cooking: false,

--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -18,6 +18,7 @@ export function mountActivityUI(root) {
 
   document.getElementById('cultivationSelector')?.addEventListener('click', () => handle('cultivation'));
   document.getElementById('physiqueSelector')?.addEventListener('click', () => handle('physique'));
+  document.getElementById('agilitySelector')?.addEventListener('click', () => handle('agility'));
   document.getElementById('miningSelector')?.addEventListener('click', () => handle('mining'));
   document.getElementById('gatheringSelector')?.addEventListener('click', () => handle('gathering'));
   document.getElementById('adventureSelector')?.addEventListener('click', () => handle('adventure'));
@@ -31,6 +32,7 @@ export function mountActivityUI(root) {
 export function updateActivitySelectors(root) {
   // Ensure minimal slices exist for UI reads
   root.physique ??= { level: 1, exp: 0, expMax: 100 };
+  root.agility  ??= { level: 1, exp: 0, expMax: 100 };
   root.mining   ??= { level: 1, exp: 0, expMax: 100 };
   root.gathering ??= { level: 1, exp: 0, expMax: 100 };
 
@@ -77,6 +79,17 @@ export function updateActivitySelectors(root) {
     const expPct = (root.physique.exp / root.physique.expMax) * 100;
     physFill.style.width = `${expPct}%`;
     physInfo.textContent = root.activities?.physique ? 'Training...' : `Level ${root.physique.level}`;
+  }
+
+  const agiSel = document.getElementById('agilitySelector');
+  const agiFill = document.getElementById('agilitySelectorFill');
+  const agiInfo = document.getElementById('agilityInfo');
+  agiSel?.classList.toggle('active', selected === 'agility');
+  agiSel?.classList.toggle('running', root.activities?.agility);
+  if (agiFill && agiInfo) {
+    const expPct = (root.agility.exp / root.agility.expMax) * 100;
+    agiFill.style.width = `${expPct}%`;
+    agiInfo.textContent = root.activities?.agility ? 'Training...' : `Level ${root.agility.level}`;
   }
 
   // Mining
@@ -129,6 +142,7 @@ export function updateCurrentTaskDisplay(root) {
     mining: 'Mining',
     gathering: 'Gathering',
     forging: 'Forging',
+    agility: 'Agility Training',
     adventure: 'Adventuring',
     cooking: 'Cooking',
     alchemy: 'Brewing'

--- a/src/features/agility/index.js
+++ b/src/features/agility/index.js
@@ -1,0 +1,6 @@
+import { agilityState } from './state.js';
+
+export const AgilityFeature = {
+  key: 'agility',
+  initialState: () => ({ ...agilityState, _v: 0 }),
+};

--- a/src/features/agility/logic.js
+++ b/src/features/agility/logic.js
@@ -1,0 +1,59 @@
+import { agilityState } from './state.js';
+
+function slice(state){
+  return state.agility || state;
+}
+
+export function getAgilityEffects(state){
+  const root = state.stats ? state : { stats: { agility: 10 } };
+  const current = root.stats.agility || 10;
+  const accuracyBonus = Math.floor(current * 2);
+  const dodgeBonus = Math.floor(current * 0.5);
+  const forgeSpeed = 1 + current * 0.02;
+  return { accuracyBonus, dodgeBonus, forgeSpeed };
+}
+
+export function getSlice(state = agilityState){
+  return slice(state);
+}
+
+export function stepTrainingCursor(position, direction, speed){
+  let pos = position + direction * speed;
+  let dir = direction;
+  if(pos >= 100){ pos = 100; dir = -1; }
+  else if(pos <= 0){ pos = 0; dir = 1; }
+  return { position: pos, direction: dir };
+}
+
+export function evaluateTrainingHit(cursorPosition, hitStreak){
+  const perfectZoneStart = 45;
+  const perfectZoneEnd = 55;
+  const goodZoneStart = 35;
+  const goodZoneEnd = 65;
+
+  let xpGain = 3 + Math.random() * 2;
+  let hitMessage = 'Poor timing!';
+  let hitColor = '#dc2626';
+  let streak = hitStreak;
+  let perfectHits = 0;
+
+  if(cursorPosition >= perfectZoneStart && cursorPosition <= perfectZoneEnd){
+    xpGain = 15 + Math.random() * 10;
+    hitMessage = 'PERFECT!';
+    hitColor = '#22c55e';
+    streak += 1;
+    perfectHits = 1;
+  }else if(cursorPosition >= goodZoneStart && cursorPosition <= goodZoneEnd){
+    xpGain = 8 + Math.random() * 4;
+    hitMessage = 'Good!';
+    hitColor = '#f59e0b';
+    streak = Math.max(0, streak - 1);
+  }else{
+    streak = 0;
+  }
+
+  const streakBonus = Math.min(streak * 0.05, 0.5);
+  xpGain *= (1 + streakBonus);
+
+  return { xpGain, hitMessage, hitColor, hitStreak: streak, perfectHits };
+}

--- a/src/features/agility/mutators.js
+++ b/src/features/agility/mutators.js
@@ -1,0 +1,130 @@
+import { agilityState } from './state.js';
+import { stepTrainingCursor, evaluateTrainingHit, getAgilityEffects } from './logic.js';
+import { ACCURACY_BASE, DODGE_BASE } from '../combat/hit.js';
+
+function slice(state){
+  return state.agility || state;
+}
+
+export function addAgilityExp(amount, state = agilityState){
+  const p = slice(state);
+  const mult = 1 + (p.obstacleCourses || 0) * 0.1;
+  p.exp = (p.exp || 0) + amount * mult;
+  while(p.exp >= p.expMax){
+    p.exp -= p.expMax;
+    p.level++;
+    p.expMax = Math.floor(p.expMax * 1.4);
+    if(state.stats){
+      state.stats.agility = (state.stats.agility || 10) + 1;
+      const { accuracyBonus, dodgeBonus } = getAgilityEffects(state);
+      state.stats.accuracy = ACCURACY_BASE + accuracyBonus;
+      state.stats.dodge = DODGE_BASE + dodgeBonus;
+    }
+  }
+  return p.exp;
+}
+
+export function consumeAgilityStamina(amount, state = agilityState){
+  const p = slice(state);
+  p.stamina = Math.max(0, (p.stamina || 0) - amount);
+  return p.stamina;
+}
+
+export function regenAgilityStamina(amount, state = agilityState){
+  const p = slice(state);
+  p.stamina = Math.min(p.maxStamina, (p.stamina || 0) + amount);
+  return p.stamina;
+}
+
+export function trainAgility(state = agilityState){
+  const root = state;
+  if(!root.activities?.agility){
+    return { message: 'You must be training agility to practice!', type: 'bad' };
+    }
+  const baseExp = 5 + Math.floor(Math.random() * 10);
+  const expGain = Math.floor(baseExp);
+  addAgilityExp(expGain, state);
+  return { message: `Training session complete! +${expGain} agility exp`, type: 'good' };
+}
+
+export function startTrainingSession(state = agilityState){
+  const p = slice(state);
+  if(p.stamina < 20) return false;
+  p.trainingSession = true;
+  p.timingActive = true;
+  p.sessionStamina = p.stamina;
+  p.sessionHits = 0;
+  p.sessionXP = 0;
+  p.cursorPosition = 0;
+  p.cursorDirection = 1;
+  p.cursorSpeed = 7;
+  p.hitStreak = 0;
+  p.perfectHits = 0;
+  return true;
+}
+
+export function endTrainingSession(state = agilityState){
+  const p = slice(state);
+  if(!p.trainingSession) return null;
+  p.trainingSession = false;
+  p.timingActive = false;
+  const summary = { hits: p.sessionHits, xp: Math.floor(p.sessionXP) };
+  p.sessionStamina = 0;
+  p.sessionHits = 0;
+  p.sessionXP = 0;
+  p.hitStreak = 0;
+  p.perfectHits = 0;
+  p.cursorSpeed = 0;
+  return summary;
+}
+
+export function moveTrainingCursor(state = agilityState, dt = 1){
+  const p = slice(state);
+  if(!p.timingActive || !p.trainingSession) return;
+  if(!p.cursorSpeed) p.cursorSpeed = 5;
+  const speed = p.cursorSpeed * 3 * dt;
+  const { position, direction } = stepTrainingCursor(p.cursorPosition, p.cursorDirection, speed);
+  p.cursorPosition = position;
+  p.cursorDirection = direction;
+}
+
+export function hitTrainingTarget(state = agilityState){
+  const p = slice(state);
+  if(!p.trainingSession || !p.timingActive) return { message: '', color: '' };
+  const result = evaluateTrainingHit(p.cursorPosition, p.hitStreak || 0);
+  p.hitStreak = result.hitStreak;
+  p.perfectHits = (p.perfectHits || 0) + result.perfectHits;
+  p.sessionHits = (p.sessionHits || 0) + 1;
+  p.sessionXP = (p.sessionXP || 0) + result.xpGain;
+  addAgilityExp(result.xpGain, state);
+  p.cursorSpeed = Math.min((p.cursorSpeed || 0) + 1.5, 25);
+  return { message: result.hitMessage, color: result.hitColor };
+}
+
+export function tickAgilityTraining(state = agilityState){
+  const p = slice(state);
+  if(p.trainingSession){
+    p.sessionStamina -= 6;
+    consumeAgilityStamina(6, state);
+    if(p.sessionStamina <= 0 || p.stamina <= 0){
+      return endTrainingSession(state);
+    }
+  }else{
+    regenAgilityStamina(0.03 * (1 + (state.stats?.agility || 10) * 0.1), state);
+  }
+  return null;
+}
+
+export function buildObstacleCourse(state = agilityState){
+  const p = slice(state);
+  const count = p.obstacleCourses || 0;
+  const stoneCost = Math.floor(50 * Math.pow(1.5, count));
+  const woodCost = Math.floor(50 * Math.pow(1.5, count));
+  if((state.stones||0) < stoneCost || (state.wood||0) < woodCost){
+    return false;
+  }
+  state.stones -= stoneCost;
+  state.wood -= woodCost;
+  p.obstacleCourses = count + 1;
+  return true;
+}

--- a/src/features/agility/selectors.js
+++ b/src/features/agility/selectors.js
@@ -1,0 +1,51 @@
+import { agilityState } from './state.js';
+import { getAgilityEffects } from './logic.js';
+
+function slice(state){
+  return state.agility || state;
+}
+
+export function getAgilityLevel(state = agilityState){
+  return slice(state).level || 1;
+}
+
+export function getAgilityExp(state = agilityState){
+  return slice(state).exp || 0;
+}
+
+export function getAgilityExpMax(state = agilityState){
+  return slice(state).expMax || 100;
+}
+
+export function getAgilityStamina(state = agilityState){
+  return slice(state).stamina || 0;
+}
+
+export function getAgilityMaxStamina(state = agilityState){
+  return slice(state).maxStamina || 0;
+}
+
+export function getAgilityBonuses(state){
+  return getAgilityEffects(state);
+}
+
+export function isAgilityTraining(state = agilityState){
+  return !!slice(state).trainingSession;
+}
+
+export function getTrainingSessionStats(state = agilityState){
+  const p = slice(state);
+  return {
+    sessionStamina: p.sessionStamina || 0,
+    sessionHits: p.sessionHits || 0,
+    sessionXP: p.sessionXP || 0,
+  };
+}
+
+export function getTrainingCursorPosition(state = agilityState){
+  return slice(state).cursorPosition || 0;
+}
+
+export function getObstacleCourses(state = agilityState){
+  return slice(state).obstacleCourses || 0;
+}

--- a/src/features/agility/state.js
+++ b/src/features/agility/state.js
@@ -1,0 +1,18 @@
+export const agilityState = {
+  level: 1,
+  exp: 0,
+  expMax: 100,
+  stamina: 100,
+  maxStamina: 100,
+  trainingSession: false,
+  timingActive: false,
+  sessionStamina: 0,
+  sessionHits: 0,
+  sessionXP: 0,
+  cursorPosition: 0,
+  cursorDirection: 1,
+  cursorSpeed: 0,
+  perfectHits: 0,
+  hitStreak: 0,
+  obstacleCourses: 0,
+};

--- a/src/features/agility/ui/agilityDisplay.js
+++ b/src/features/agility/ui/agilityDisplay.js
@@ -1,0 +1,31 @@
+import { on } from '../../../shared/events.js';
+import { setText } from '../../../shared/utils/dom.js';
+import { getAgilityBonuses, getObstacleCourses } from '../selectors.js';
+import { buildObstacleCourse } from '../mutators.js';
+
+function render(state){
+  const bonuses = getAgilityBonuses(state);
+  setText('currentAgilityStat', state.stats?.agility || 10);
+  setText('agilityAccuracyStat', `+${bonuses.accuracyBonus}`);
+  setText('agilityDodgeStat', `+${bonuses.dodgeBonus}`);
+  setText('agilityForgeSpeedStat', `+${Math.floor((bonuses.forgeSpeed - 1) * 100)}%`);
+  const courses = getObstacleCourses(state);
+  setText('obstacleCourseCount', courses);
+  setText('agilityXpMult', `+${courses * 10}% XP`);
+  const nextStone = Math.floor(50 * Math.pow(1.5, courses));
+  const nextWood = Math.floor(50 * Math.pow(1.5, courses));
+  setText('obstacleCourseCost', `${nextStone} stone, ${nextWood} wood`);
+}
+
+export function mountAgilityUI(state){
+  const buildBtn = document.getElementById('buildObstacleCourse');
+  if(buildBtn){
+    buildBtn.addEventListener('click', () => {
+      if(buildObstacleCourse(state)){
+        render(state);
+      }
+    });
+  }
+  on('RENDER', () => render(state));
+  render(state);
+}

--- a/src/features/agility/ui/trainingGame.js
+++ b/src/features/agility/ui/trainingGame.js
@@ -1,0 +1,147 @@
+import { on } from '../../../shared/events.js';
+import { setText, log } from '../../../shared/utils/dom.js';
+import { startTrainingSession, hitTrainingTarget, trainAgility, moveTrainingCursor } from '../mutators.js';
+import {
+  getAgilityLevel,
+  getAgilityExp,
+  getAgilityExpMax,
+  getAgilityStamina,
+  getAgilityMaxStamina,
+  getTrainingSessionStats,
+  getTrainingCursorPosition,
+  isAgilityTraining
+} from '../selectors.js';
+
+function render(state){
+  setText('agilityLevelActivity', getAgilityLevel(state));
+  setText('agilityExpActivity', Math.floor(getAgilityExp(state)));
+  setText('agilityExpMaxActivity', getAgilityExpMax(state));
+  setText('agilityCurrentStamina', Math.floor(getAgilityStamina(state)));
+  setText('agilityMaxStamina', getAgilityMaxStamina(state));
+
+  const agilityFillActivity = document.getElementById('agilityFillActivity');
+  if(agilityFillActivity){
+    const expPercent = getAgilityExp(state) / getAgilityExpMax(state) * 100;
+    agilityFillActivity.style.width = expPercent + '%';
+  }
+
+  const staminaFill = document.getElementById('agilityStaminaFill');
+  if(staminaFill){
+    const staminaPercent = getAgilityStamina(state) / getAgilityMaxStamina(state) * 100;
+    staminaFill.style.width = staminaPercent + '%';
+  }
+
+  const session = getTrainingSessionStats(state);
+  const active = isAgilityTraining(state);
+  const sessionControls = document.getElementById('agilitySessionControls');
+  const trainingGame = document.getElementById('agilityTrainingGame');
+  if(sessionControls && trainingGame){
+    if(active){
+      sessionControls.style.display = 'none';
+      trainingGame.style.display = 'block';
+      setText('agilitySessionStamina', Math.floor(session.sessionStamina));
+      setText('agilitySessionHits', session.sessionHits);
+      setText('agilitySessionXP', Math.floor(session.sessionXP));
+    }else{
+      sessionControls.style.display = 'block';
+      trainingGame.style.display = 'none';
+    }
+  }
+
+  // Start cursor animation if a session is active
+  if(active && cursorAnimFrame === null){
+    startCursorAnimation(state);
+  }
+
+  const startSessionBtn = document.getElementById('startAgilityTrainingSession');
+  if(startSessionBtn){
+    const canStart = getAgilityStamina(state) >= 20;
+    startSessionBtn.disabled = !canStart;
+    startSessionBtn.textContent = canStart ? '🚀 Start Training Session' : '😴 Need 20+ Stamina';
+  }
+
+  const cursor = document.getElementById('agilityTimingCursor');
+  if(cursor){
+    cursor.style.left = getTrainingCursorPosition(state) + '%';
+  }
+
+  const startBtn = document.getElementById('startAgilityActivity');
+  if(startBtn){
+    startBtn.textContent = state.activities?.agility ? '🛑 Stop Training' : '🏃 Start Training';
+    startBtn.onclick = () => state.activities?.agility ? globalThis.stopActivity('agility') : globalThis.startActivity('agility');
+  }
+}
+
+function showHitFeedback(message, color){
+  const el = document.getElementById('agilityHitFeedback');
+  if(el){
+    el.textContent = message;
+    el.style.color = color;
+    el.style.opacity = '1';
+    setTimeout(() => { el.style.opacity = '0'; }, 500);
+  }
+}
+
+let cursorAnimFrame = null;
+let lastFrameTime = 0;
+let animState;
+
+function animateCursor(timestamp){
+  if(!isAgilityTraining(animState)){
+    cursorAnimFrame = null;
+    return;
+  }
+  const dt = lastFrameTime ? (timestamp - lastFrameTime) / 1000 : 0;
+  lastFrameTime = timestamp;
+  moveTrainingCursor(animState, dt);
+  const cursor = document.getElementById('agilityTimingCursor');
+  if(cursor){
+    cursor.style.left = getTrainingCursorPosition(animState) + '%';
+  }
+  cursorAnimFrame = requestAnimationFrame(animateCursor);
+}
+
+function startCursorAnimation(state){
+  animState = state;
+  lastFrameTime = performance.now();
+  cursorAnimFrame = requestAnimationFrame(animateCursor);
+}
+
+export function mountAgilityTrainingUI(state){
+  const cardIds = ['agilityActiveTrainingCard', 'agilityEffectsCard', 'agilityCoursesCard'];
+  for (const id of cardIds) {
+    const el = document.getElementById(id);
+    if (el) el.style.display = 'block';
+  }
+
+  const startBtn = document.getElementById('startAgilityTrainingSession');
+  if(startBtn){
+    startBtn.addEventListener('click', () => {
+      if(startTrainingSession(state)){
+        log('Agility session started! Hit the perfect zone for maximum XP!', 'good');
+        startCursorAnimation(state);
+        render(state);
+      }
+    });
+  }
+
+  const hitBtn = document.getElementById('agilityHitButton');
+  if(hitBtn){
+    hitBtn.addEventListener('click', () => {
+      const { message, color } = hitTrainingTarget(state);
+      showHitFeedback(message, color);
+    });
+  }
+
+  const dummyBtn = document.getElementById('trainAgilityBtn');
+  if(dummyBtn){
+    dummyBtn.addEventListener('click', () => {
+      const res = trainAgility(state);
+      if(res?.message) log(res.message, res.type);
+    });
+  }
+
+  on('RENDER', () => render(state));
+  render(state);
+}
+

--- a/src/features/forging/logic.js
+++ b/src/features/forging/logic.js
@@ -1,11 +1,13 @@
 import { S } from '../../shared/state.js';
 import { log } from '../../shared/utils/dom.js';
+import { getAgilityEffects } from '../agility/logic.js';
 
 export function getForgingTime(tier, state = S) {
   const baseMinutes = tier === 0 ? 1 : Math.pow(3, tier + 1);
   const level = state.forging?.level || 1;
   const reduction = Math.pow(0.95, Math.max(0, level - 1));
-  return baseMinutes * 60 * reduction; // seconds
+  const { forgeSpeed } = getAgilityEffects(state);
+  return baseMinutes * 60 * reduction / forgeSpeed; // seconds
 }
 
 export function startForging(itemId, element, state = S) {

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -10,6 +10,7 @@ import { mountLawDisplay } from "./progression/ui/lawDisplay.js";
 import { mountMiningUI } from "./mining/ui/miningDisplay.js";
 import { mountGatheringUI } from "./gathering/ui/gatheringDisplay.js";
 import { mountPhysiqueUI } from "./physique/ui/physiqueDisplay.js";
+import { mountAgilityUI } from "./agility/ui/agilityDisplay.js";
 import { mountMindReadingUI } from "./mind/ui/mindReadingTab.js";
 import { mountAstralTreeUI } from "./progression/ui/astralTree.js";
 import { mountForgingUI } from "./forging/ui/forgingDisplay.js";
@@ -28,6 +29,7 @@ export function mountAllFeatureUIs(state) {
   mountGatheringUI(state);
   mountForgingUI(state);
   mountPhysiqueUI(state);
+  mountAgilityUI(state);
   mountLawDisplay(state);
   mountMindReadingUI(state);
   mountAstralTreeUI(state);

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -8,6 +8,7 @@ import { miningState } from '../features/mining/state.js';
 import { physiqueState } from '../features/physique/state.js';
 import { forgingState } from '../features/forging/state.js';
 import { gatheringState } from '../features/gathering/state.js';
+import { agilityState } from '../features/agility/state.js';
 
 export function loadSave(){
   try{
@@ -80,6 +81,7 @@ export const defaultState = () => {
   activities: {
     cultivation: false,
     physique: false,
+    agility: false,
     mining: false,
     gathering: false,
     adventure: false,
@@ -89,6 +91,7 @@ export const defaultState = () => {
   },
   // Activity data containers
   physique: structuredClone(physiqueState),
+  agility: structuredClone(agilityState),
   mining: structuredClone(miningState),
   gathering: structuredClone(gatheringState),
   forging: structuredClone(forgingState),
@@ -192,6 +195,7 @@ export let S = loadSave() || defaultState();
 S.sect = { ...structuredClone(sectState), ...S.sect };
 S.karma = { ...structuredClone(karmaState), ...S.karma };
 S.physique = { ...structuredClone(physiqueState), ...S.physique };
+S.agility = { ...structuredClone(agilityState), ...S.agility };
 recalculateBuildingBonuses(S);
 
 // Map resource properties to inventory entries so the inventory is the

--- a/src/ui/sidebar.js
+++ b/src/ui/sidebar.js
@@ -23,6 +23,17 @@ export function renderSidebarActivities() {
       cost: {}
     },
     {
+      id: 'agility',
+      label: 'Agility',
+      icon: '<iconify-icon icon="mdi:run-fast" class="ui-icon" width="20"></iconify-icon>',
+      group: 'leveling',
+      levelId: 'agilityInfo',
+      initialLevel: 'Level 1',
+      progressFillId: 'agilitySelectorFill',
+      progressTextId: 'agilityProgressText',
+      cost: {}
+    },
+    {
       id: 'mining',
       label: 'Mining',
       icon: '<iconify-icon icon="hugeicons:mining-02" class="ui-icon" width="20"></iconify-icon>',

--- a/ui/index.js
+++ b/ui/index.js
@@ -71,8 +71,10 @@ import { updateResourceDisplay } from '../src/features/inventory/ui/resourceDisp
 import { updateKarmaDisplay } from '../src/features/karma/ui/karmaHUD.js';
 import { updateLawsUI } from '../src/features/progression/ui/lawsHUD.js';
 import { calcKarmaGain } from '../src/features/karma/selectors.js';
-import { tickPhysiqueTraining, endTrainingSession } from '../src/features/physique/mutators.js';
-import { mountTrainingGameUI } from '../src/features/physique/ui/trainingGame.js';
+import { tickPhysiqueTraining } from '../src/features/physique/mutators.js';
+import { mountTrainingGameUI as mountPhysiqueTrainingUI } from '../src/features/physique/ui/trainingGame.js';
+import { tickAgilityTraining } from '../src/features/agility/mutators.js';
+import { mountAgilityTrainingUI } from '../src/features/agility/ui/trainingGame.js';
 import { toggleAutoMeditate, toggleAutoAdventure } from '../src/features/automation/mutators.js';
 import { isAutoMeditate, isAutoAdventure } from '../src/features/automation/selectors.js';
 import { selectActivity as selectActivityMut, startActivity as startActivityMut, stopActivity as stopActivityMut } from '../src/features/activity/mutators.js';
@@ -120,7 +122,8 @@ function initUI(){
   const mhKey = typeof mh === 'string' ? mh : mh?.key || 'fist';
   const mhName = WEAPONS[mhKey]?.displayName || (mhKey === 'fist' ? 'Fists' : mhKey);
   initializeWeaponChip({ key: mhKey, name: mhName });
-  mountTrainingGameUI(S);
+  mountPhysiqueTrainingUI(S);
+  mountAgilityTrainingUI(S);
   mountMiningUI(S);
   mountGatheringUI(S);
   mountForgingUI(S);
@@ -483,12 +486,19 @@ function tick(){
   advanceForging(S);
   
   // Physique training progression
-  const sessionEnd = tickPhysiqueTraining(S);
-  if(sessionEnd){
-    let msg = `Training session complete! ${sessionEnd.hits} hits for ${sessionEnd.xp} XP`;
-    if(sessionEnd.qiRecovered){
-      msg += ` and recovered ${sessionEnd.qiRecovered.toFixed(0)} Qi`;
+  const physSessionEnd = tickPhysiqueTraining(S);
+  if(physSessionEnd){
+    let msg = `Training session complete! ${physSessionEnd.hits} hits for ${physSessionEnd.xp} XP`;
+    if(physSessionEnd.qiRecovered){
+      msg += ` and recovered ${physSessionEnd.qiRecovered.toFixed(0)} Qi`;
     }
+    log(msg, 'good');
+  }
+
+  // Agility training progression
+  const agiSessionEnd = tickAgilityTraining(S);
+  if(agiSessionEnd){
+    const msg = `Agility session complete! ${agiSessionEnd.hits} hits for ${agiSessionEnd.xp} XP`;
     log(msg, 'good');
   }
   


### PR DESCRIPTION
## Summary
- add active agility training with stamina-based minigame
- obstacle courses cost stones and wood and boost agility XP
- agility increases accuracy, dodge, and forging speed

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68b8bf55b8d88326a591523dc05f0fec