### PR TITLE
feat: add agility training

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -274,6 +274,13 @@ way-of-ascension/
 │   │   │   └── ui/
 │   │   │       ├── physiqueDisplay.js
 │   │   │       └── trainingGame.js
+│   │   ├── agility/
+│   │   │   ├── logic.js
+│   │   │   ├── mutators.js
+│   │   │   ├── selectors.js
+│   │   │   ├── state.js
+│   │   │   └── ui/
+│   │   │       └── agilityDisplay.js
 │   │   ├── talismans/
 │   │   │   └── data/
 │   │   │       └── talismans.js
@@ -360,6 +367,7 @@ way-of-ascension/
 ├── src/features/gathering/ui/
 │   └── gatheringDisplay.js
 ├── src/features/forging/index.js
+├── src/features/agility/index.js
 ├── src/features/physique/index.js
 └── style.css
 ```
@@ -1043,6 +1051,14 @@ Paths added:
 - `src/features/physique/selectors.js` – Accessors for physique levels, experience, stamina, and bonuses.
 - `src/features/physique/ui/physiqueDisplay.js` – Renders physique progress and bonuses in the UI.
  - `src/features/physique/ui/trainingGame.js` – UI for the physique training mini-game; logic and state updates live in `logic.js` and `mutators.js`.
+
+### Agility Feature (`src/features/agility/`)
+- `src/features/agility/state.js` – Tracks agility level, experience, and obstacle courses.
+- `src/features/agility/logic.js` – Calculates accuracy, dodge, and forging bonuses from agility.
+- `src/features/agility/mutators.js` – Manages agility experience, training ticks, and course construction.
+- `src/features/agility/selectors.js` – Accessors for agility level, experience, and courses.
+- `src/features/agility/ui/agilityDisplay.js` – UI for agility training and obstacle course upgrades.
+- `src/features/agility/index.js` – Agility feature descriptor.
 
 ### Alchemy Feature
 - `src/features/alchemy/index.js` – Registers alchemy hooks.

--- a/index.html
+++ b/index.html
@@ -391,6 +391,35 @@
         </div>
       </section>
 
+      <section id="activity-agility" class="activity-content tab-content" style="display:none;">
+        <h2> Agility Training</h2>
+        <div class="cards">
+          <div class="card">
+            <h4>Training Status</h4>
+            <div class="stat"><span>Agility Level</span><span id="agilityLevelActivity">1</span></div>
+            <div class="stat"><span>Experience</span><span><span id="agilityExpActivity">0</span>/<span id="agilityExpMaxActivity">100</span></span></div>
+            <div class="bar"><div class="fill" id="agilityFillActivity"></div></div>
+            <button class="btn primary" id="startAgilityActivity"> Start Training</button>
+          </div>
+
+          <div class="card" id="agilityObstacleCard">
+            <h4> Obstacle Courses</h4>
+            <div class="stat"><span>Courses Built</span><span id="agilityObstacleCount">0</span></div>
+            <div class="stat"><span>XP Bonus</span><span id="agilityXpBonus">0%</span></div>
+            <button class="btn" id="buildObstacleBtn"> Build Course</button>
+          </div>
+
+          <div class="card" id="agilityEffectsCard" style="display:none;">
+            <h4> Agility Effects</h4>
+            <p class="muted">Current bonuses from your agility stat:</p>
+            <div class="stat"><span>Current Agility</span><span id="currentAgilityStat">10</span></div>
+            <div class="stat"><span>Accuracy Bonus</span><span id="agilityAccuracyStat">+0</span></div>
+            <div class="stat"><span>Dodge Bonus</span><span id="agilityDodgeStat">+0</span></div>
+            <div class="stat"><span>Forge Speed</span><span id="agilityForgeStat">+0%</span></div>
+          </div>
+        </div>
+      </section>
+
       <section id="activity-mining" class="activity-content tab-content" style="display:none;">
         <h2> Mining</h2>
         <div class="cards">

--- a/src/features/activity/index.js
+++ b/src/features/activity/index.js
@@ -3,9 +3,11 @@ export const ActivityFeature = {
   initialState: () => ({
     cultivation: false,
     physique: false,
+    agility: false,
     mining: false,
     adventure: false,
     cooking: false,
+    forging: false,
     sect: false,
     _v: 0,
   }),

--- a/src/features/activity/state.js
+++ b/src/features/activity/state.js
@@ -4,6 +4,7 @@ export function ensureActivities(root) {
     root.activities = {
       cultivation: false,
       physique: false,
+      agility: false,
       mining: false,
       adventure: false,
       cooking: false,

--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -18,6 +18,7 @@ export function mountActivityUI(root) {
 
   document.getElementById('cultivationSelector')?.addEventListener('click', () => handle('cultivation'));
   document.getElementById('physiqueSelector')?.addEventListener('click', () => handle('physique'));
+  document.getElementById('agilitySelector')?.addEventListener('click', () => handle('agility'));
   document.getElementById('miningSelector')?.addEventListener('click', () => handle('mining'));
   document.getElementById('gatheringSelector')?.addEventListener('click', () => handle('gathering'));
   document.getElementById('adventureSelector')?.addEventListener('click', () => handle('adventure'));
@@ -33,6 +34,7 @@ export function updateActivitySelectors(root) {
   root.physique ??= { level: 1, exp: 0, expMax: 100 };
   root.mining   ??= { level: 1, exp: 0, expMax: 100 };
   root.gathering ??= { level: 1, exp: 0, expMax: 100 };
+  root.agility ??= { level: 1, exp: 0, expMax: 100 };
 
   const selected = root.ui?.selectedActivity || 'cultivation';
 
@@ -77,6 +79,18 @@ export function updateActivitySelectors(root) {
     const expPct = (root.physique.exp / root.physique.expMax) * 100;
     physFill.style.width = `${expPct}%`;
     physInfo.textContent = root.activities?.physique ? 'Training...' : `Level ${root.physique.level}`;
+  }
+
+  // Agility
+  const agiSel = document.getElementById('agilitySelector');
+  const agiFill = document.getElementById('agilitySelectorFill');
+  const agiInfo = document.getElementById('agilityInfo');
+  agiSel?.classList.toggle('active', selected === 'agility');
+  agiSel?.classList.toggle('running', root.activities?.agility);
+  if (agiFill && agiInfo) {
+    const expPct = (root.agility.exp / root.agility.expMax) * 100;
+    agiFill.style.width = `${expPct}%`;
+    agiInfo.textContent = root.activities?.agility ? 'Training...' : `Level ${root.agility.level}`;
   }
 
   // Mining
@@ -126,6 +140,7 @@ export function updateCurrentTaskDisplay(root) {
   const map = {
     cultivation: 'Cultivating',
     physique: 'Physique Training',
+    agility: 'Agility Training',
     mining: 'Mining',
     gathering: 'Gathering',
     forging: 'Forging',

--- a/src/features/agility/index.js
+++ b/src/features/agility/index.js
@@ -1,0 +1,6 @@
+import { agilityState } from './state.js';
+
+export const AgilityFeature = {
+  key: 'agility',
+  initialState: () => ({ ...agilityState, _v: 0 }),
+};

--- a/src/features/agility/logic.js
+++ b/src/features/agility/logic.js
@@ -1,0 +1,18 @@
+import { agilityState } from './state.js';
+
+function slice(state){
+  return state.agility || state;
+}
+
+export function getAgilityEffects(state){
+  const root = state.stats ? state : { stats: { agility: 10 } };
+  const current = root.stats.agility || 10;
+  const accuracyBonus = current;
+  const dodgeBonus = current;
+  const forgeSpeed = current * 0.02; // 2% speed per agility
+  return { accuracyBonus, dodgeBonus, forgeSpeed };
+}
+
+export function getSlice(state = agilityState){
+  return slice(state);
+}

--- a/src/features/agility/mutators.js
+++ b/src/features/agility/mutators.js
@@ -1,0 +1,42 @@
+import { agilityState } from './state.js';
+import { recomputePlayerTotals } from '../inventory/logic.js';
+
+function slice(state){
+  return state.agility || state;
+}
+
+export function addAgilityExp(amount, state = agilityState){
+  const a = slice(state);
+  a.exp = (a.exp || 0) + amount;
+  while(a.exp >= a.expMax){
+    a.exp -= a.expMax;
+    a.level++;
+    a.expMax = Math.floor(a.expMax * 1.4);
+    if(state.stats){
+      state.stats.agility = (state.stats.agility || 10) + 1;
+      recomputePlayerTotals(state);
+    }
+  }
+  return a.exp;
+}
+
+export function tickAgilityTraining(state = agilityState){
+  const root = state;
+  if(!root.activities?.agility) return;
+  const a = slice(state);
+  const mult = 1 + (a.obstacleCourses || 0) * 0.1;
+  addAgilityExp(5 * mult, state);
+}
+
+export function buildObstacleCourse(state = agilityState){
+  const root = state;
+  const a = slice(state);
+  const count = a.obstacleCourses || 0;
+  const stoneCost = Math.floor(50 * Math.pow(1.5, count));
+  const woodCost = Math.floor(30 * Math.pow(1.5, count));
+  if((root.stones || 0) < stoneCost || (root.wood || 0) < woodCost) return false;
+  root.stones -= stoneCost;
+  root.wood -= woodCost;
+  a.obstacleCourses = count + 1;
+  return true;
+}

--- a/src/features/agility/selectors.js
+++ b/src/features/agility/selectors.js
@@ -1,0 +1,21 @@
+import { agilityState } from './state.js';
+
+function slice(state){
+  return state.agility || state;
+}
+
+export function getAgilityLevel(state = agilityState){
+  return slice(state).level;
+}
+
+export function getAgilityExp(state = agilityState){
+  return slice(state).exp;
+}
+
+export function getAgilityExpMax(state = agilityState){
+  return slice(state).expMax;
+}
+
+export function getObstacleCourses(state = agilityState){
+  return slice(state).obstacleCourses || 0;
+}

--- a/src/features/agility/state.js
+++ b/src/features/agility/state.js
@@ -1,0 +1,6 @@
+export const agilityState = {
+  level: 1,
+  exp: 0,
+  expMax: 100,
+  obstacleCourses: 0,
+};

--- a/src/features/agility/ui/agilityDisplay.js
+++ b/src/features/agility/ui/agilityDisplay.js
@@ -1,0 +1,35 @@
+import { getAgilityLevel, getAgilityExp, getAgilityExpMax, getObstacleCourses } from '../selectors.js';
+import { getAgilityEffects } from '../logic.js';
+import { buildObstacleCourse } from '../mutators.js';
+import { setText, setFill } from '../../../shared/utils/dom.js';
+
+export function mountAgilityUI(state){
+  const startBtn = document.getElementById('startAgilityActivity');
+  if(startBtn){
+    startBtn.onclick = () => state.activities?.agility ? globalThis.stopActivity('agility') : globalThis.startActivity('agility');
+  }
+  const buildBtn = document.getElementById('buildObstacleBtn');
+  if(buildBtn){
+    buildBtn.onclick = () => { buildObstacleCourse(state); updateAgilityUI(state); };
+  }
+  updateAgilityUI(state);
+}
+
+export function updateAgilityUI(state){
+  setText('agilityLevelActivity', getAgilityLevel(state));
+  setText('agilityExpActivity', Math.floor(getAgilityExp(state)));
+  setText('agilityExpMaxActivity', getAgilityExpMax(state));
+  setFill('agilityFillActivity', getAgilityExp(state) / getAgilityExpMax(state));
+  const courses = getObstacleCourses(state);
+  setText('agilityObstacleCount', courses);
+  setText('agilityXpBonus', `${courses * 10}%`);
+  const effects = getAgilityEffects(state);
+  setText('currentAgilityStat', state.stats?.agility || 10);
+  setText('agilityAccuracyStat', `+${effects.accuracyBonus}`);
+  setText('agilityDodgeStat', `+${effects.dodgeBonus}`);
+  setText('agilityForgeStat', `+${Math.round(effects.forgeSpeed * 100)}%`);
+  const startBtn = document.getElementById('startAgilityActivity');
+  if(startBtn){
+    startBtn.textContent = state.activities?.agility ? '🛑 Stop Training' : '🏃 Start Training';
+  }
+}

--- a/src/features/forging/logic.js
+++ b/src/features/forging/logic.js
@@ -5,7 +5,9 @@ export function getForgingTime(tier, state = S) {
   const baseMinutes = tier === 0 ? 1 : Math.pow(3, tier + 1);
   const level = state.forging?.level || 1;
   const reduction = Math.pow(0.95, Math.max(0, level - 1));
-  return baseMinutes * 60 * reduction; // seconds
+  const agility = state.stats?.agility || 10;
+  const speedMult = 1 + agility * 0.02;
+  return (baseMinutes * 60 * reduction) / speedMult; // seconds
 }
 
 export function startForging(itemId, element, state = S) {

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -10,6 +10,7 @@ import { mountLawDisplay } from "./progression/ui/lawDisplay.js";
 import { mountMiningUI } from "./mining/ui/miningDisplay.js";
 import { mountGatheringUI } from "./gathering/ui/gatheringDisplay.js";
 import { mountPhysiqueUI } from "./physique/ui/physiqueDisplay.js";
+import { mountAgilityUI } from "./agility/ui/agilityDisplay.js";
 import { mountMindReadingUI } from "./mind/ui/mindReadingTab.js";
 import { mountAstralTreeUI } from "./progression/ui/astralTree.js";
 import { mountForgingUI } from "./forging/ui/forgingDisplay.js";
@@ -28,6 +29,7 @@ export function mountAllFeatureUIs(state) {
   mountGatheringUI(state);
   mountForgingUI(state);
   mountPhysiqueUI(state);
+  mountAgilityUI(state);
   mountLawDisplay(state);
   mountMindReadingUI(state);
   mountAstralTreeUI(state);

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -34,8 +34,9 @@ export function recomputePlayerTotals(player) {
   player.stats = player.stats || {};
   const baseArmor = calcBaseArmor(player);
   player.stats.armor = armor + baseArmor;
-  player.stats.accuracy = ACCURACY_BASE + accuracy;
-  player.stats.dodge = DODGE_BASE + dodge;
+  const agi = player.stats.agility || 10;
+  player.stats.accuracy = ACCURACY_BASE + (agi - 10) + accuracy;
+  player.stats.dodge = DODGE_BASE + (agi - 10) + dodge;
   player.shield = player.shield || { current: 0, max: 0 };
   const mind = player.stats.mind || 0;
   const shieldMult = 1 + mind * 0.06;

--- a/src/shared/mutators.js
+++ b/src/shared/mutators.js
@@ -9,6 +9,7 @@ export * from '../features/karma/mutators.js';
 export * from '../features/loot/mutators.js';
 export * from '../features/mining/mutators.js';
 export * from '../features/physique/mutators.js';
+export * from '../features/agility/mutators.js';
 export * from '../features/proficiency/mutators.js';
 export * from '../features/progression/mutators.js';
 export * from '../features/sect/mutators.js';

--- a/src/shared/selectors.js
+++ b/src/shared/selectors.js
@@ -9,6 +9,7 @@ export * from '../features/karma/selectors.js';
 export * from '../features/loot/selectors.js';
 export * from '../features/mining/selectors.js';
 export * from '../features/physique/selectors.js';
+export * from '../features/agility/selectors.js';
 export * from '../features/proficiency/selectors.js';
 export * from '../features/progression/selectors.js';
 export * from '../features/sect/selectors.js';

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -6,6 +6,7 @@ import { recalculateBuildingBonuses } from '../features/sect/mutators.js';
 import { karmaState } from '../features/karma/state.js';
 import { miningState } from '../features/mining/state.js';
 import { physiqueState } from '../features/physique/state.js';
+import { agilityState } from '../features/agility/state.js';
 import { forgingState } from '../features/forging/state.js';
 import { gatheringState } from '../features/gathering/state.js';
 
@@ -80,6 +81,7 @@ export const defaultState = () => {
   activities: {
     cultivation: false,
     physique: false,
+    agility: false,
     mining: false,
     gathering: false,
     adventure: false,
@@ -89,6 +91,7 @@ export const defaultState = () => {
   },
   // Activity data containers
   physique: structuredClone(physiqueState),
+  agility: structuredClone(agilityState),
   mining: structuredClone(miningState),
   gathering: structuredClone(gatheringState),
   forging: structuredClone(forgingState),

--- a/src/ui/sidebar.js
+++ b/src/ui/sidebar.js
@@ -23,6 +23,17 @@ export function renderSidebarActivities() {
       cost: {}
     },
     {
+      id: 'agility',
+      label: 'Agility',
+      icon: '<iconify-icon icon="mdi:run-fast" class="ui-icon" width="20"></iconify-icon>',
+      group: 'leveling',
+      levelId: 'agilityLevel',
+      initialLevel: 'Level 1',
+      progressFillId: 'agilityProgressFill',
+      progressTextId: 'agilityProgressText',
+      cost: {},
+    },
+    {
       id: 'mining',
       label: 'Mining',
       icon: '<iconify-icon icon="hugeicons:mining-02" class="ui-icon" width="20"></iconify-icon>',

--- a/style.css
+++ b/style.css
@@ -2528,6 +2528,12 @@ main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
   box-shadow:0 0 8px rgba(239, 68, 68, 0.4);
 }
 
+/* Agility training bars */
+#agilityFillActivity{
+  background:linear-gradient(90deg, #3b82f6, #2563eb);
+  box-shadow:0 0 8px rgba(59, 130, 246, 0.4);
+}
+
 /* STYLE-GUIDE-UPDATE: Parchment stat text */
 .stat{display:flex; justify-content:space-between; font-size:13px; margin:8px 0; color:var(--ink); position:relative; z-index:1;}
 .row{display:flex; gap:10px; flex-wrap:wrap}
@@ -3892,6 +3898,10 @@ tr:last-child td {
 
 #physiqueProgressFill {
   background: linear-gradient(90deg, #ef4444, #dc2626) !important; /* Red for physique */
+}
+
+#agilityProgressFill {
+  background: linear-gradient(90deg, #3b82f6, #2563eb) !important; /* Blue for agility */
 }
 
 #miningProgressFill {


### PR DESCRIPTION
## Summary
- add new agility feature with obstacle course upgrades and active training
- boost accuracy, dodge, and forging speed from agility
- document agility feature and wire into UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bf55b8d88326a591523dc05f0fec