### PR TITLE
feat: add side-location discovery

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -52,6 +52,7 @@ way-of-ascension/
 │   ├── game-state-and-mechanics.md
 │   ├── proficiency.md
 │   ├── parameters-and-formulas.md
+│   ├── side-location-discovery.md
 │   ├── project-structure.md
 │   └── ARCHITECTURE.md
 ├── node_modules/
@@ -359,6 +360,16 @@ way-of-ascension/
 ├── src/features/gathering/state.js
 ├── src/features/gathering/ui/
 │   └── gatheringDisplay.js
+├── src/features/sideLocations/index.js
+├── src/features/sideLocations/logic.js
+├── src/features/sideLocations/state.js
+├── src/features/agility/index.js
+├── src/features/agility/logic.js
+├── src/features/agility/mutators.js
+├── src/features/agility/selectors.js
+├── src/features/agility/state.js
+├── src/features/agility/ui/agilityDisplay.js
+├── src/features/agility/ui/trainingGame.js
 ├── src/features/forging/index.js
 ├── src/features/physique/index.js
 └── style.css
@@ -373,6 +384,7 @@ way-of-ascension/
 - `docs/To-dos/Palms-and-fists.md` – Concept notes for palm and fist weapon styles.
 - `parameters-and-formulas.md` – Base stats, cultivation stats, activity starting stats, damage formulas, and skill XP scaling reference.
 - `To-dos/Balance.md` – Notes on planned balance adjustments.
+- `docs/side-location-discovery.md` – Design for discovering optional side locations during Adventure.
 
 ### Shared Modules (`src/shared/`)
 
@@ -1021,12 +1033,25 @@ Paths added:
 ### Gathering Feature (`src/features/gathering/`)
 - `src/features/gathering/index.js` – Gathering feature descriptor.
 - `src/features/gathering/state.js` – Tracks gathering level, experience, unlocked resources and yields.
-- `src/features/gathering/logic.js` – Handles wood gathering rates, resource gains and spirit wood chance.
+  - `src/features/gathering/logic.js` – Handles resource gathering rates with chances for Spirit Wood and Aromatic Herbs.
 - `src/features/gathering/mutators.js` – External wrappers to modify gathering state and listeners for `ACTIVITY:START`.
 - `src/features/gathering/selectors.js` – Provides accessors for gathering state and derived rates.
 - `src/features/gathering/migrations.js` – Save migrations for gathering slice (currently none).
-- `src/features/gathering/ui/gatheringDisplay.js` – Updates gathering activity and sidebar displays.
+  - `src/features/gathering/ui/gatheringDisplay.js` – Updates gathering activity and sidebar displays.
 
+### Agility Feature (`src/features/agility/`)
+- `src/features/agility/state.js` – Tracks agility training progress and level.
+- `src/features/agility/logic.js` – Calculates training effects.
+- `src/features/agility/mutators.js` – Starts and ends agility training sessions.
+- `src/features/agility/selectors.js` – Accessors for agility state and cursor position.
+- `src/features/agility/ui/agilityDisplay.js` – Shows agility stats and start/stop controls.
+- `src/features/agility/ui/trainingGame.js` – Mini-game UI for agility training.
+- `src/features/agility/index.js` – Agility feature descriptor.
+
+### Side Locations Feature (`src/features/sideLocations/`)
+- `src/features/sideLocations/state.js` – Tracks discovered nodes and discovery cooldown.
+- `src/features/sideLocations/logic.js` – Listens for adventure kills to unlock new resource nodes.
+- `src/features/sideLocations/index.js` – Side locations feature descriptor.
 
 ### Forging Feature (`src/features/forging/`)
 - `src/features/forging/state.js` – Tracks forging level, experience, and current forging job.
@@ -1147,3 +1172,5 @@ Paths added:
 - `src/features/progression/index.js` – Progression feature descriptor.
 - `src/features/sect/index.js` – Sect feature descriptor.
 - `src/features/weaponGeneration/index.js` – Weapon generation feature descriptor.
+- `src/features/agility/index.js` – Agility feature descriptor.
+- `src/features/sideLocations/index.js` – Side locations feature descriptor.

--- a/docs/side-location-discovery.md
+++ b/docs/side-location-discovery.md
@@ -1,0 +1,47 @@
+# Side-Location Discovery
+
+This document outlines the design for discovering optional locations after defeating enemies in Adventure.
+
+## Concept
+
+Each enemy defeat emits a lightweight `KILL` event. A new **side-locations** feature listens to this event and rolls for discovery.
+
+Side locations come in two classes:
+
+1. **Persistent nodes** – permanent Mining or Gathering spots that become available once discovered.
+2. **One-time locales** – timed or single-use locations claimed once before expiring (details in a later patch).
+
+## Discovery Rules
+
+- **Trigger**: every enemy kill in an eligible Adventure stage.
+- **Cooldown**: after a successful discovery, a one-hour internal cooldown prevents additional discoveries.
+- **Chance**: Stage 1 has a 10 % base chance. Each later stage in the same region reduces the chance by 10 % (Stage 2 = 9 %, etc.).
+- **Empty stages**: if all discoverables in a stage are already found, a successful roll yields nothing.
+
+### Pools and Caps
+
+- Each stage defines a pool of remaining discoveries.
+- Global caps prevent overpopulation (e.g., at most one active one-time locale per stage).
+
+## Classes and Behavior
+
+### Persistent Nodes
+
+These “found spots” add options to Mining or Gathering panels and never expire.
+
+Examples in **Peaceful Lands**:
+
+- **Iron Ore Deposit** (Stage 2) – yields Iron Ore with a small chance of Ore Dust. Appears in Mining as a new node.
+- **Herb Garden** (Stage 5) – produces Herbs with a rare Aromatic Herb. Appears in Gathering as a new node.
+
+## User Interface
+
+- Adventure tab shows a count of pending discoveries. Display requires a minimum Agility level.
+- Each locale uses a card UI listing name, flavor text, effects, timer, and action buttons.
+- Persistent discoveries appear automatically in Mining/Gathering lists marked with a “NEW” tag.
+
+## Persistence
+
+- Persistent nodes save as owned spots.
+- One-time locales save their remaining time and are removed silently if expired on load.
+

--- a/index.html
+++ b/index.html
@@ -534,12 +534,20 @@
                   <span class="resource-rate" id="woodRate">+2-4/sec</span>
                 </label>
               </div>
+              <div class="resource-option" data-resource="herbs" id="herbsOption" style="display:none;">
+                <input type="radio" name="gatheringResource" id="gatherHerbs" value="herbs">
+                <label for="gatherHerbs">
+                  <span class="resource-icon"></span>
+                  <span class="resource-name">Herbs</span>
+                  <span class="resource-rate" id="herbsRate">+1-2/sec</span>
+                </label>
+              </div>
             </div>
           </div>
 
           <div class="card" id="gatheringStatsCard" style="display:none;">
             <h4> Gathering Progress</h4>
-            <div class="stat"><span>Wood Collected</span><span id="gatheredWood">0</span></div>
+            <div class="stat"><span id="gatheredResourceLabel">Resources Collected</span><span id="gatheredResource">0</span></div>
             <div class="stat"><span>Gathering Rate</span><span id="currentGatheringRate">0/sec</span></div>
             <div class="muted" style="margin-top:8px">Gathering grants experience over time</div>
           </div>

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -16,7 +16,7 @@ import { chanceToHit, DODGE_BASE } from '../combat/hit.js';
 import { tryCastAbility, processAbilityQueue } from '../ability/mutators.js';
 import { ENEMY_DATA } from './data/enemies.js';
 import { setText, setFill, log } from '../../shared/utils/dom.js';
-import { on } from '../../shared/events.js';
+import { on, emit } from '../../shared/events.js';
 import { applyRandomAffixes } from '../affixes/logic.js';
 import { AFFIXES } from '../affixes/data/affixes.js';
 import { gainProficiency, gainProficiencyFromEnemy } from '../proficiency/mutators.js';
@@ -818,7 +818,9 @@ function defeatEnemy() {
       }
     }
   }
-  
+
+  emit('ADVENTURE:KILL', { zone: S.adventure.currentZone, area: S.adventure.currentArea });
+
   S.adventure.bestiary = S.adventure.bestiary || {};
   const enemyType = enemy.type || enemy.name;
   S.adventure.bestiary[enemyType] = (S.adventure.bestiary[enemyType] || 0) + 1;

--- a/src/features/gathering/logic.js
+++ b/src/features/gathering/logic.js
@@ -4,6 +4,7 @@ import { log } from '../../shared/utils/dom.js';
 export function getGatheringRate(resource, state = S) {
   const baseRates = {
     wood: 3,
+    herbs: 2,
   };
   const levelBonus = state.gathering?.level ? state.gathering.level * 0.1 : 0;
   return (baseRates[resource] || 1) * (1 + levelBonus);
@@ -27,6 +28,13 @@ export function advanceGathering(state = S) {
       if (Math.random() < 0.05) {
         state.spiritWood = (state.spiritWood || 0) + 1;
         log?.('You found Spirit Wood!', 'good');
+      }
+      break;
+    case 'herbs':
+      state.herbs = (state.herbs || 0) + totalRate;
+      if (Math.random() < 0.05) {
+        state.aromaticHerb = (state.aromaticHerb || 0) + 1;
+        log?.('You found an Aromatic Herb!', 'good');
       }
       break;
   }

--- a/src/features/gathering/ui/gatheringDisplay.js
+++ b/src/features/gathering/ui/gatheringDisplay.js
@@ -9,7 +9,8 @@ export function updateActivityGathering(state = S) {
   setText('gatheringExpActivity', Math.floor(state.gathering.exp));
   setText('gatheringExpMaxActivity', state.gathering.expMax);
 
-  const current = state.activities.gathering ? 'Wood' : 'Nothing';
+  const resourceNames = { wood: 'Wood', herbs: 'Herbs' };
+  const current = state.activities.gathering ? (resourceNames[state.gathering.selectedResource] || 'Nothing') : 'Nothing';
   setText('currentlyGathering', current);
 
   const gatheringFillActivity = document.getElementById('gatheringFillActivity');
@@ -26,12 +27,16 @@ export function updateActivityGathering(state = S) {
   const selectedRadio = document.querySelector(`input[name="gatheringResource"][value="${state.gathering.selectedResource}"]`);
   if (selectedRadio) selectedRadio.checked = true;
 
+  const herbsOption = document.getElementById('herbsOption');
+  if (herbsOption) herbsOption.style.display = state.gathering.unlockedResources?.includes('herbs') ? 'block' : 'none';
+
   const gatheringStatsCard = document.getElementById('gatheringStatsCard');
   if (gatheringStatsCard) gatheringStatsCard.style.display = state.activities.gathering ? 'block' : 'none';
 
   if (state.activities.gathering) {
-    setText('gatheredWood', state.gathering.resourcesGained || 0);
-    const baseRate = getGatheringRate('wood', state);
+    setText('gatheredResource', state.gathering.resourcesGained || 0);
+    setText('gatheredResourceLabel', `${resourceNames[state.gathering.selectedResource] || 'Resource'} Collected`);
+    const baseRate = getGatheringRate(state.gathering.selectedResource, state);
     setText('currentGatheringRate', `${baseRate.toFixed(1)}/sec`);
   }
 
@@ -41,6 +46,11 @@ export function updateActivityGathering(state = S) {
 function updateGatheringRateDisplays(state = S) {
   const woodRate = getGatheringRate('wood', state);
   setText('woodRate', `+${woodRate.toFixed(1)}/sec`);
+  const herbsRateEl = document.getElementById('herbsRate');
+  if (herbsRateEl) {
+    const herbsRate = getGatheringRate('herbs', state);
+    setText('herbsRate', `+${herbsRate.toFixed(1)}/sec`);
+  }
 }
 
 export function updateGatheringSidebar(state = S) {

--- a/src/features/mining/logic.js
+++ b/src/features/mining/logic.js
@@ -29,6 +29,10 @@ export function advanceMining(state = S) {
       break;
     case 'iron':
       state.iron = (state.iron || 0) + totalRate;
+      if (Math.random() < 0.02) {
+        state.oreDust = (state.oreDust || 0) + 1;
+        log?.('You found Ore Dust!', 'good');
+      }
       break;
     case 'ice':
       state.ice = (state.ice || 0) + totalRate;

--- a/src/features/mining/ui/miningDisplay.js
+++ b/src/features/mining/ui/miningDisplay.js
@@ -26,8 +26,8 @@ export function updateActivityMining(state = S) {
 
   const ironOption = document.getElementById('ironOption');
   const iceOption = document.getElementById('iceOption');
-  if (ironOption) ironOption.style.display = state.mining.level >= 3 ? 'block' : 'none';
-  if (iceOption) iceOption.style.display = state.mining.level >= 15 ? 'block' : 'none';
+  if (ironOption) ironOption.style.display = state.mining.unlockedResources?.includes('iron') ? 'block' : 'none';
+  if (iceOption) iceOption.style.display = state.mining.unlockedResources?.includes('ice') ? 'block' : 'none';
 
   const selectedRadio = document.querySelector(`input[name="miningResource"][value="${state.mining.selectedResource}"]`);
   if (selectedRadio) selectedRadio.checked = true;

--- a/src/features/sideLocations/index.js
+++ b/src/features/sideLocations/index.js
@@ -1,0 +1,6 @@
+import { sideLocationState } from './state.js';
+
+export const SideLocationFeature = {
+  key: 'sideLocations',
+  initialState: () => ({ ...sideLocationState, _v: 0 }),
+};

--- a/src/features/sideLocations/logic.js
+++ b/src/features/sideLocations/logic.js
@@ -1,0 +1,55 @@
+import { on } from '../../shared/events.js';
+import { log } from '../../shared/utils/dom.js';
+
+const DISCOVERY_COOLDOWN_MS = 60 * 60 * 1000;
+const BASE_CHANCE = 0.10;
+
+const STAGE_DISCOVERIES = {
+  '0-1': [{ type: 'mining', resource: 'iron', name: 'Iron Ore Deposit' }],
+  '0-4': [{ type: 'gathering', resource: 'herbs', name: 'Herb Garden' }],
+};
+
+export function initSideLocations(state) {
+  // Ensure previously discovered nodes are available on load
+  state.sideLocations?.discovered?.forEach(r => {
+    if (STAGE_DISCOVERIES['0-1'][0].resource === r) {
+      state.mining.unlockedResources = state.mining.unlockedResources || ['stones'];
+      if (!state.mining.unlockedResources.includes(r)) state.mining.unlockedResources.push(r);
+    }
+    if (STAGE_DISCOVERIES['0-4'][0].resource === r) {
+      state.gathering.unlockedResources = state.gathering.unlockedResources || ['wood'];
+      if (!state.gathering.unlockedResources.includes(r)) state.gathering.unlockedResources.push(r);
+    }
+  });
+
+  on('ADVENTURE:KILL', ({ zone, area }) => {
+    handleKill(state, zone, area);
+  });
+}
+
+function handleKill(state, zone, area) {
+  if (!state.sideLocations) return;
+  const now = Date.now();
+  if (now - (state.sideLocations.lastDiscovery || 0) < DISCOVERY_COOLDOWN_MS) return;
+  const chance = Math.max(0, BASE_CHANCE - area * 0.01);
+  if (Math.random() >= chance) return;
+  const key = `${zone}-${area}`;
+  const pool = STAGE_DISCOVERIES[key];
+  if (!pool || pool.length === 0) return;
+  const pick = pool[0];
+  if (state.sideLocations.discovered.includes(pick.resource)) return;
+  state.sideLocations.discovered.push(pick.resource);
+  state.sideLocations.lastDiscovery = now;
+  if (pick.type === 'mining') {
+    state.mining.unlockedResources = state.mining.unlockedResources || ['stones'];
+    if (!state.mining.unlockedResources.includes(pick.resource)) {
+      state.mining.unlockedResources.push(pick.resource);
+    }
+  } else if (pick.type === 'gathering') {
+    state.gathering.unlockedResources = state.gathering.unlockedResources || ['wood'];
+    if (!state.gathering.unlockedResources.includes(pick.resource)) {
+      state.gathering.unlockedResources.push(pick.resource);
+    }
+  }
+  log?.(`You discovered a ${pick.name}!`, 'excellent');
+}

--- a/src/features/sideLocations/state.js
+++ b/src/features/sideLocations/state.js
@@ -1,0 +1,4 @@
+export const sideLocationState = {
+  lastDiscovery: 0,
+  discovered: [],
+};

--- a/src/game/GameController.js
+++ b/src/game/GameController.js
@@ -3,6 +3,8 @@ import { loadSave, saveDebounced } from "../shared/saveLoad.js";
 import { recalculateBuildingBonuses } from "../features/sect/mutators.js";
 import { initFeatureState, tickFeatures } from "../features/registry.js";
 import { ensureMindState, onTick as mindOnTick } from "../features/mind/index.js";
+import { sideLocationState } from "../features/sideLocations/state.js";
+import { initSideLocations } from "../features/sideLocations/logic.js";
 
 // Register feature hooks
 import "../features/proficiency/index.js";
@@ -15,13 +17,16 @@ export function createGameController() {
   const state = {
     app: { mode: "town", lastTick: performance.now() },
     ...initFeatureState(),
+    sideLocations: structuredClone(sideLocationState),
     // legacy root pieces remain attached to `state` until migrated
   };
 
   const hydrated = loadSave(state);
   Object.assign(state, hydrated);
+  state.sideLocations = { ...structuredClone(sideLocationState), ...state.sideLocations };
   ensureMindState(state);
   recalculateBuildingBonuses(state);
+  initSideLocations(state);
 
   let running = false;
   let acc = 0;

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -9,6 +9,7 @@ import { physiqueState } from '../features/physique/state.js';
 import { forgingState } from '../features/forging/state.js';
 import { gatheringState } from '../features/gathering/state.js';
 import { agilityState } from '../features/agility/state.js';
+import { sideLocationState } from '../features/sideLocations/state.js';
 
 export function loadSave(){
   try{
@@ -56,7 +57,7 @@ export const defaultState = () => {
   autoFillShieldFromQi: true,
   stunBar: 0, // STATUS-REFORM player stun accumulation
   realm: { tier: 0, stage: 1 },
-  wood:0, spiritWood:0, cores:0,
+  wood:0, spiritWood:0, cores:0, iron:0, oreDust:0, herbs:0, aromaticHerb:0,
   pills:{qi:0, body:0, ward:0},
   atkBase:5, armorBase:2, tempAtk:0, tempArmor:0,
   // Expanded Stat System
@@ -160,6 +161,7 @@ export const defaultState = () => {
     }
   },
   sect: structuredClone(sectState),
+  sideLocations: structuredClone(sideLocationState),
   };
 };
 
@@ -196,13 +198,14 @@ S.sect = { ...structuredClone(sectState), ...S.sect };
 S.karma = { ...structuredClone(karmaState), ...S.karma };
 S.physique = { ...structuredClone(physiqueState), ...S.physique };
 S.agility = { ...structuredClone(agilityState), ...S.agility };
+S.sideLocations = { ...structuredClone(sideLocationState), ...S.sideLocations };
 recalculateBuildingBonuses(S);
 
 // Map resource properties to inventory entries so the inventory is the
 // single source of truth for all items.  These properties are not
 // serialized directly; instead their values are derived from the
 // corresponding entries in `S.inventory`.
-['stones', 'ore', 'herbs', 'wood', 'spiritWood'].forEach(key => {
+['stones', 'iron', 'oreDust', 'herbs', 'aromaticHerb', 'wood', 'spiritWood'].forEach(key => {
   const initial = S[key] || 0;
   Object.defineProperty(S, key, {
     get() {


### PR DESCRIPTION
## Summary
- hook adventure kills to a side-location discovery system with cooldown and stage-specific pools
- unlock iron ore and herb nodes that appear in mining and gathering UIs with rare drop chances
- register side-location state during game initialization

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations: imports from shared/state.js, DOM usage)


------
https://chatgpt.com/codex/tasks/task_e_68b9b0723fc48326b3236ba9f34bc652