### PR TITLE
feat: add env-driven config

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -59,8 +59,10 @@ way-of-ascension/
 ├── scripts/
 │   ├── balance-validate.js
 │   ├── scan-codex-output.js
+│   ├── start.js
 │   └── validate-structure.js
 ├── src/
+│   ├── config.js
 │   ├── index.js
 │   ├── data/
 │   │   └── status.ts
@@ -859,6 +861,16 @@ function updateAll() {
 **Purpose**: A simple Node.js server to serve the game's static files for local development.
 **Dependencies**: `http`, `fs`, `path`
 **When to modify**: If server configuration, port, or file handling logic needs to change.
+
+### Start Script (`scripts/start.js`)
+
+**Purpose**: Loads environment variables from `.env` files and boots the local server.
+**When to modify**: Adjust startup or environment-loading behavior.
+
+### Config (`src/config.js`)
+
+**Purpose**: Centralized environment and feature flag configuration derived from Vercel/Vite envs.
+**When to modify**: Change feature flag handling or defaults.
 
 ### Changelog (`CHANGELOG.md`)
 **Purpose**: Tracks notable changes, additions, and fixes across versions.

--- a/src/config.js
+++ b/src/config.js
@@ -1,17 +1,47 @@
-export const isProd = process.env.NODE_ENV === 'production';
+// Unified environment accessor for Node, Vite and browser builds
+const env = (typeof import.meta !== 'undefined' && import.meta.env) || process.env;
+
+// Determine Vercel environment with production-safe default
+const vercelEnv = (env?.VERCEL_ENV || env?.NODE_ENV || 'production').toLowerCase();
+
+export const isProd = vercelEnv === 'production';
+export const isPreview = vercelEnv === 'preview';
+export const isDev = !isProd && !isPreview;
+
+// Parse env values into booleans/numbers with prod-safe defaults
+function parseEnv(name, fallback = false) {
+  const val = env?.[name] ?? env?.[`VITE_${name}`];
+  if (val === undefined) return fallback;
+
+  if (val === 'true' || val === true) return true;
+  if (val === 'false' || val === false) return false;
+
+  const num = Number(val);
+  return Number.isNaN(num) ? fallback : num;
+}
 
 export const featureFlags = {
-  proficiency: process.env.FEATURE_PROFICIENCY !== 'false',
-  sect: process.env.FEATURE_SECT !== 'false',
-  karma: process.env.FEATURE_KARMA !== 'false',
-  alchemy: process.env.FEATURE_ALCHEMY !== 'false',
-  cooking: process.env.FEATURE_COOKING !== 'false',
-  mining: process.env.FEATURE_MINING !== 'false',
-  gathering: process.env.FEATURE_GATHERING !== 'false',
-  forging: process.env.FEATURE_FORGING !== 'false',
-  physique: process.env.FEATURE_PHYSIQUE !== 'false',
-  agility: process.env.FEATURE_AGILITY !== 'false',
-  law: process.env.FEATURE_LAW !== 'false',
-  mind: process.env.FEATURE_MIND !== 'false',
-  astralTree: process.env.FEATURE_ASTRAL_TREE !== 'false'
+  proficiency: parseEnv('FEATURE_PROFICIENCY'),
+  sect: parseEnv('FEATURE_SECT'),
+  karma: parseEnv('FEATURE_KARMA'),
+  alchemy: parseEnv('FEATURE_ALCHEMY'),
+  cooking: parseEnv('FEATURE_COOKING'),
+  mining: parseEnv('FEATURE_MINING'),
+  gathering: parseEnv('FEATURE_GATHERING'),
+  forging: parseEnv('FEATURE_FORGING'),
+  physique: parseEnv('FEATURE_PHYSIQUE'),
+  agility: parseEnv('FEATURE_AGILITY'),
+  law: parseEnv('FEATURE_LAW'),
+  mind: parseEnv('FEATURE_MIND'),
+  astralTree: parseEnv('FEATURE_ASTRAL_TREE')
 };
+
+// Print a summary of active flags in non-production environments
+if (!isProd) {
+  const active = Object.entries(featureFlags)
+    .filter(([, enabled]) => enabled)
+    .map(([name]) => name)
+    .join(', ') || 'none';
+  console.log(`[flags] active: ${active}`);
+}
+


### PR DESCRIPTION
## Summary
- read Vercel/Vite envs in `src/config.js`
- expose feature flags with prod-safe defaults and startup logging
- document `config.js` and `scripts/start.js`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68ba108d96cc8326a71eac523388e80a