### PR TITLE
Handle main env as production

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,7 +1,8 @@
 import { config } from 'dotenv';
 import path from 'path';
 
-const env = process.env.NODE_ENV || 'development';
+const inputEnv = process.env.NODE_ENV || 'development';
+const env = ['production', 'prod', 'main'].includes(inputEnv) ? 'production' : inputEnv;
 config({ path: path.resolve(`.env.${env}`) });
 
 await import('../server.js');

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,11 @@
 // Unified environment accessor for Node, Vite and browser builds
 const env = (typeof import.meta !== 'undefined' && import.meta.env) || process.env;
 
-// Determine Vercel environment with production-safe default
-const vercelEnv = (env?.VERCEL_ENV || env?.NODE_ENV || 'production').toLowerCase();
+// Determine Vercel environment with production-safe default and common aliases
+const rawEnv = env?.VERCEL_ENV || env?.NODE_ENV || (env?.PROD ? 'production' : '') || 'production';
+const vercelEnv = String(rawEnv).toLowerCase();
 
-export const isProd = vercelEnv === 'production';
+export const isProd = ['production', 'prod', 'main'].includes(vercelEnv);
 export const isPreview = vercelEnv === 'preview';
 export const isDev = !isProd && !isPreview;
 


### PR DESCRIPTION
## Summary
- treat `main` and `prod` as production aliases in env config
- load production `.env` for `main`/`prod` NODE_ENV values in start script

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state rule violations)


------
https://chatgpt.com/codex/tasks/task_e_68ba1440d3448326952faffd7daa40f9