### PR TITLE
feat: add basic dungeon system

### DIFF
--- a/index.html
+++ b/index.html
@@ -782,9 +782,14 @@
               <h3>🗺️ Adventure Map</h3>
               <button class="btn small ghost close-button" id="closeMapButton" aria-label="Close map">✕</button>
             </div>
-            <div class="map-content" id="mapContent">
+            <div class="map-tabs tab-bar">
+              <button class="map-tab-btn active" id="mapTabAreas">Areas</button>
+              <button class="map-tab-btn" id="mapTabDungeons">Dungeons</button>
+            </div>
+            <div class="map-content" id="mapContentAreas">
               <!-- Zone accordions will be populated by JavaScript -->
             </div>
+            <div class="map-content" id="mapContentDungeons" style="display:none;"></div>
           </div>
         </div>
       </section>

--- a/src/features/adventure/data/zones.js
+++ b/src/features/adventure/data/zones.js
@@ -82,14 +82,42 @@ export const ZONES = [
         description: 'Stone guardians protect ancient secrets.',
         loot: { stones: 12, ore: 2 }
       },
-      { 
-        id: 'forest-heart', 
-        name: 'Forest Heart', 
-        enemy: 'Forest Spirit', 
+      {
+        id: 'forest-heart',
+        name: 'Forest Heart',
+        enemy: 'Forest Spirit',
         killReq: 40,
         description: 'The forest\'s guardian spirit awaits challengers.',
         loot: { stones: 15, wood: 6 },
         isBoss: true
+      }
+    ],
+    dungeons: [
+      {
+        id: 'flooded-grotto',
+        name: 'Flooded Grotto',
+        element: 'water',
+        discoverAtStage: 2,
+        floors: [
+          { enemy: 'River Frog' },
+          { enemy: 'Water Snake' },
+          { enemy: 'River Frog' },
+          { enemy: 'Water Snake' },
+          { boss: true, enemy: 'Water Snake' }
+        ]
+      },
+      {
+        id: 'stone-hollow',
+        name: 'Stone Hollow',
+        element: 'earth',
+        discoverAtStage: 7,
+        floors: [
+          { enemy: 'Stone Lizard' },
+          { enemy: 'Ruin Guardian' },
+          { enemy: 'Stone Lizard' },
+          { enemy: 'Ruin Guardian' },
+          { boss: true, enemy: 'Ruin Guardian' }
+        ]
       }
     ]
   },
@@ -285,6 +313,11 @@ export function getZoneById(zoneId) {
 export function getAreaById(zoneId, areaId) {
   const zone = getZoneById(zoneId);
   return zone ? zone.areas.find(area => area.id === areaId) : null;
+}
+
+export function getDungeonById(zoneId, dungeonId) {
+  const zone = getZoneById(zoneId);
+  return zone?.dungeons?.find(d => d.id === dungeonId) || null;
 }
 
 export function getNextArea(zoneId, areaId) {

--- a/src/features/adventure/ui/adventureDisplay.js
+++ b/src/features/adventure/ui/adventureDisplay.js
@@ -2,7 +2,7 @@ import { S } from '../../../shared/state.js';
 import { setFill, setText, log } from '../../../shared/utils/dom.js';
 import { ZONES } from '../data/zones.js';
 import { startAdventure, startAdventureCombat, startBossCombat, progressToNextArea, retreatFromCombat, resetQiOnRetreat } from '../mutators.js';
-import { updateActivityAdventure } from '../logic.js';
+import { updateActivityAdventure, progressDungeonEncounter } from '../logic.js';
 import { clamp } from '../../progression/selectors.js';
 
 export function updateAdventureProgress(state = S) {
@@ -72,7 +72,13 @@ export function mountAdventureControls(root) {
     startBtn.classList.remove('primary'); startBtn.classList.add('warn');
   });
 
-  document.getElementById('progressButton')?.addEventListener('click', () => progressToNextArea());
+  document.getElementById('progressButton')?.addEventListener('click', () => {
+    if (root.adventure?.dungeonState) {
+      progressDungeonEncounter();
+    } else {
+      progressToNextArea();
+    }
+  });
   document.getElementById('challengeBossButton')?.addEventListener('click', () => {
     startAdventure();
     if (!root.activities?.adventure && typeof globalThis.startActivity === 'function') {


### PR DESCRIPTION
## Summary
- add dungeon definitions and helper lookups
- implement dungeon combat flow with cooldown and progress UI
- display discovered dungeons on map and allow entry

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68ba12e2149c8326b4c72bd24576c15e