### PR TITLE
Normalize env and load original env file

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -2,11 +2,17 @@ import { config } from 'dotenv';
 import path from 'path';
 
 const inputEnv = process.env.NODE_ENV || 'development';
-const env = ['production', 'prod', 'main'].includes(inputEnv) ? 'production' : inputEnv;
 
-// Ensure downstream code treats "main" and "prod" as production
-config({ path: path.resolve(`.env.${env}`), override: true });
-process.env.NODE_ENV = env;
-process.env.VERCEL_ENV = process.env.VERCEL_ENV || env;
+// Load environment variables for the original input
+config({ path: path.resolve(`.env.${inputEnv}`), override: true });
+
+// Normalize environment name so "main" and "prod" map to production
+const envName = ['production', 'prod', 'main'].includes(inputEnv)
+  ? 'production'
+  : inputEnv;
+
+// Ensure downstream code treats aliases as production
+process.env.NODE_ENV = envName;
+process.env.VERCEL_ENV = envName;
 
 await import('../server.js');


### PR DESCRIPTION
## Summary
- load environment variables from `.env.<original NODE_ENV>` while preserving the original value
- normalize `NODE_ENV`/`VERCEL_ENV` so `main` and `prod` map to `production`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI verification enforcement report)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1c30f5f88326ad30dda2eaa660c1