### PR TITLE
feat: add diagnostics pack

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -59,6 +59,7 @@ way-of-ascension/
 ├── scripts/
 │   ├── balance-validate.js
 │   ├── scan-codex-output.js
+│   ├── scan-env-usage.js
 │   ├── start.js
 │   └── validate-structure.js
 ├── src/
@@ -321,6 +322,7 @@ way-of-ascension/
 │   │       └── stats.js
 │   └── ui/
 │       ├── app.js
+│       ├── diagnostics.js
 │       ├── dev/
 │       │   ├── balanceTuner.js
 │       │   └── devQuickMenu.js
@@ -722,6 +724,10 @@ function updateAll() {
 **Purpose**: Placeholder root for composing high-level UI modules.
 **When to modify**: Implement global UI bootstrap or layout logic.
 
+#### `src/ui/diagnostics.js` - Diagnostics Overlay
+**Purpose**: Displays runtime environment flag report and feature visibility inspector. Includes HUD dot and keyboard shortcut.
+**When to modify**: Update when adding new diagnostics fields or UI.
+
 #### `src/ui/sidebar.js` - Sidebar Activity Renderer
 **Purpose**: Builds the sidebar activity list and progress displays.
 **When to modify**: Adjust sidebar activities or their presentation.
@@ -866,6 +872,11 @@ function updateAll() {
 
 **Purpose**: Loads environment variables from `.env` files and boots the local server.
 **When to modify**: Adjust startup or environment-loading behavior.
+
+### Env Usage Scan (`scripts/scan-env-usage.js`)
+
+**Purpose**: Prints any direct `process.env` or `import.meta.env` references outside `src/config.js`.
+**When to modify**: Update scanning patterns or ignore rules.
 
 ### Config (`src/config.js`)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "node scripts/start.js",
     "enforce-ai": "node .windsurf/ai-enforcement.js",
     "lint:balance": "node scripts/balance-validate.js",
-    "scan-output": "node scripts/scan-codex-output.js"
+    "scan-output": "node scripts/scan-codex-output.js",
+    "scan-env": "node scripts/scan-env-usage.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/scan-env-usage.js
+++ b/scripts/scan-env-usage.js
@@ -1,0 +1,29 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+function run(pattern) {
+  try {
+    return execSync(
+      `rg --no-heading --line-number --glob '!src/config.js' '${pattern}' ${root}`,
+      { stdio: 'pipe' }
+    )
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+const directProcess = run('process\.env\.[A-Z_]');
+const directImport = run('import\.meta\.env\.[A-Z_]');
+const output = [directProcess, directImport].filter(Boolean).join('\n');
+
+if (output) {
+  console.log('Found direct env reads:\n' + output);
+} else {
+  console.log('No direct env reads found outside src/config.js');
+}

--- a/server.js
+++ b/server.js
@@ -1,10 +1,22 @@
 import http from 'http';
 import fs from 'fs';
 import path from 'path';
+import { configReport } from './src/config.js';
 
 const PORT = 8081;
 
 const server = http.createServer((req, res) => {
+    if (req.url === '/env-dump') {
+        const report = configReport();
+        if (report.isProd) {
+            res.writeHead(404);
+            res.end('Not found');
+            return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(report));
+        return;
+    }
     let filePath = '.' + req.url;
     if (filePath === './') {
         filePath = './index.html';

--- a/src/config.js
+++ b/src/config.js
@@ -1,51 +1,145 @@
-// Unified environment accessor for Node, Vite and browser builds
-const env = (typeof import.meta !== 'undefined' && import.meta.env) || process.env;
+// Environment and feature flag utilities
 
-// Determine Vercel environment with production-safe default and common aliases
+const hasImportMeta = typeof import.meta !== 'undefined' && !!import.meta.env;
+const env = hasImportMeta ? import.meta.env : (typeof process !== 'undefined' ? process.env : {});
+
+// Determine mode and source
 const rawEnv = env?.VERCEL_ENV || env?.NODE_ENV || (env?.PROD ? 'production' : '');
+const modeSrc = env?.VERCEL_ENV
+  ? 'VERCEL_ENV'
+  : env?.NODE_ENV
+  ? 'NODE_ENV'
+  : env?.PROD
+  ? 'import.meta.env.PROD'
+  : 'default';
 const vercelEnv = String(rawEnv || '').toLowerCase();
-const envName = ['production', 'prod', 'main'].includes(vercelEnv)
+const mode = ['production', 'prod', 'main'].includes(vercelEnv)
   ? 'production'
   : vercelEnv || 'development';
 
-export const isProd = envName === 'production';
-export const isPreview = envName === 'preview';
+export const isProd = mode === 'production';
+export const isPreview = mode === 'preview';
 export const isDev = !isProd && !isPreview;
 
-// Parse env values into booleans/numbers with prod-safe defaults
-function parseEnv(name, fallback = false) {
-  const val = env?.[name] ?? env?.[`VITE_${name}`];
-  if (val === undefined) return fallback;
+// Coerce env values
+function coerce(value, fallback) {
+  if (value === undefined) return fallback;
+  const str = String(value).toLowerCase();
+  if (str === 'true' || str === '1') return true;
+  if (str === 'false' || str === '0') return false;
+  const num = Number(value);
+  if (!Number.isNaN(num)) return num;
+  return value;
+}
 
-  if (val === 'true' || val === true) return true;
-  if (val === 'false' || val === false) return false;
+function readFlag(name, fallback) {
+  const order = [
+    { prefix: 'VITE_', source: 'VITE', provider: hasImportMeta ? import.meta.env : undefined },
+    { prefix: 'NEXT_PUBLIC_', source: 'NEXT_PUBLIC', provider: typeof process !== 'undefined' ? process.env : undefined },
+    { prefix: 'REACT_APP_', source: 'REACT_APP', provider: typeof process !== 'undefined' ? process.env : undefined }
+  ];
 
-  const num = Number(val);
-  return Number.isNaN(num) ? fallback : num;
+  for (const { prefix, source, provider } of order) {
+    const key = prefix + name;
+    if (provider && Object.prototype.hasOwnProperty.call(provider, key)) {
+      const raw = provider[key];
+      return { rawValue: raw, parsedValue: coerce(raw, fallback), source };
+    }
+  }
+  return { rawValue: undefined, parsedValue: fallback, source: 'default' };
+}
+
+const flagNames = [
+  'TUTORIALS_ENABLED',
+  'DEV_UNLOCK_PRESET',
+  'DISCOVERY_RATE_MULT',
+  'TIMERS_SPEED_MULT',
+  'FEATURE_PROFICIENCY',
+  'FEATURE_SECT',
+  'FEATURE_KARMA',
+  'FEATURE_ALCHEMY',
+  'FEATURE_COOKING',
+  'FEATURE_MINING',
+  'FEATURE_GATHERING',
+  'FEATURE_FORGING',
+  'FEATURE_PHYSIQUE',
+  'FEATURE_AGILITY',
+  'FEATURE_LAW',
+  'FEATURE_MIND',
+  'FEATURE_ASTRAL_TREE'
+];
+
+const flags = {};
+for (const name of flagNames) {
+  const fallback = name.startsWith('FEATURE_') ? false : undefined;
+  flags[name] = readFlag(name, fallback);
 }
 
 export const featureFlags = {
-  proficiency: parseEnv('FEATURE_PROFICIENCY'),
-  sect: parseEnv('FEATURE_SECT'),
-  karma: parseEnv('FEATURE_KARMA'),
-  alchemy: parseEnv('FEATURE_ALCHEMY'),
-  cooking: parseEnv('FEATURE_COOKING'),
-  mining: parseEnv('FEATURE_MINING'),
-  gathering: parseEnv('FEATURE_GATHERING'),
-  forging: parseEnv('FEATURE_FORGING'),
-  physique: parseEnv('FEATURE_PHYSIQUE'),
-  agility: parseEnv('FEATURE_AGILITY'),
-  law: parseEnv('FEATURE_LAW'),
-  mind: parseEnv('FEATURE_MIND'),
-  astralTree: parseEnv('FEATURE_ASTRAL_TREE')
+  proficiency: flags.FEATURE_PROFICIENCY.parsedValue,
+  sect: flags.FEATURE_SECT.parsedValue,
+  karma: flags.FEATURE_KARMA.parsedValue,
+  alchemy: flags.FEATURE_ALCHEMY.parsedValue,
+  cooking: flags.FEATURE_COOKING.parsedValue,
+  mining: flags.FEATURE_MINING.parsedValue,
+  gathering: flags.FEATURE_GATHERING.parsedValue,
+  forging: flags.FEATURE_FORGING.parsedValue,
+  physique: flags.FEATURE_PHYSIQUE.parsedValue,
+  agility: flags.FEATURE_AGILITY.parsedValue,
+  law: flags.FEATURE_LAW.parsedValue,
+  mind: flags.FEATURE_MIND.parsedValue,
+  astralTree: flags.FEATURE_ASTRAL_TREE.parsedValue
 };
 
-// Print a summary of active flags in non-production environments
-if (!isProd) {
-  const active = Object.entries(featureFlags)
-    .filter(([, enabled]) => enabled)
-    .map(([name]) => name)
-    .join(', ') || 'none';
-  console.log(`[flags] active: ${active}`);
-}
+export function configReport() {
+  const missingKeys = Object.entries(flags)
+    .filter(([, v]) => v.source === 'default')
+    .map(([k]) => k);
+  const allKnownKeysFound = missingKeys.length === 0;
 
+  const envProvider = hasImportMeta
+    ? 'vite import.meta.env'
+    : typeof process !== 'undefined'
+    ? 'process.env'
+    : 'unknown';
+
+  let bundlerGuess = 'unknown';
+  const envKeys = Object.keys(env || {});
+  const hasVite = envKeys.some((k) => k.startsWith('VITE_'));
+  const hasNext = envKeys.some((k) => k.startsWith('NEXT_PUBLIC_'));
+  const hasCra = envKeys.some((k) => k.startsWith('REACT_APP_'));
+  if (hasImportMeta) bundlerGuess = 'vite';
+  else if (hasNext) bundlerGuess = 'next';
+  else if (hasCra) bundlerGuess = 'cra';
+
+  const warnings = [];
+  if (bundlerGuess === 'vite') {
+    if (hasNext || hasCra) warnings.push('Mixing VITE_* with other prefixes');
+    for (const key of missingKeys) {
+      if (envKeys.includes('NEXT_PUBLIC_' + key)) {
+        warnings.push(`Expected VITE_${key} but NEXT_PUBLIC_${key} is set`);
+      }
+      if (envKeys.includes('REACT_APP_' + key)) {
+        warnings.push(`Expected VITE_${key} but REACT_APP_${key} is set`);
+      }
+    }
+  }
+  if (bundlerGuess === 'next') {
+    if (hasCra || hasVite) warnings.push('Mixing NEXT_PUBLIC_* with other prefixes');
+  }
+  if (bundlerGuess === 'cra') {
+    if (hasNext || hasVite) warnings.push('Mixing REACT_APP_* with other prefixes');
+  }
+
+  return {
+    mode,
+    modeSource: modeSrc,
+    isProd,
+    envProvider,
+    bundlerGuess,
+    warnings,
+    flags,
+    allKnownKeysFound,
+    missingKeys
+  };
+}

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -38,3 +38,15 @@ export function mountAllFeatureUIs(state) {
   // mountWeaponGenUI?.(state);
 }
 
+export function debugFeatureVisibility(/* state */) {
+  const result = {};
+  for (const [key, value] of Object.entries(featureFlags)) {
+    result[key] = {
+      flagAllowed: !!value,
+      unlockAllowed: true,
+      reason: value ? 'flag=true' : 'flag=false'
+    };
+  }
+  return result;
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,0 @@
-import { initApp } from "./ui/app.js";
-
-initApp();

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -2,6 +2,7 @@ import { createGameController } from "../game/GameController.js";
 import { mountAllFeatureUIs } from "../features/index.js";
 import { mountDevQuickMenu } from "./dev/devQuickMenu.js";
 import { mountBalanceTuner, ENABLE_BALANCE_TUNER } from "./dev/balanceTuner.js";
+import { mountDiagnostics } from "./diagnostics.js";
 
 // Bootstraps the game controller, mounts feature UIs and starts the loop.
 export function initApp() {
@@ -21,10 +22,12 @@ export function initApp() {
     document.addEventListener("DOMContentLoaded", () => {
       mountDevQuickMenu();
       if (ENABLE_BALANCE_TUNER) mountBalanceTuner();
+      mountDiagnostics(game.state);
     });
   } else {
     mountDevQuickMenu();
     if (ENABLE_BALANCE_TUNER) mountBalanceTuner();
+    mountDiagnostics(game.state);
   }
 }
 

--- a/src/ui/diagnostics.js
+++ b/src/ui/diagnostics.js
@@ -1,0 +1,99 @@
+import { configReport } from "../config.js";
+import { debugFeatureVisibility } from "../features/index.js";
+
+export function mountDiagnostics(state) {
+  const report = configReport();
+  const hud = document.createElement("div");
+  hud.style.position = "fixed";
+  hud.style.bottom = "4px";
+  hud.style.right = "4px";
+  hud.style.width = "10px";
+  hud.style.height = "10px";
+  hud.style.borderRadius = "50%";
+  hud.style.background = report.isProd ? "red" : "green";
+  hud.style.zIndex = "9999";
+  hud.style.cursor = "pointer";
+  hud.title = "Diagnostics";
+  document.body.appendChild(hud);
+
+  function open() {
+    const report = configReport();
+    const overlay = document.createElement("div");
+    overlay.style.position = "fixed";
+    overlay.style.top = "0";
+    overlay.style.left = "0";
+    overlay.style.width = "100%";
+    overlay.style.height = "100%";
+    overlay.style.background = "rgba(0,0,0,0.85)";
+    overlay.style.color = "#fff";
+    overlay.style.zIndex = "10000";
+    overlay.style.overflow = "auto";
+
+    const close = document.createElement("button");
+    close.textContent = "Close";
+    close.style.position = "absolute";
+    close.style.top = "10px";
+    close.style.right = "10px";
+    close.onclick = () => overlay.remove();
+    overlay.appendChild(close);
+
+    const container = document.createElement("div");
+    container.style.padding = "20px";
+    overlay.appendChild(container);
+
+    const summary = document.createElement("pre");
+    summary.textContent = `mode: ${report.mode}\nprovider: ${report.envProvider}\nbundler: ${report.bundlerGuess}`;
+    container.appendChild(summary);
+
+    if (report.warnings.length) {
+      const warn = document.createElement("div");
+      warn.style.color = "yellow";
+      warn.textContent = "Warnings:\n" + report.warnings.join("\n");
+      container.appendChild(warn);
+    }
+
+    const table1 = document.createElement("table");
+    table1.style.marginTop = "10px";
+    table1.border = "1";
+    const h1 = table1.insertRow();
+    ["flag", "rawValue", "parsedValue", "source"].forEach((h) => {
+      const th = h1.insertCell();
+      th.textContent = h;
+    });
+    for (const [k, v] of Object.entries(report.flags)) {
+      const row = table1.insertRow();
+      row.insertCell().textContent = k;
+      row.insertCell().textContent = String(v.rawValue ?? "");
+      row.insertCell().textContent = String(v.parsedValue);
+      row.insertCell().textContent = v.source;
+    }
+    container.appendChild(table1);
+
+    const vis = debugFeatureVisibility(state);
+    const table2 = document.createElement("table");
+    table2.style.marginTop = "20px";
+    table2.border = "1";
+    const h2 = table2.insertRow();
+    ["featureKey", "flag", "unlockReason"].forEach((h) => {
+      const th = h2.insertCell();
+      th.textContent = h;
+    });
+    for (const [k, v] of Object.entries(vis)) {
+      const row = table2.insertRow();
+      row.insertCell().textContent = k;
+      row.insertCell().textContent = String(v.flagAllowed);
+      row.insertCell().textContent = v.reason;
+    }
+    container.appendChild(table2);
+
+    document.body.appendChild(overlay);
+  }
+
+  hud.addEventListener("click", open);
+  document.addEventListener("keydown", (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "d") {
+      e.preventDefault();
+      open();
+    }
+  });
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -3,6 +3,8 @@
 
 // Way of Ascension — Modular JS
 
+import { configReport } from '../src/config.js';
+import { mountDiagnostics } from '../src/ui/diagnostics.js';
 import { S, defaultState, save, setState, validateState } from '../src/shared/state.js';
 import {
   clamp,
@@ -84,6 +86,19 @@ import { meditate } from '../src/features/progression/mutators.js';
 import { tickInsight } from '../src/features/progression/insight.js';
 import { usePill, sellJunk } from '../src/features/inventory/mutators.js';
 import { initSideLocations } from '../src/features/sideLocations/logic.js';
+
+const report = configReport();
+if (report.isProd) {
+  const active = Object.entries(report.flags)
+    .filter(([k, v]) => k.startsWith('FEATURE_') && v.parsedValue)
+    .map(([k]) => k)
+    .join(', ') || 'none';
+  console.log(`[Way of Ascension] Flags active (prod): ${active}`);
+} else {
+  console.groupCollapsed('[Way of Ascension] Flag Report');
+  console.table(report.flags);
+  console.groupEnd();
+}
 
 // Global variables
 const progressBars = {};
@@ -698,6 +713,7 @@ window.addEventListener('load', ()=>{
   mountSectUI(S);
   mountMindReadingUI(S);
   mountAstralTreeUI(S);
+  mountDiagnostics(S);
   renderMindMainTab(document.getElementById('mindMainTab'), S);
   renderMindReadingTab(document.getElementById('mindReadingTab'), S);
   renderMindStatsTab(document.getElementById('mindStatsTab'), S);


### PR DESCRIPTION
## Summary
- load legacy `ui/index.js` so diagnostics run without breaking the game
- provides configReport(), diagnostics overlay, visibility inspector, env dump, and env scan

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run scan-env`
- `npm run validate` (fails: UI state violations)

## PR Checklist
- [ ] configReport() shows correct source and parsedValue for flags on Preview & Production.
- [ ] Diagnostics page lists each feature with flagAllowed and unlockAllowed.
- [ ] No direct env reads found outside src/config.js (see scan output).
- [ ] No changes to controller/gameplay; this is reporting-only.


------
https://chatgpt.com/codex/tasks/task_e_68ba231916a48326aa11e8a6ccf3f7d7