### PR TITLE
Add timed catching progress and nets

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -376,6 +376,7 @@ way-of-ascension/
 ├── src/features/agility/ui/agilityDisplay.js
 ├── src/features/agility/ui/trainingGame.js
 ├── src/features/catching/
+│   ├── data.js
 │   ├── logic.js
 │   ├── state.js
 │   └── ui/
@@ -1082,9 +1083,10 @@ Paths added:
 - `src/features/agility/index.js` – Agility feature descriptor.
 
 ### Catching Feature (`src/features/catching/`)
-- `src/features/catching/state.js` – Tracks caught creatures, hunger, and taming progress.
-- `src/features/catching/logic.js` – Handles hunger decay over time for captured creatures.
-- `src/features/catching/ui/catchingDisplay.js` – UI for selecting locations, catching, and taming creatures.
+- `src/features/catching/state.js` – Tracks caught creatures, nets, active attempts, hunger, and taming progress.
+- `src/features/catching/logic.js` – Handles hunger decay, timed catching attempts, and taming checks.
+- `src/features/catching/data.js` – Icon mappings for catchable creatures.
+- `src/features/catching/ui/catchingDisplay.js` – UI for selecting locations, managing nets, and handling catching/taming.
 
 ### Side Locations Feature (`src/features/sideLocations/`)
 - `src/features/sideLocations/state.js` – Tracks discovered nodes and discovery cooldown.

--- a/index.html
+++ b/index.html
@@ -471,7 +471,10 @@
             <div class="card">
               <h4> Catching</h4>
               <select id="catchingLocation"></select>
+              <div id="catchChance" class="muted"></div>
               <button class="btn primary" id="catchCritterBtn">Attempt Catch</button>
+              <div class="bar"><div class="fill" id="catchingProgressFill"></div></div>
+              <div class="stat"><span>Catching Nets</span><span id="catchingNets">1</span></div>
             </div>
             <div class="card">
               <h4> Caught Creatures</h4>

--- a/src/features/catching/data.js
+++ b/src/features/catching/data.js
@@ -1,0 +1,16 @@
+export const iconMap = {
+  'Forest Rabbit': 'mdi:rabbit',
+  'Wild Boar': 'mdi:pig',
+  'River Frog': 'mdi:frog',
+  'Honey Bee': 'mdi:bee',
+  'Tree Sprite': 'mdi:pine-tree',
+  'Stone Lizard': 'mdi:lizard',
+  'Water Snake': 'mdi:snake',
+  'Grass Wolf': 'mdi:wolf',
+  'Ruin Guardian': 'mdi:shield',
+  'Forest Spirit': 'mdi:tree',
+};
+
+export function getIcon(name){
+  return iconMap[name] || 'mdi:help-circle';
+}

--- a/src/features/catching/logic.js
+++ b/src/features/catching/logic.js
@@ -1,9 +1,12 @@
+import { ZONES } from '../adventure/data/zones.js';
+import { getIcon } from './data.js';
+
 export function advanceCatching(state){
   const root = state.catching || state;
-  if(!root?.creatures) return;
+  if(!root) return;
   const now = Date.now();
   const interval = 3 * 60 * 60 * 1000; // 3 hours
-  root.creatures.forEach(cr => {
+  root.creatures?.forEach(cr => {
     const elapsed = now - (cr.lastFed || now);
     const hungerLoss = (elapsed / interval) * 0.2;
     const newHunger = Math.max(0, 1 - hungerLoss);
@@ -11,4 +14,40 @@ export function advanceCatching(state){
       cr.hunger = newHunger;
     }
   });
+
+  const attempt = root.currentAttempt;
+  if(attempt){
+    if(!state.activities?.catching){
+      root.currentAttempt = null;
+    } else if(now - attempt.start >= attempt.duration){
+      const zone = ZONES[attempt.zi];
+      const area = zone?.areas?.[attempt.ai];
+      const stage = attempt.stage;
+      const chance = Math.pow(0.5, stage);
+      if(area && Math.random() < chance){
+        root.creatures.push({
+          id: `${area.id}-${Date.now()}`,
+          name: area.enemy,
+          icon: getIcon(area.enemy),
+          hunger: 1,
+          tameProgress: 0,
+          lastFed: Date.now(),
+          lastTameAttempt: 0,
+          tamed: false
+        });
+      }
+      root.currentAttempt = null;
+      if(state.activities) state.activities.catching = false;
+    }
+  }
+}
+
+export function attemptTame(creature){
+  const now = Date.now();
+  if(now - (creature.lastTameAttempt || 0) < 3600 * 1000) return;
+  creature.lastTameAttempt = now;
+  if(Math.random() < (creature.tameProgress || 0) / 100){
+    creature.tamed = true;
+    creature.tameProgress = 100;
+  }
 }

--- a/src/features/catching/state.js
+++ b/src/features/catching/state.js
@@ -2,5 +2,7 @@ export const catchingState = {
   level: 1,
   exp: 0,
   expMax: 100,
+  nets: 1,
+  currentAttempt: null,
   creatures: [] // { id, name, icon, hunger, tameProgress, lastFed, lastTameAttempt, tamed }
 };


### PR DESCRIPTION
## Summary
- add catching nets and attempt tracking to catching state
- resolve catches over time, with agility reducing duration
- show catch chance, progress bar, and net count in catching UI
- document new catching data module

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js)

------
https://chatgpt.com/codex/tasks/task_e_68bb14f905148326a4d782cc874c6ff3