### PR TITLE
feat: make agility node unlock catching

### DIFF
--- a/astral-tree-prototype/template-tree/astral_tree-v2.0.json
+++ b/astral-tree-prototype/template-tree/astral_tree-v2.0.json
@@ -2126,7 +2126,7 @@
     },
     {
       "id": 4062,
-      "label": "unlock agility and forge tab",
+      "label": "unlock agility and catching tab",
       "group": "Hub",
       "type": "notable",
       "x": 490.5407956922057,

--- a/src/features/progression/data/astral_tree.json
+++ b/src/features/progression/data/astral_tree.json
@@ -2126,7 +2126,7 @@
     },
     {
       "id": 4062,
-      "label": "unlock agility and forge tab",
+      "label": "unlock agility and catching tab",
       "group": "Hub",
       "type": "notable",
       "x": 490.5407956922057,


### PR DESCRIPTION
## Summary
- update astral tree node to unlock agility with catching instead of forging

## Testing
- `npm test` (fails: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68bb21052be08326998cd26c536c620b