### PR TITLE
Trim sect buildings and unlock cooking/forging

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -2,6 +2,7 @@
 import { selectActivity } from "../mutators.js";
 import { getActiveActivity } from "../selectors.js";
 import { fCap, qCap } from "../../progression/selectors.js";
+import { getBuildingLevel } from "../../sect/selectors.js";
 
 export function mountActivityUI(root) {
   const handle = name => {
@@ -38,7 +39,18 @@ export function updateActivitySelectors(root) {
   root.gathering ??= { level: 1, exp: 0, expMax: 100 };
   root.catching ??= { level: 1, exp: 0, expMax: 100 };
 
-  const selected = root.ui?.selectedActivity || 'cultivation';
+  const kitchenBuilt = getBuildingLevel('kitchen', root) > 0;
+  const forgingBuilt = getBuildingLevel('forging_room', root) > 0;
+  let selected = root.ui?.selectedActivity || 'cultivation';
+  if ((selected === 'cooking' && !kitchenBuilt) || (selected === 'forging' && !forgingBuilt)) {
+    selected = 'cultivation';
+    root.ui.selectedActivity = selected;
+  }
+
+  const cookItem = document.querySelector('.activity-item[data-activity="cooking"]');
+  if (cookItem) cookItem.style.display = kitchenBuilt ? '' : 'none';
+  const forgeItem = document.querySelector('.activity-item[data-activity="forging"]');
+  if (forgeItem) forgeItem.style.display = forgingBuilt ? '' : 'none';
 
   // Generic highlight for dynamically rendered sidebar items
   document.querySelectorAll('.activity-item[data-activity]')

--- a/src/features/cooking/logic.js
+++ b/src/features/cooking/logic.js
@@ -1,4 +1,5 @@
 import { log } from '../../shared/utils/dom.js';
+import { getCookingSpeedBonus } from './selectors.js';
 
 export function getFoodSlotData(state) {
   if (!state.foodSlots) {
@@ -7,9 +8,12 @@ export function getFoodSlotData(state) {
       slot2: null,
       slot3: null,
       lastUsed: 0,
+      baseCooldown: 5000,
       cooldown: 5000,
     };
   }
+  const speed = 1 + getCookingSpeedBonus(state);
+  state.foodSlots.cooldown = state.foodSlots.baseCooldown / speed;
   return {
     meat: state.meat || 0,
     cookedMeat: state.cookedMeat || 0,
@@ -55,6 +59,7 @@ export function equipFood(foodType, slotNumber, state) {
       slot2: null,
       slot3: null,
       lastUsed: 0,
+      baseCooldown: 5000,
       cooldown: 5000,
     };
   }

--- a/src/features/cooking/selectors.js
+++ b/src/features/cooking/selectors.js
@@ -1,11 +1,18 @@
 import { S } from '../../shared/state.js';
+import { getBuildingBonuses } from '../sect/selectors.js';
 
 export function getCookingState(state = S) {
   return state.cooking || { level: 1, exp: 0, expMax: 100, successBonus: 0 };
 }
 
 export function getCookingSuccessBonus(state = S) {
-  return getCookingState(state).successBonus || 0;
+  const base = getCookingState(state).successBonus || 0;
+  const building = getBuildingBonuses(state).cookingSuccess || 0;
+  return base + building;
+}
+
+export function getCookingSpeedBonus(state = S){
+  return getBuildingBonuses(state).cookingSpeed || 0;
 }
 
 export function getCookingYieldBonus(state = S) {

--- a/src/features/forging/logic.js
+++ b/src/features/forging/logic.js
@@ -1,13 +1,15 @@
 import { S } from '../../shared/state.js';
 import { log } from '../../shared/utils/dom.js';
 import { getAgilityEffects } from '../agility/logic.js';
+import { getBuildingBonuses } from '../sect/selectors.js';
 
 export function getForgingTime(tier, state = S) {
   const baseMinutes = tier === 0 ? 1 : Math.pow(3, tier + 1);
   const level = state.forging?.level || 1;
   const reduction = Math.pow(0.95, Math.max(0, level - 1));
   const { forgeSpeed } = getAgilityEffects(state);
-  return baseMinutes * 60 * reduction / forgeSpeed; // seconds
+  const buildingSpeed = 1 + (getBuildingBonuses(state).imbuementSpeed || 0);
+  return baseMinutes * 60 * reduction / (forgeSpeed * buildingSpeed);
 }
 
 export function startForging(itemId, element, state = S) {

--- a/src/features/sect/data/buildings.js
+++ b/src/features/sect/data/buildings.js
@@ -1,181 +1,54 @@
 export const SECT_BUILDINGS = {
-  // Basic Infrastructure (Unlocked from start)
-  meditation_mat: {
-    name: 'Meditation Mat',
-    desc: 'A simple mat for focused cultivation',
-    icon: '🧘',
-    category: 'cultivation',
-    unlockReq: {realm: 0, stage: 1}, // Mortal 1
+  kitchen: {
+    name: 'Kitchen',
+    desc: 'Facility for preparing meals - unlocks cooking',
+    icon: '🍳',
+    category: 'cooking',
+    unlockReq: { realm: 1, stage: 3 }, // Qi Refining 3
     maxLevel: 5,
-    baseCost: {stones: 20},
+    baseCost: { stones: 40, wood: 20 },
     costScaling: 1.8,
     effects: {
-      1: {qiRegenMult: 0.15, foundationMult: 0.20, desc: '+15% Qi regen, +20% foundation gain'},
-      2: {qiRegenMult: 0.30, foundationMult: 0.40, desc: '+30% Qi regen, +40% foundation gain'},
-      3: {qiRegenMult: 0.50, foundationMult: 0.65, desc: '+50% Qi regen, +65% foundation gain'},
-      4: {qiRegenMult: 0.75, foundationMult: 0.95, desc: '+75% Qi regen, +95% foundation gain'},
-      5: {qiRegenMult: 1.00, foundationMult: 1.30, desc: '+100% Qi regen, +130% foundation gain'}
+      1: { cookingUnlock: true, cookingSuccess: 0.01, cookingSpeed: 0.05, desc: 'Unlocks cooking, +1% success, +5% speed' },
+      2: { cookingSuccess: 0.02, cookingSpeed: 0.10, desc: '+2% success, +10% speed' },
+      3: { cookingSuccess: 0.03, cookingSpeed: 0.15, desc: '+3% success, +15% speed' },
+      4: { cookingSuccess: 0.04, cookingSpeed: 0.20, desc: '+4% success, +20% speed' },
+      5: { cookingSuccess: 0.05, cookingSpeed: 0.25, desc: '+5% success, +25% speed' }
     }
   },
 
-  spirit_well: {
-    name: 'Spirit Well',
-    desc: 'A well that gathers spiritual energy',
-    icon: '🏺',
-    category: 'cultivation',
-    unlockReq: {realm: 1, stage: 3}, // Qi Refining 3
-    maxLevel: 4,
-    baseCost: {stones: 50, wood: 20},
-    costScaling: 2.0,
-    effects: {
-      1: {qiCapMult: 0.25, desc: '+25% Qi capacity'},
-      2: {qiCapMult: 0.50, desc: '+50% Qi capacity'},
-      3: {qiCapMult: 0.80, desc: '+80% Qi capacity'},
-      4: {qiCapMult: 1.20, desc: '+120% Qi capacity'}
-    }
-  },
-
-  // Resource Buildings
-  herbal_garden: {
-    name: 'Herbal Garden',
-    desc: 'Cultivated plots for growing spiritual herbs',
-    icon: '🌿',
-    category: 'resources',
-    unlockReq: {realm: 1, stage: 5}, // Qi Refining 5
-    maxLevel: 6,
-    baseCost: {stones: 40, wood: 25},
-    costScaling: 1.9,
-    effects: {
-      1: {herbYield: 0.30, desc: '+30% herb yield'},
-      2: {herbYield: 0.60, desc: '+60% herb yield'},
-      3: {herbYield: 1.00, desc: '+100% herb yield'},
-      4: {herbYield: 1.50, desc: '+150% herb yield'},
-      5: {herbYield: 2.10, desc: '+210% herb yield'},
-      6: {herbYield: 3.00, desc: '+300% herb yield'}
-    }
-  },
-
-  spirit_mine: {
-    name: 'Spirit Mine',
-    desc: 'Deep shafts that extract spiritual ores',
-    icon: '⛏️',
-    category: 'resources',
-    unlockReq: {realm: 2, stage: 1}, // Foundation 1
-    maxLevel: 5,
-    baseCost: {stones: 80, ore: 15},
-    costScaling: 2.1,
-    effects: {
-      1: {oreYield: 0.40, desc: '+40% ore yield'},
-      2: {oreYield: 0.85, desc: '+85% ore yield'},
-      3: {oreYield: 1.40, desc: '+140% ore yield'},
-      4: {oreYield: 2.10, desc: '+210% ore yield'},
-      5: {oreYield: 3.00, desc: '+300% ore yield'}
-    }
-  },
-
-  sacred_grove: {
-    name: 'Sacred Grove',
-    desc: 'Ancient trees imbued with spiritual energy',
-    icon: '🌳',
-    category: 'resources',
-    unlockReq: {realm: 2, stage: 3}, // Foundation 3
-    maxLevel: 5,
-    baseCost: {stones: 100, wood: 50, herbs: 20},
-    costScaling: 2.0,
-    effects: {
-      1: {woodYield: 0.50, desc: '+50% wood yield'},
-      2: {woodYield: 1.00, desc: '+100% wood yield'},
-      3: {woodYield: 1.70, desc: '+170% wood yield'},
-      4: {woodYield: 2.50, desc: '+250% wood yield'},
-      5: {woodYield: 3.50, desc: '+350% wood yield'}
-    }
-  },
-
-  // Advanced Buildings
   alchemy_lab: {
     name: 'Alchemy Laboratory',
     desc: 'Advanced facility for pill refinement - unlocks alchemy',
     icon: '🏛️',
     category: 'alchemy',
-    unlockReq: {realm: 1, stage: 5}, // Qi Refining 5 - earlier unlock
+    unlockReq: { realm: 1, stage: 5 }, // Qi Refining 5
     maxLevel: 4,
-    baseCost: {stones: 100, ore: 40, wood: 60, herbs: 30}, // Reduced cost
-    costScaling: 2.0, // Reduced scaling
+    baseCost: { stones: 100, ore: 40, wood: 60, herbs: 30 },
+    costScaling: 2.0,
     effects: {
-      1: {alchemyUnlock: true, alchemySlots: 1, alchemySuccess: 0.15, desc: 'Unlocks alchemy, +1 slot, +15% success'},
-      2: {alchemySlots: 1, alchemySuccess: 0.30, desc: '+1 slot, +30% success'},
-      3: {alchemySlots: 2, alchemySuccess: 0.50, desc: '+2 slots, +50% success'},
-      4: {alchemySlots: 2, alchemySuccess: 0.75, desc: '+2 slots, +75% success'}
+      1: { alchemyUnlock: true, alchemySlots: 1, alchemySuccess: 0.15, desc: 'Unlocks alchemy, +1 slot, +15% success' },
+      2: { alchemySlots: 1, alchemySuccess: 0.30, desc: '+1 slot, +30% success' },
+      3: { alchemySlots: 2, alchemySuccess: 0.50, desc: '+2 slots, +50% success' },
+      4: { alchemySlots: 2, alchemySuccess: 0.75, desc: '+2 slots, +75% success' }
     }
   },
 
-  training_grounds: {
-    name: 'Training Grounds',
-    desc: 'Facilities for combat training and sparring',
-    icon: '⚔️',
-    category: 'combat',
-    unlockReq: {realm: 2, stage: 7}, // Foundation 7
+  forging_room: {
+    name: 'Forging Room',
+    desc: 'Workshop for imbuement and forging - unlocks forging',
+    icon: '⚒️',
+    category: 'forging',
+    unlockReq: { realm: 2, stage: 1 }, // Foundation 1
     maxLevel: 5,
-    baseCost: {stones: 200, ore: 80, wood: 60},
-    costScaling: 2.2,
+    baseCost: { stones: 120, ore: 60, wood: 80 },
+    costScaling: 2.0,
     effects: {
-      1: {atkBase: 3, armorBase: 2, desc: '+3 ATK, +2 Armor'},
-      2: {atkBase: 6, armorBase: 4, desc: '+6 ATK, +4 Armor'},
-      3: {atkBase: 10, armorBase: 7, desc: '+10 ATK, +7 Armor'},
-      4: {atkBase: 15, armorBase: 11, desc: '+15 ATK, +11 Armor'},
-      5: {atkBase: 22, armorBase: 16, desc: '+22 ATK, +16 Armor'}
-    }
-  },
-
-  disciple_quarters: {
-    name: 'Disciple Quarters',
-    desc: 'Housing for sect disciples',
-    icon: '🏠',
-    category: 'disciples',
-    unlockReq: {realm: 3, stage: 1}, // Core 1
-    maxLevel: 6,
-    baseCost: {stones: 120, wood: 100},
-    costScaling: 1.7,
-    effects: {
-      1: {disciples: 1, desc: '+1 disciple'},
-      2: {disciples: 2, desc: '+2 disciples'},
-      3: {disciples: 3, desc: '+3 disciples'},
-      4: {disciples: 4, desc: '+4 disciples'},
-      5: {disciples: 6, desc: '+6 disciples'},
-      6: {disciples: 8, desc: '+8 disciples'}
-    }
-  },
-
-  // Elite Buildings (High-tier unlocks)
-  grand_library: {
-    name: 'Grand Library',
-    desc: 'Repository of ancient cultivation knowledge',
-    icon: '📚',
-    category: 'knowledge',
-    unlockReq: {realm: 3, stage: 5}, // Core 5
-    maxLevel: 3,
-    baseCost: {stones: 500, wood: 300, herbs: 100, cores: 10},
-    costScaling: 2.5,
-    effects: {
-      1: {lawPoints: 5, qiRegenMult: 0.25, desc: '+5 law points, +25% Qi regen'},
-      2: {lawPoints: 10, qiRegenMult: 0.50, desc: '+10 law points, +50% Qi regen'},
-      3: {lawPoints: 20, qiRegenMult: 1.00, desc: '+20 law points, +100% Qi regen'}
-    }
-  },
-
-  celestial_observatory: {
-    name: 'Celestial Observatory',
-    desc: 'Tower for studying heavenly phenomena',
-    icon: '🔭',
-    category: 'advanced',
-    unlockReq: {realm: 4, stage: 1}, // Nascent 1
-    maxLevel: 2,
-    baseCost: {stones: 800, ore: 400, wood: 300, herbs: 200, cores: 25},
-    costScaling: 3.0,
-    effects: {
-      1: {breakthroughBonus: 0.20, lawPoints: 10, desc: '+20% breakthrough chance, +10 law points'},
-      2: {breakthroughBonus: 0.40, lawPoints: 25, desc: '+40% breakthrough chance, +25 law points'}
+      1: { forgingUnlock: true, imbuementSpeed: 0.05, desc: 'Unlocks forging, +5% imbuement speed' },
+      2: { imbuementSpeed: 0.10, desc: '+10% imbuement speed' },
+      3: { imbuementSpeed: 0.15, desc: '+15% imbuement speed' },
+      4: { imbuementSpeed: 0.20, desc: '+20% imbuement speed' },
+      5: { imbuementSpeed: 0.25, desc: '+25% imbuement speed' }
     }
   }
 };
-

--- a/src/features/sect/logic.js
+++ b/src/features/sect/logic.js
@@ -30,9 +30,11 @@ export function canUpgrade(buildings, resources, progression, key){
 
 export function calculateBonuses(buildings){
   const bonuses = {
-    qiRegenMult: 0, qiCapMult: 0, herbYield: 0, oreYield: 0, woodYield: 0,
-    alchemySlots: 0, alchemySuccess: 0, atkBase: 0, armorBase: 0,
-    disciples: 0, lawPoints: 0, breakthroughBonus: 0, foundationMult: 0
+    cookingSuccess: 0,
+    cookingSpeed: 0,
+    alchemySlots: 0,
+    alchemySuccess: 0,
+    imbuementSpeed: 0
   };
   for(const [key, level] of Object.entries(buildings)){
     const b = SECT_BUILDINGS[key];
@@ -41,18 +43,10 @@ export function calculateBonuses(buildings){
       const eff = b.effects[i];
       if(!eff) continue;
       for(const [k,v] of Object.entries(eff)){
-        if(k === 'desc' || k === 'alchemyUnlock') continue;
+        if(k === 'desc' || k.endsWith('Unlock')) continue;
         bonuses[k] = (bonuses[k] || 0) + v;
       }
     }
   }
   return bonuses;
-}
-
-export function disciplesFromBuildings(buildings){
-  return calculateBonuses(buildings).disciples || 0;
-}
-
-export function lawPointsFromBuildings(buildings){
-  return calculateBonuses(buildings).lawPoints || 0;
 }

--- a/src/features/sect/selectors.js
+++ b/src/features/sect/selectors.js
@@ -11,13 +11,3 @@ export function getBuildingLevel(key, state = sectState){
 export function getBuildingBonuses(state = sectState){
   return slice(state).bonuses || {};
 }
-
-export function getDisciples(state = sectState){
-  const bonuses = getBuildingBonuses(state);
-  const base = state.disciples || 0;
-  return base + (bonuses.disciples || 0);
-}
-
-export function getLawPointBonus(state = sectState){
-  return getBuildingBonuses(state).lawPoints || 0;
-}

--- a/src/features/sect/state.js
+++ b/src/features/sect/state.js
@@ -1,18 +1,10 @@
 export const sectState = {
   buildings: {},
   bonuses: {
-    qiRegenMult: 0,
-    qiCapMult: 0,
-    herbYield: 0,
-    oreYield: 0,
-    woodYield: 0,
+    cookingSuccess: 0,
+    cookingSpeed: 0,
     alchemySlots: 0,
     alchemySuccess: 0,
-    atkBase: 0,
-    armorBase: 0,
-    disciples: 0,
-    lawPoints: 0,
-    breakthroughBonus: 0,
-    foundationMult: 0,
+    imbuementSpeed: 0,
   },
 };

--- a/src/features/sect/ui/sectScreen.js
+++ b/src/features/sect/ui/sectScreen.js
@@ -1,9 +1,9 @@
 import { SECT_BUILDINGS } from '../data/buildings.js';
-import { getBuildingLevel, getBuildingBonuses } from '../selectors.js';
+import { getBuildingLevel } from '../selectors.js';
 import { getBuildingCost } from '../logic.js';
 import { upgradeBuilding } from '../mutators.js';
 import { on } from '../../../shared/events.js';
-import { setText } from '../../../shared/utils/dom.js';
+import { updateActivitySelectors } from '../../activity/ui/activityUI.js';
 
 function renderBuildings(state){
   const container = document.getElementById('buildingsContainer');
@@ -12,52 +12,52 @@ function renderBuildings(state){
   for(const [key, b] of Object.entries(SECT_BUILDINGS)){
     const level = getBuildingLevel(key, state);
     const next = level + 1;
-    const row = document.createElement('div');
-    row.className = 'building-row';
 
-    const label = document.createElement('span');
-    label.textContent = `${b.icon} ${b.name} (Lv ${level})`;
-    row.appendChild(label);
+    const card = document.createElement('div');
+    card.className = 'building-card';
 
-    const effect = document.createElement('span');
+    const title = document.createElement('h5');
+    title.textContent = `${b.icon} ${b.name} (Lv ${level}/${b.maxLevel})`;
+    card.appendChild(title);
+
+    const effect = document.createElement('div');
+    effect.className = 'effect';
     if(next > b.maxLevel){
       effect.textContent = b.effects[level]?.desc || '';
     } else {
       effect.textContent = b.effects[next]?.desc || '';
     }
-    row.appendChild(effect);
+    card.appendChild(effect);
 
-    const costSpan = document.createElement('span');
+    const costDiv = document.createElement('div');
+    costDiv.className = 'materials';
     if(next > b.maxLevel){
-      costSpan.textContent = 'Max level';
+      costDiv.textContent = 'Max level';
     } else {
       const cost = getBuildingCost(key, next);
       const costStr = Object.entries(cost).map(([res, amt]) => `${amt} ${res}`).join(', ');
-      costSpan.textContent = `Cost: ${costStr}`;
+      costDiv.textContent = costStr;
     }
-    row.appendChild(costSpan);
+    card.appendChild(costDiv);
 
     const btn = document.createElement('button');
+    btn.className = 'btn small';
     btn.textContent = next > b.maxLevel ? 'Max' : 'Upgrade';
     btn.disabled = next > b.maxLevel;
     btn.addEventListener('click', () => {
-      if(upgradeBuilding(state, key)) render(state);
+      if(upgradeBuilding(state, key)){
+        render(state);
+        updateActivitySelectors(state);
+      }
     });
-    row.appendChild(btn);
+    card.appendChild(btn);
 
-    container.appendChild(row);
+    container.appendChild(card);
   }
-}
-
-function renderDisciples(state){
-  const bonuses = getBuildingBonuses(state);
-  const total = (state.disciples || 0) + (bonuses.disciples || 0);
-  setText('discTotal', total);
 }
 
 function render(state){
   renderBuildings(state);
-  renderDisciples(state);
 }
 
 export function mountSectUI(state){

--- a/style.css
+++ b/style.css
@@ -4903,3 +4903,7 @@ html.reduce-motion .log-sheet{transition:none;}
 .creature-header{display:flex;align-items:center;gap:4px}
 .creature-actions{margin-top:4px;display:flex;gap:4px}
 .creature-list .bar{height:6px;margin:4px 0}
+#buildingsContainer{display:flex;flex-wrap:wrap;gap:1rem}
+.building-card{border:1px solid #374151;background:var(--secondary-bg);padding:12px;border-radius:6px;width:100%;box-sizing:border-box}
+@media(min-width:768px){.building-card{width:40%}}
+.building-card .materials{margin:8px 0;color:#6b7280;font-size:.9rem}


### PR DESCRIPTION
## Summary
- Replace sect building list with Kitchen, Alchemy Laboratory and Forging Room
- Render building cards and reveal activities when corresponding rooms are built
- Apply building bonuses for cooking and forging speed/bonuses

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2364d3f883269766be1c3077f3ab