### PR TITLE
Show XP values on sidebar progress bars

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -2,6 +2,8 @@
 import { selectActivity } from "../mutators.js";
 import { getActiveActivity } from "../selectors.js";
 import { fCap, qCap } from "../../progression/selectors.js";
+import { setText } from "../../../shared/utils/dom.js";
+import { fmt } from "../../../shared/utils/number.js";
 
 export function mountActivityUI(root) {
   const handle = name => {
@@ -92,6 +94,7 @@ export function updateActivitySelectors(root) {
     const expPct = (root.agility.exp / root.agility.expMax) * 100;
     agiFill.style.width = `${expPct}%`;
     agiInfo.textContent = root.activities?.agility ? 'Training...' : `Level ${root.agility.level}`;
+    setText('agilityProgressText', `${fmt(root.agility.exp)} / ${fmt(root.agility.expMax)} XP`);
   }
 
   // Mining
@@ -128,6 +131,7 @@ export function updateActivitySelectors(root) {
     const expPct = (root.catching.exp / root.catching.expMax) * 100;
     catchFill.style.width = `${expPct}%`;
     catchInfo.textContent = root.activities?.catching ? 'Catching...' : `Level ${root.catching.level}`;
+    setText('catchingProgressText', `${fmt(root.catching.exp)} / ${fmt(root.catching.expMax)} XP`);
   }
 
   // Adventure

--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { startForging } from '../mutators.js';
 import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
@@ -118,7 +119,7 @@ function updateForgingSidebar(state = S) {
   if (fill) {
     const pct = (state.forging.exp / state.forging.expMax) * 100;
     fill.style.width = pct + '%';
-    setText('forgingProgressTextSidebar', pct.toFixed(0) + '%');
+    setText('forgingProgressTextSidebar', `${fmt(state.forging.exp)} / ${fmt(state.forging.expMax)} XP`);
   }
 }
 

--- a/src/features/gathering/ui/gatheringDisplay.js
+++ b/src/features/gathering/ui/gatheringDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { getGatheringRate } from '../logic.js';
 
@@ -60,7 +61,7 @@ export function updateGatheringSidebar(state = S) {
   if (fill) {
     const progressPct = Math.floor(state.gathering.exp / state.gathering.expMax * 100);
     fill.style.width = progressPct + '%';
-    setText('gatheringProgressText', progressPct + '%');
+    setText('gatheringProgressText', `${fmt(state.gathering.exp)} / ${fmt(state.gathering.expMax)} XP`);
   }
 }
 

--- a/src/features/mining/ui/miningDisplay.js
+++ b/src/features/mining/ui/miningDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { getMiningRate } from '../logic.js';
 
@@ -60,7 +61,7 @@ export function updateMiningSidebar(state = S) {
   if (miningFill) {
     const progressPct = Math.floor(state.mining.exp / state.mining.expMax * 100);
     miningFill.style.width = progressPct + '%';
-    setText('miningProgressText', progressPct + '%');
+    setText('miningProgressText', `${fmt(state.mining.exp)} / ${fmt(state.mining.expMax)} XP`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Display flat XP values for mining, gathering, forging, agility, and catching sidebar bars
- Import formatting helper and update selectors so text shows `current / max XP`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68bb21f3cb78832681a17e109294f407