### PR TITLE
Show flat XP in sidebar skill bars

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -2,6 +2,7 @@
 import { selectActivity } from "../mutators.js";
 import { getActiveActivity } from "../selectors.js";
 import { fCap, qCap } from "../../progression/selectors.js";
+import { fmt } from "../../../shared/utils/number.js";
 
 export function mountActivityUI(root) {
   const handle = name => {
@@ -86,12 +87,14 @@ export function updateActivitySelectors(root) {
   const agiSel = document.getElementById('agilitySelector');
   const agiFill = document.getElementById('agilitySelectorFill');
   const agiInfo = document.getElementById('agilityInfo');
+  const agiText = document.getElementById('agilityProgressText');
   agiSel?.classList.toggle('active', selected === 'agility');
   agiSel?.classList.toggle('running', root.activities?.agility);
   if (agiFill && agiInfo) {
-    const expPct = (root.agility.exp / root.agility.expMax) * 100;
-    agiFill.style.width = `${expPct}%`;
+    const expFrac = root.agility.exp / root.agility.expMax;
+    agiFill.style.width = `${expFrac * 100}%`;
     agiInfo.textContent = root.activities?.agility ? 'Training...' : `Level ${root.agility.level}`;
+    if (agiText) agiText.textContent = `${fmt(root.agility.exp)} / ${fmt(root.agility.expMax)} XP`;
   }
 
   // Mining

--- a/src/features/catching/ui/catchingDisplay.js
+++ b/src/features/catching/ui/catchingDisplay.js
@@ -1,5 +1,7 @@
 import { ZONES } from '../../adventure/data/zones.js';
 import { startCatch } from '../mutators.js';
+import { setText } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 
 function renderCaughtCreatures(state){
   const container = document.getElementById('caughtCreatures');
@@ -99,5 +101,13 @@ export function updateCatchingUI(state){
   if(progressFill){
     const pct = (root.currentCatch?.progress ?? 0) * 100;
     progressFill.style.width = `${pct}%`;
+  }
+  const levelEl = document.getElementById('catchingLevel');
+  if (levelEl) levelEl.textContent = `Level ${root.level}`;
+  const xpFill = document.getElementById('catchingProgressFill');
+  if (xpFill) {
+    const frac = root.exp / root.expMax;
+    xpFill.style.width = `${frac * 100}%`;
+    setText('catchingProgressText', `${fmt(root.exp)} / ${fmt(root.expMax)} XP`);
   }
 }

--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { startForging } from '../mutators.js';
 import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
@@ -116,9 +117,9 @@ function updateForgingSidebar(state = S) {
   setText('forgingLevelSidebar', `Level ${state.forging.level}`);
   const fill = document.getElementById('forgingProgressFillSidebar');
   if (fill) {
-    const pct = (state.forging.exp / state.forging.expMax) * 100;
-    fill.style.width = pct + '%';
-    setText('forgingProgressTextSidebar', pct.toFixed(0) + '%');
+    const frac = state.forging.exp / state.forging.expMax;
+    fill.style.width = (frac * 100) + '%';
+    setText('forgingProgressTextSidebar', `${fmt(state.forging.exp)} / ${fmt(state.forging.expMax)} XP`);
   }
 }
 

--- a/src/features/gathering/ui/gatheringDisplay.js
+++ b/src/features/gathering/ui/gatheringDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { getGatheringRate } from '../logic.js';
 
@@ -58,9 +59,9 @@ export function updateGatheringSidebar(state = S) {
   setText('gatheringLevel', `Level ${state.gathering.level}`);
   const fill = document.getElementById('gatheringProgressFill');
   if (fill) {
-    const progressPct = Math.floor(state.gathering.exp / state.gathering.expMax * 100);
-    fill.style.width = progressPct + '%';
-    setText('gatheringProgressText', progressPct + '%');
+    const progressFrac = state.gathering.exp / state.gathering.expMax;
+    fill.style.width = (progressFrac * 100) + '%';
+    setText('gatheringProgressText', `${fmt(state.gathering.exp)} / ${fmt(state.gathering.expMax)} XP`);
   }
 }
 

--- a/src/features/mining/ui/miningDisplay.js
+++ b/src/features/mining/ui/miningDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { getMiningRate } from '../logic.js';
 
@@ -58,9 +59,9 @@ export function updateMiningSidebar(state = S) {
   setText('miningLevel', `Level ${state.mining.level}`);
   const miningFill = document.getElementById('miningProgressFill');
   if (miningFill) {
-    const progressPct = Math.floor(state.mining.exp / state.mining.expMax * 100);
-    miningFill.style.width = progressPct + '%';
-    setText('miningProgressText', progressPct + '%');
+    const progressFrac = state.mining.exp / state.mining.expMax;
+    miningFill.style.width = (progressFrac * 100) + '%';
+    setText('miningProgressText', `${fmt(state.mining.exp)} / ${fmt(state.mining.expMax)} XP`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Display flat XP totals for mining, gathering, forging, catching, and agility in the sidebar instead of percentages
- Keep sidebar progress bars consistent in width with the cultivation bar

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations; AI changes blocked until validation passes)*

------
https://chatgpt.com/codex/tasks/task_e_68bb21f3cb78832681a17e109294f407