### PR TITLE
Animate cultivation fill with shimmer

### DIFF
--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -258,17 +258,42 @@ export function updateCurrentRealmHeader() {
   }
 }
 
+let fillAnimation;
+
+function animateFoundationFill(targetPercent) {
+  const foundationFill = document.getElementById('foundationFill');
+  if (!foundationFill) return;
+  const start = parseFloat(foundationFill.style.getPropertyValue('--fill-height')) || 0;
+  const startTime = performance.now();
+  const duration = 1000;
+  foundationFill.classList.add('filling');
+  foundationFill.style.opacity = '1';
+
+  function step(now) {
+    const progress = Math.min((now - startTime) / duration, 1);
+    const value = start + (targetPercent - start) * progress;
+    foundationFill.style.setProperty('--fill-height', `${value}%`);
+    if (progress < 1) {
+      fillAnimation = requestAnimationFrame(step);
+    } else {
+      foundationFill.classList.remove('filling');
+    }
+  }
+
+  cancelAnimationFrame(fillAnimation);
+  fillAnimation = requestAnimationFrame(step);
+}
+
 export function updateCultivationVisualization() {
   const foundationFill = document.getElementById('foundationFill');
   const yinYangContainer = document.getElementById('yinYangContainer');
   const cultivationViz = document.getElementById('cultivationVisualization');
-  
+
   if (!foundationFill || !yinYangContainer || !cultivationViz) return;
 
   // Update foundation fill as liquid filling the silhouette
   const foundationPercent = Math.max(0, Math.min(100, (S.foundation / fCap(S)) * 100));
-  foundationFill.style.setProperty('--fill-height', `${foundationPercent}%`);
-  foundationFill.style.opacity = '1'; // Always visible when element exists
+  animateFoundationFill(foundationPercent);
 
   // Update realm-based styling
   const realmClasses = [

--- a/style.css
+++ b/style.css
@@ -721,8 +721,8 @@ html.reduce-motion .rune-ring .orbit {
       black var(--fill-height, 0%), 
       transparent calc(var(--fill-height, 0%) + 1%)
     );
-  transition: all 2.5s cubic-bezier(0.23, 1, 0.32, 1);
   animation: auroraShimmer 6s ease-in-out infinite;
+  animation-play-state: paused;
 }
 
 .foundation-fill::before {
@@ -761,6 +761,7 @@ html.reduce-motion .rune-ring .orbit {
       transparent calc(var(--fill-height, 0%) + 4%)
     );
   animation: liquidShimmer 3s ease-in-out infinite;
+  animation-play-state: paused;
 }
 
 .foundation-fill::after {
@@ -791,6 +792,13 @@ html.reduce-motion .rune-ring .orbit {
       transparent calc(var(--fill-height, 0%) + 2%)
     );
   animation: liquidFlow 4s ease-in-out infinite reverse;
+  animation-play-state: paused;
+}
+
+.foundation-fill.filling,
+.foundation-fill.filling::before,
+.foundation-fill.filling::after {
+  animation-play-state: running;
 }
 
  


### PR DESCRIPTION
## Summary
- Smoothly animate foundation fill in cultivation silhouette
- Trigger liquid shimmer only while the fill is in motion

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: verification report with existing UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb31b36dc48326b37014bedc48ac5c