### PR TITLE
Animate cultivation silhouette fill

### DIFF
--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -37,6 +37,30 @@ export function updateRealmUI() {
   }
 }
 
+let fillAnimFrame = null;
+function animateFoundationFill(el, target) {
+  const start = parseFloat(el.dataset.currentFill || '0');
+  const duration = 600;
+  const startTime = performance.now();
+
+  el.classList.add('filling');
+  if (fillAnimFrame) cancelAnimationFrame(fillAnimFrame);
+
+  function step(now) {
+    const progress = Math.min((now - startTime) / duration, 1);
+    const value = start + (target - start) * progress;
+    el.style.setProperty('--fill-height', `${value}%`);
+    el.dataset.currentFill = value;
+    if (progress < 1) {
+      fillAnimFrame = requestAnimationFrame(step);
+    } else {
+      el.classList.remove('filling');
+    }
+  }
+
+  fillAnimFrame = requestAnimationFrame(step);
+}
+
 export function updateActivityCultivation() {
   setText('realmNameActivity', `${REALMS[S.realm.tier].name} ${S.realm.stage}`);
   updateCurrentRealmHeader();
@@ -267,7 +291,7 @@ export function updateCultivationVisualization() {
 
   // Update foundation fill as liquid filling the silhouette
   const foundationPercent = Math.max(0, Math.min(100, (S.foundation / fCap(S)) * 100));
-  foundationFill.style.setProperty('--fill-height', `${foundationPercent}%`);
+  animateFoundationFill(foundationFill, foundationPercent);
   foundationFill.style.opacity = '1'; // Always visible when element exists
 
   // Update realm-based styling

--- a/style.css
+++ b/style.css
@@ -722,6 +722,10 @@ html.reduce-motion .rune-ring .orbit {
       transparent calc(var(--fill-height, 0%) + 1%)
     );
   transition: all 2.5s cubic-bezier(0.23, 1, 0.32, 1);
+  animation: none;
+}
+
+.foundation-fill.filling {
   animation: auroraShimmer 6s ease-in-out infinite;
 }
 
@@ -753,13 +757,17 @@ html.reduce-motion .rune-ring .orbit {
       black calc(var(--fill-height, 0%) + 2%), 
       transparent calc(var(--fill-height, 0%) + 4%)
     );
-  -webkit-mask: 
-    linear-gradient(0deg, 
-      black 0%, 
-      black calc(var(--fill-height, 0%) - 3%), 
-      black calc(var(--fill-height, 0%) + 2%), 
+  -webkit-mask:
+    linear-gradient(0deg,
+      black 0%,
+      black calc(var(--fill-height, 0%) - 3%),
+      black calc(var(--fill-height, 0%) + 2%),
       transparent calc(var(--fill-height, 0%) + 4%)
     );
+  animation: none;
+}
+
+.foundation-fill.filling::before {
   animation: liquidShimmer 3s ease-in-out infinite;
 }
 
@@ -784,12 +792,16 @@ html.reduce-motion .rune-ring .orbit {
       black calc(var(--fill-height, 0%) - 1%), 
       transparent calc(var(--fill-height, 0%) + 2%)
     );
-  -webkit-mask: 
-    linear-gradient(0deg, 
-      black 0%, 
-      black calc(var(--fill-height, 0%) - 1%), 
+  -webkit-mask:
+    linear-gradient(0deg,
+      black 0%,
+      black calc(var(--fill-height, 0%) - 1%),
       transparent calc(var(--fill-height, 0%) + 2%)
     );
+  animation: none;
+}
+
+.foundation-fill.filling::after {
   animation: liquidFlow 4s ease-in-out infinite reverse;
 }
 


### PR DESCRIPTION
## Summary
- Animate foundation fill within cultivation silhouette using `requestAnimationFrame`
- Trigger shimmer animation only while filling

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: verification enforcement issues)


------
https://chatgpt.com/codex/tasks/task_e_68bb31b36dc48326b37014bedc48ac5c