### PR TITLE
feat: gate features by flags and unlocks

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -93,6 +93,8 @@ export const featureFlags = {
   astralTree: flags.FEATURE_ASTRAL_TREE.parsedValue
 };
 
+export const devUnlockPreset = flags.DEV_UNLOCK_PRESET.parsedValue;
+
 export function configReport() {
   const missingKeys = Object.entries(flags)
     .filter(([, v]) => v.source === 'default')

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -15,38 +15,74 @@ import { mountCatchingUI } from "./catching/ui/catchingDisplay.js";
 import { mountMindReadingUI } from "./mind/ui/mindReadingTab.js";
 import { mountAstralTreeUI } from "./progression/ui/astralTree.js";
 import { mountForgingUI } from "./forging/ui/forgingDisplay.js";
-import { featureFlags } from "../config.js";
+import { featureFlags, devUnlockPreset } from "../config.js";
+import { selectProgress, selectAstral, selectSect } from "../shared/selectors.js";
+import { advanceRealm, unlockAstralNode } from "./progression/mutators.js";
+import { forceBuild } from "./sect/mutators.js";
 
 
 // Example placeholder for later:
 // import { mountWeaponGenUI } from "./weaponGeneration/ui/weaponGenerationDisplay.js";
 
+const unlockMap = {
+  astralTree: (s) => selectProgress.mortalStage(s) >= 2,
+  mining: (s) => selectAstral.isNodeUnlocked(4060, s),
+  physique: (s) => selectAstral.isNodeUnlocked(4060, s),
+  gathering: (s) => selectAstral.isNodeUnlocked(4061, s),
+  mind: (s) => selectAstral.isNodeUnlocked(4061, s),
+  catching: (s) => selectAstral.isNodeUnlocked(4062, s),
+  agility: (s) => selectAstral.isNodeUnlocked(4062, s),
+  alchemy: (s) => selectSect.isBuildingBuilt('alchemy', s),
+  cooking: (s) => selectSect.isBuildingBuilt('kitchen', s),
+  law: (s) => selectProgress.isQiRefiningReached(s),
+  sect: (s) => selectProgress.mortalStage(s) >= 3,
+  proficiency: (s) => selectProgress.mortalStage(s) >= 5,
+};
+
+function applyDevUnlockPreset(state) {
+  if (devUnlockPreset !== 'all') return;
+  const prog = state.progression || state;
+  while (selectProgress.mortalStage(prog) < 5) advanceRealm(prog);
+  while (!selectProgress.isQiRefiningReached(prog)) advanceRealm(prog);
+  unlockAstralNode(4060, prog);
+  unlockAstralNode(4061, prog);
+  unlockAstralNode(4062, prog);
+  forceBuild(state, 'alchemy');
+  forceBuild(state, 'kitchen');
+}
+
 export function mountAllFeatureUIs(state) {
-  if (featureFlags.proficiency) mountProficiencyUI(state);
-  if (featureFlags.sect) mountSectUI(state);
-  if (featureFlags.karma) mountKarmaUI(state);
-  if (featureFlags.alchemy) mountAlchemyUI(state);
-  if (featureFlags.cooking) mountCookingUI(state);
-  if (featureFlags.mining) mountMiningUI(state);
-  if (featureFlags.gathering) mountGatheringUI(state);
-  if (featureFlags.forging) mountForgingUI(state);
-  if (featureFlags.physique) mountPhysiqueUI(state);
-  if (featureFlags.agility) mountAgilityUI(state);
-  if (featureFlags.catching) mountCatchingUI(state);
-  if (featureFlags.law) mountLawDisplay(state);
-  if (featureFlags.mind) mountMindReadingUI(state);
-  if (featureFlags.astralTree) mountAstralTreeUI(state);
+  applyDevUnlockPreset(state);
+  const vis = debugFeatureVisibility(state);
+  if (vis.proficiency.visible) mountProficiencyUI(state);
+  if (vis.sect.visible) mountSectUI(state);
+  if (vis.karma.visible) mountKarmaUI(state);
+  if (vis.alchemy.visible) mountAlchemyUI(state);
+  if (vis.cooking.visible) mountCookingUI(state);
+  if (vis.mining.visible) mountMiningUI(state);
+  if (vis.gathering.visible) mountGatheringUI(state);
+  if (vis.forging.visible) mountForgingUI(state);
+  if (vis.physique.visible) mountPhysiqueUI(state);
+  if (vis.agility.visible) mountAgilityUI(state);
+  if (vis.catching.visible) mountCatchingUI(state);
+  if (vis.law.visible) mountLawDisplay(state);
+  if (vis.mind.visible) mountMindReadingUI(state);
+  if (vis.astralTree.visible) mountAstralTreeUI(state);
 
   // mountWeaponGenUI?.(state);
 }
 
-export function debugFeatureVisibility(/* state */) {
+export function debugFeatureVisibility(state) {
   const result = {};
-  for (const [key, value] of Object.entries(featureFlags)) {
+  for (const [key, flag] of Object.entries(featureFlags)) {
+    const unlockFn = unlockMap[key] || (() => true);
+    const unlockAllowed = unlockFn(state);
+    const flagAllowed = !!flag;
     result[key] = {
-      flagAllowed: !!value,
-      unlockAllowed: true,
-      reason: value ? 'flag=true' : 'flag=false'
+      flagAllowed,
+      unlockAllowed,
+      visible: flagAllowed && unlockAllowed,
+      reason: !flagAllowed ? 'flag=false' : unlockAllowed ? 'unlocked' : 'locked',
     };
   }
   return result;

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -155,3 +155,8 @@ export function meditate(root) {
   root.foundation = clamp(root.foundation + gain, 0, fCap(root));
   return gain;
 }
+
+export function unlockAstralNode(id, state = progressionState) {
+  state.astralUnlockedNodes = state.astralUnlockedNodes || new Set();
+  state.astralUnlockedNodes.add(id);
+}

--- a/src/features/progression/selectors.js
+++ b/src/features/progression/selectors.js
@@ -1,4 +1,5 @@
 import { progressionState } from './state.js';
+import { REALMS } from './data/realms.js';
 import { getTunable } from '../../shared/tunables.js';
 import {
   getLawBonuses as calcLawBonuses,
@@ -75,4 +76,33 @@ export function calculatePlayerAttackRate(state = progressionState) {
 
 export function breakthroughChance(state = progressionState) {
   return calcBreakthroughChance(state);
+}
+
+export function mortalStage(state = progressionState) {
+  const slice = state.progression || state;
+  const realm = slice.realm || {};
+  if ((realm.tier ?? 0) > 0) return REALMS[0]?.stages || 0;
+  return realm.stage || 0;
+}
+
+export function isQiRefiningReached(state = progressionState) {
+  const slice = state.progression || state;
+  return (slice.realm?.tier ?? 0) >= 1;
+}
+
+export function isNodeUnlocked(id, state = progressionState) {
+  const slice = state.progression || state;
+  let set = slice.astralUnlockedNodes;
+  if (!set) {
+    try {
+      const arr = JSON.parse(localStorage.getItem('astralTreeAllocated') || '[]');
+      set = new Set(arr);
+    } catch {
+      set = new Set();
+    }
+    slice.astralUnlockedNodes = set;
+  }
+  if (set instanceof Set) return set.has(id);
+  if (Array.isArray(set)) return set.includes(id);
+  return false;
 }

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -182,14 +182,19 @@ function buildManifest(nodes) {
 function loadAllocations() {
   try {
     const arr = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
-    return new Set(arr);
+    const set = new Set(arr);
+    S.astralUnlockedNodes = set;
+    return set;
   } catch {
-    return new Set();
+    const empty = new Set();
+    S.astralUnlockedNodes = empty;
+    return empty;
   }
 }
 
 function saveAllocations(set) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify([...set]));
+  S.astralUnlockedNodes = set;
   save();
 }
 

--- a/src/features/sect/mutators.js
+++ b/src/features/sect/mutators.js
@@ -25,3 +25,11 @@ export function upgradeBuilding(state, key){
   recalculateBuildingBonuses(state);
   return true;
 }
+
+export function forceBuild(state, key){
+  const slice = state.sect || sectState;
+  if ((slice.buildings[key] || 0) > 0) return true;
+  slice.buildings[key] = 1;
+  recalculateBuildingBonuses(state);
+  return true;
+}

--- a/src/features/sect/selectors.js
+++ b/src/features/sect/selectors.js
@@ -11,3 +11,7 @@ export function getBuildingLevel(key, state = sectState){
 export function getBuildingBonuses(state = sectState){
   return slice(state).bonuses || {};
 }
+
+export function isBuildingBuilt(key, state = sectState){
+  return getBuildingLevel(key, state) > 0;
+}

--- a/src/shared/selectors.js
+++ b/src/shared/selectors.js
@@ -1,3 +1,6 @@
+import { mortalStage, isQiRefiningReached, isNodeUnlocked } from '../features/progression/selectors.js';
+import { isBuildingBuilt } from '../features/sect/selectors.js';
+
 export * from '../features/ability/selectors.js';
 export * from '../features/adventure/selectors.js';
 export * from '../features/affixes/selectors.js';
@@ -13,3 +16,7 @@ export * from '../features/proficiency/selectors.js';
 export * from '../features/progression/selectors.js';
 export * from '../features/sect/selectors.js';
 export * from '../features/weaponGeneration/selectors.js';
+
+export const selectProgress = { mortalStage, isQiRefiningReached };
+export const selectAstral = { isNodeUnlocked };
+export const selectSect = { isBuildingBuilt };

--- a/src/ui/diagnostics.js
+++ b/src/ui/diagnostics.js
@@ -74,7 +74,7 @@ export function mountDiagnostics(state) {
     table2.style.marginTop = "20px";
     table2.border = "1";
     const h2 = table2.insertRow();
-    ["featureKey", "flag", "unlockReason"].forEach((h) => {
+    ["featureKey", "flagAllowed", "unlockAllowed", "visible", "reason"].forEach((h) => {
       const th = h2.insertCell();
       th.textContent = h;
     });
@@ -82,6 +82,8 @@ export function mountDiagnostics(state) {
       const row = table2.insertRow();
       row.insertCell().textContent = k;
       row.insertCell().textContent = String(v.flagAllowed);
+      row.insertCell().textContent = String(v.unlockAllowed);
+      row.insertCell().textContent = String(v.visible);
       row.insertCell().textContent = v.reason;
     }
     container.appendChild(table2);


### PR DESCRIPTION
## Summary
- gate feature UIs using flag + progression/astral/sect unlock conditions
- add shared selectors for progression stage, qi refining, astral nodes, and sect buildings
- update diagnostics inspector to show flag and unlock status per feature

## Testing
- `npm test`
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68bb385eaeac8326bc33059157ee5229