### PR TITLE
Use star chart icon for astral tree button

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,9 @@
           <div class="cultivation-layout">
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
-                <button id="openAstralTree" class="astral-tree-btn">Astral Tree</button>
+                <button id="openAstralTree" class="astral-tree-btn" aria-label="Open Astral Tree">
+                  <iconify-icon icon="mdi:chart-star" width="28"></iconify-icon>
+                </button>
                 <div id="astralInsightMini" class="astral-insight-mini"></div>
 
                 <!-- Misty fog layers behind silhouette -->

--- a/style.css
+++ b/style.css
@@ -4659,6 +4659,22 @@ html.reduce-motion .log-sheet{transition:none;}
   top:10px;
   right:10px;
   z-index:5;
+  width:44px;
+  height:44px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:50%;
+  background:rgba(0,0,0,0.4);
+  border:1px solid rgba(255,255,255,0.3);
+  color:#ffd700;
+  cursor:pointer;
+  transition:background .2s,transform .2s;
+}
+
+.astral-tree-btn:hover{
+  background:rgba(255,255,255,0.1);
+  transform:scale(1.05);
 }
 
 .astral-skill-tree svg{


### PR DESCRIPTION
## Summary
- replace text-based Astral Tree button with star chart icon
- restyle the astral tree button with round, gold-highlighted design

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI verification violations)


------
https://chatgpt.com/codex/tasks/task_e_68bb4a4d78c083269b9a2e24862a4a07