### PR TITLE
feat: style astral tree button with star chart icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,15 @@
           <div class="cultivation-layout">
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
-                <button id="openAstralTree" class="astral-tree-btn">Astral Tree</button>
+                <button id="openAstralTree" class="astral-tree-btn" aria-label="Open Astral Tree">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="5" cy="5" r="1"/>
+                    <circle cx="19" cy="6" r="1"/>
+                    <circle cx="12" cy="13" r="1"/>
+                    <circle cx="7" cy="19" r="1"/>
+                    <path d="M5 5l7 8l7-7M12 13l-5 6"/>
+                  </svg>
+                </button>
                 <div id="astralInsightMini" class="astral-insight-mini"></div>
 
                 <!-- Misty fog layers behind silhouette -->

--- a/style.css
+++ b/style.css
@@ -4659,6 +4659,25 @@ html.reduce-motion .log-sheet{transition:none;}
   top:10px;
   right:10px;
   z-index:5;
+  width:40px;
+  height:40px;
+  background:#222;
+  color:#fff;
+  border:1px solid #555;
+  border-radius:50%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:0;
+}
+
+.astral-tree-btn:hover{
+  background:#333;
+}
+
+.astral-tree-btn svg{
+  width:24px;
+  height:24px;
 }
 
 .astral-skill-tree svg{


### PR DESCRIPTION
## Summary
- replace Astral Tree text button with star chart icon
- add circular styling and hover state for Astral Tree button

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI verification violations)


------
https://chatgpt.com/codex/tasks/task_e_68bb4a4d78c083269b9a2e24862a4a07