### PR TITLE
feat: add iconized astral tree button

### DIFF
--- a/assets/astral-tree-available.svg
+++ b/assets/astral-tree-available.svg
@@ -1,0 +1,22 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g2" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#005fce"/>
+      <stop offset="100%" stop-color="#00b4ff"/>
+    </radialGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#g2)" filter="url(#glow)"/>
+  <g stroke="#ffffff" stroke-width="2" stroke-linecap="round">
+    <line x1="32" y1="18" x2="32" y2="30"/>
+    <line x1="32" y1="34" x2="32" y2="46"/>
+    <line x1="18" y1="32" x2="30" y2="32"/>
+    <line x1="34" y1="32" x2="46" y2="32"/>
+  </g>
+</svg>

--- a/assets/astral-tree-normal.svg
+++ b/assets/astral-tree-normal.svg
@@ -1,0 +1,9 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#e0f8ff"/>
+      <stop offset="100%" stop-color="#7ab6d9"/>
+    </radialGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#g1)" stroke="#b0d2e6" stroke-width="2"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -147,7 +147,9 @@
           <div class="cultivation-layout">
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
-                <button id="openAstralTree" class="astral-tree-btn">Astral Tree</button>
+                <button id="openAstralTree" class="astral-tree-btn" title="Astral Tree">
+                  <img id="astralTreeIcon" src="assets/astral-tree-normal.svg" alt="Astral Tree">
+                </button>
                 <div id="astralInsightMini" class="astral-insight-mini"></div>
 
                 <!-- Misty fog layers behind silhouette -->

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -72,6 +72,13 @@ export function updateActivityCultivation() {
   setText('qiRegenActivity', qiRegenPerSec(S).toFixed(1));
   setText('foundationRate', foundationGainPerSec(S).toFixed(1));
   setText('astralInsightMini', `Insight: ${Math.round(S.astralPoints || 0)}`);
+  const astralIcon = document.getElementById('astralTreeIcon');
+  if (astralIcon) {
+    const src = (S.astralPoints || 0) > 0 ? 'assets/astral-tree-available.svg' : 'assets/astral-tree-normal.svg';
+    if (astralIcon.getAttribute('src') !== src) {
+      astralIcon.setAttribute('src', src);
+    }
+  }
   setText('btChanceActivity', (breakthroughChance(S) * 100).toFixed(1) + '%');
   setText('powerMultActivity', powerMult(S).toFixed(1) + 'x');
 

--- a/style.css
+++ b/style.css
@@ -4659,6 +4659,16 @@ html.reduce-motion .log-sheet{transition:none;}
   top:10px;
   right:10px;
   z-index:5;
+  background:none;
+  border:none;
+  padding:0;
+  cursor:pointer;
+}
+
+.astral-tree-btn img{
+  width:48px;
+  height:48px;
+  display:block;
 }
 
 .astral-skill-tree svg{


### PR DESCRIPTION
## Summary
- replace Astral Tree text button with icon
- show glowing icon when insight points can be spent

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)


------
https://chatgpt.com/codex/tasks/task_e_68bb52017bc483269a61c2245a2d2421