### PR TITLE
feat: update astral tree button icons

### DIFF
--- a/assets/icons/astral-tree-available.svg
+++ b/assets/icons/astral-tree-available.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="g" cx="30%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#00a8ff"/>
+    </radialGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#g)" stroke="#00d0ff" stroke-width="4" filter="url(#glow)"/>
+  <path d="M32 20 l3 7 7 1-5 5 1 7-6-3-6 3 1-7-5-5 7-1z" fill="#ffffff" opacity="0.8"/>
+</svg>

--- a/assets/icons/astral-tree.svg
+++ b/assets/icons/astral-tree.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="g" cx="30%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#7aa7c7"/>
+    </radialGradient>
+  </defs>
+  <circle cx="32" cy="32" r="30" fill="url(#g)" stroke="#9ebccf" stroke-width="4"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
           <div class="cultivation-layout">
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
-                <button id="openAstralTree" class="astral-tree-btn">Astral Tree</button>
+                <button id="openAstralTree" class="astral-tree-btn" aria-label="Astral Tree"></button>
                 <div id="astralInsightMini" class="astral-insight-mini"></div>
 
                 <!-- Misty fog layers behind silhouette -->

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -245,7 +245,11 @@ export function mountAstralTreeUI() {
     document.documentElement.style.overflowY = prevDocOverflowY || '';
   });
 
-  buildTree().catch(err => console.error('Failed to build Astral Tree', err));
+  buildTree()
+    .then(fn => {
+      if (fn) setInterval(fn, 1000);
+    })
+    .catch(err => console.error('Failed to build Astral Tree', err));
 }
 
 async function buildTree() {
@@ -561,8 +565,18 @@ async function buildTree() {
       e.el.classList.toggle('active', active);
     });
   }
+  const openBtn = document.getElementById('openAstralTree');
+  function updateAstralButton() {
+    if (!openBtn) return;
+    const canPurchase = nodes.some(n =>
+      isAllocatable(n.id, allocated, adj, manifest)
+    );
+    openBtn.classList.toggle('can-purchase', canPurchase);
+  }
 
   refreshClasses();
+  updateAstralButton();
+  return updateAstralButton;
 }
 
 function isAllocatable(id, allocated, adj, manifest) {

--- a/style.css
+++ b/style.css
@@ -4659,6 +4659,16 @@ html.reduce-motion .log-sheet{transition:none;}
   top:10px;
   right:10px;
   z-index:5;
+  width:48px;
+  height:48px;
+  background:url(assets/icons/astral-tree.svg) no-repeat center/contain;
+  border:none;
+  padding:0;
+  cursor:pointer;
+}
+
+.astral-tree-btn.can-purchase{
+  background-image:url(assets/icons/astral-tree-available.svg);
 }
 
 .astral-skill-tree svg{


### PR DESCRIPTION
## Summary
- replace Astral Tree text button with icon and highlight when a node can be purchased
- add SVG assets and styles for normal and available states
- periodically check purchase availability to toggle button state

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bb52017bc483269a61c2245a2d2421