### PR TITLE
feat: gate astral tree until stage 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -1156,7 +1156,19 @@
           <h4 id="breakthroughResultTitle">Breakthrough Result</h4>
           <button class="btn small ghost" id="closeBreakthroughResultBtn">×</button>
         </div>
-        <div id="breakthroughResultBody"></div>
+      <div id="breakthroughResultBody"></div>
+      </div>
+    </div>
+    <div class="modal-overlay" id="astralTreeUnlockOverlay" style="display: none;">
+      <div class="modal-backdrop"></div>
+      <div class="modal-content card" id="astralTreeUnlockCard">
+        <div class="card-header">
+          <h4>Astral Tree Unlocked</h4>
+          <button class="btn small ghost" id="closeAstralUnlockBtn">×</button>
+        </div>
+        <div style="text-align:center; padding: 10px;">
+          <img src="assets/icons/astral-tree-available.svg" alt="Astral Tree Unlocked" style="width:80px;height:80px;" />
+        </div>
       </div>
     </div>
   </main>

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -3,6 +3,7 @@
 import { REALMS } from '../data/realms.js';
 import { LAWS } from '../data/laws.js';
 import { S } from '../../../shared/state.js';
+import { isProd } from '../../../config.js';
 import {
   qCap,
   qiRegenPerSec,
@@ -13,6 +14,8 @@ import {
 } from '../selectors.js';
 import { advanceRealm } from '../mutators.js';
 import { qs, setText, log } from '../../../shared/utils/dom.js';
+
+let pendingAstralUnlock = false;
 
 export function getRealmName(tier) {
   return REALMS[tier].name;
@@ -380,11 +383,36 @@ function showBreakthroughResult(success, info = {}) {
   }
 
   overlay.style.display = 'flex';
+
+  if (
+    success &&
+    isProd &&
+    S.realm.tier === 0 &&
+    S.realm.stage === 2 &&
+    !localStorage.getItem('astral-tree-unlock-shown')
+  ) {
+    pendingAstralUnlock = true;
+  }
 }
 
 function hideBreakthroughResult() {
   const overlay = document.getElementById('breakthroughResultOverlay');
   if (overlay) overlay.style.display = 'none';
+  if (pendingAstralUnlock) {
+    pendingAstralUnlock = false;
+    showAstralUnlockOverlay();
+  }
+}
+
+function showAstralUnlockOverlay() {
+  const overlay = document.getElementById('astralTreeUnlockOverlay');
+  if (overlay) overlay.style.display = 'flex';
+}
+
+function hideAstralUnlockOverlay() {
+  const overlay = document.getElementById('astralTreeUnlockOverlay');
+  if (overlay) overlay.style.display = 'none';
+  localStorage.setItem('astral-tree-unlock-shown', '1');
 }
 
 export function setupProgressToggle() {
@@ -480,5 +508,11 @@ export function initRealmUI(){
   const backdrop = overlay?.querySelector('.modal-backdrop');
   if (closeBtn) closeBtn.addEventListener('click', hideBreakthroughResult);
   if (backdrop) backdrop.addEventListener('click', hideBreakthroughResult);
+
+  const astralClose = qs('#closeAstralUnlockBtn');
+  const astralOverlay = qs('#astralTreeUnlockOverlay');
+  const astralBackdrop = astralOverlay?.querySelector('.modal-backdrop');
+  if (astralClose) astralClose.addEventListener('click', hideAstralUnlockOverlay);
+  if (astralBackdrop) astralBackdrop.addEventListener('click', hideAstralUnlockOverlay);
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -109,6 +109,13 @@ const progressBars = {};
 let lastInventorySnapshot = JSON.stringify(S.inventory || []);
 let lastEquipmentSnapshot = JSON.stringify(S.equipment || {});
 
+function updateAstralTreeButton() {
+  const btn = document.getElementById('openAstralTree');
+  if (!btn) return;
+  const unlocked = S.realm.tier > 0 || S.realm.stage >= 2;
+  btn.style.display = report.isProd && !unlocked ? 'none' : '';
+}
+
 // Activity Management System (delegates to feature)
 function selectActivity(activityType) { selectActivityMut(S, activityType); }
 function startActivity(activityName)  { startActivityMut(S, activityName); }
@@ -148,6 +155,8 @@ function initUI(){
   mountCatchingUI(S);
   mountForgingUI(S);
   setupAbilityUI();
+
+  updateAstralTreeButton();
 
   // Assign buttons
   // Buttons (with safe null checks)
@@ -301,6 +310,7 @@ function updateAll(){
   renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
 
   emit('RENDER');
+  updateAstralTreeButton();
 }
 
 

--- a/validation.log
+++ b/validation.log
@@ -5,6 +5,7 @@
 ❌ VERIFICATION FAILED - MUST fix before proceeding
 
 🚨 VIOLATIONS DETECTED:
+   • UI write violation: src/features/activity/ui/activityUI.js mutates root.* (use mutators)
    • UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js
    • UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js
    • UI state violation: src/features/adventure/ui/progressBar.js imports S from shared/state.js
@@ -31,6 +32,7 @@
    • UI rule: src/features/combat/ui/floatingText.js uses Math.random() — move randomness to logic.js
    • UI timer: src/features/combat/ui/fx.js uses timers/RAF — prefer feature.tick and RENDER
    • UI timer: src/features/physique/ui/trainingGame.js uses timers/RAF — prefer feature.tick and RENDER
+   • UI timer: src/features/progression/ui/astralTree.js uses timers/RAF — prefer feature.tick and RENDER
    • UI rule: src/features/progression/ui/realm.js uses Math.random() — move randomness to logic.js
    • UI timer: src/features/progression/ui/realm.js uses timers/RAF — prefer feature.tick and RENDER
 


### PR DESCRIPTION
## Summary
- Hide astral tree button in production until reaching Mortal Stage 2
- Add overlay celebrating Astral Tree unlock after stage advancement

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb543296f88326b8af28628fe295d0