### PR TITLE
feat: double astral tree connector width

### DIFF
--- a/style.css
+++ b/style.css
@@ -4680,8 +4680,8 @@ html.reduce-motion .log-sheet{transition:none;}
 .astral-skill-tree svg.dragging{cursor:grabbing;}
 .connector{
   stroke:#fff;
-  /* increase base connector width by 25% */
-  stroke-width:1.9;
+  /* double base connector width */
+  stroke-width:3.8;
   fill:none;
   opacity:0.9;
   color:#fff;
@@ -4710,8 +4710,8 @@ html.reduce-motion .log-sheet{transition:none;}
   animation:nodePulse 2.5s ease-in-out infinite;
 }
 .connector.active{
-  /* 25% wider active connectors */
-  stroke-width:3.1;
+  /* double width for active connectors */
+  stroke-width:6.2;
   opacity:1;
   filter:drop-shadow(0 0 8px #fff);
 }
@@ -4719,8 +4719,8 @@ html.reduce-motion .log-sheet{transition:none;}
 
 .connector.travel{
   stroke:#fff;
-  /* 25% wider travel animation line */
-  stroke-width:3.8;
+  /* double width for travel animation line */
+  stroke-width:7.6;
   stroke-linecap:round;
   filter:drop-shadow(0 0 8px #fff);
   pointer-events:none;


### PR DESCRIPTION
## Summary
- double base astral tree connector width
- double widths for active and travel connector states

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: VERIFICATION FAILED - MUST fix before proceeding)*

------
https://chatgpt.com/codex/tasks/task_e_68bb552a54488326985128389ba10f8d