### PR TITLE
Gate astral tree behind stage 2 with unlock overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,8 +147,8 @@
           <div class="cultivation-layout">
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
-                <button id="openAstralTree" class="astral-tree-btn" aria-label="Astral Tree"></button>
-                <div id="astralInsightMini" class="astral-insight-mini"></div>
+                <button id="openAstralTree" class="astral-tree-btn" aria-label="Astral Tree" style="display:none;"></button>
+                <div id="astralInsightMini" class="astral-insight-mini" style="display:none;"></div>
 
                 <!-- Misty fog layers behind silhouette -->
                 <div class="misty-fog">
@@ -1157,6 +1157,18 @@
           <button class="btn small ghost" id="closeBreakthroughResultBtn">×</button>
         </div>
         <div id="breakthroughResultBody"></div>
+      </div>
+    </div>
+    <div class="modal-overlay" id="astralTreeUnlockOverlay" style="display: none;">
+      <div class="modal-backdrop"></div>
+      <div class="modal-content card" id="astralTreeUnlockCard">
+        <div class="card-header">
+          <h4>Astral Tree Unlocked!</h4>
+          <button class="btn small ghost" id="closeAstralTreeUnlockBtn">×</button>
+        </div>
+        <div class="card-body" style="text-align:center;">
+          <img src="assets/icons/astral-tree-available.svg" alt="Astral Tree Unlocked" />
+        </div>
       </div>
     </div>
   </main>

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -9,10 +9,15 @@ import {
   fCap,
   foundationGainPerSec,
   powerMult,
-  breakthroughChance
+  breakthroughChance,
+  mortalStage
 } from '../selectors.js';
 import { advanceRealm } from '../mutators.js';
 import { qs, setText, log } from '../../../shared/utils/dom.js';
+import { isProd, featureFlags } from '../../../config.js';
+import { mountAstralTreeUI } from './astralTree.js';
+
+let pendingAstralUnlock = false;
 
 export function getRealmName(tier) {
   return REALMS[tier].name;
@@ -385,6 +390,21 @@ function showBreakthroughResult(success, info = {}) {
 function hideBreakthroughResult() {
   const overlay = document.getElementById('breakthroughResultOverlay');
   if (overlay) overlay.style.display = 'none';
+  if (pendingAstralUnlock) {
+    pendingAstralUnlock = false;
+    showAstralTreeUnlockOverlay();
+  }
+}
+
+function showAstralTreeUnlockOverlay() {
+  const overlay = document.getElementById('astralTreeUnlockOverlay');
+  if (!overlay) return;
+  overlay.style.display = 'flex';
+}
+
+function hideAstralTreeUnlockOverlay() {
+  const overlay = document.getElementById('astralTreeUnlockOverlay');
+  if (overlay) overlay.style.display = 'none';
 }
 
 export function setupProgressToggle() {
@@ -456,6 +476,14 @@ export function updateBreakthrough() {
       const info = advanceRealm(S);
       log('Breakthrough succeeded! Realm advanced.', 'good');
       showBreakthroughResult(true, info);
+      if (isProd && featureFlags.astralTree && info.type === 'stage' && mortalStage(S) === 2) {
+        const btn = document.getElementById('openAstralTree');
+        const mini = document.getElementById('astralInsightMini');
+        if (btn) btn.style.display = '';
+        if (mini) mini.style.display = '';
+        mountAstralTreeUI(S);
+        pendingAstralUnlock = true;
+      }
     } else {
       S.qi = 0;
       S.foundation = Math.max(0, S.foundation - Math.ceil(fCap(S) * 0.25));
@@ -480,5 +508,11 @@ export function initRealmUI(){
   const backdrop = overlay?.querySelector('.modal-backdrop');
   if (closeBtn) closeBtn.addEventListener('click', hideBreakthroughResult);
   if (backdrop) backdrop.addEventListener('click', hideBreakthroughResult);
+
+  const closeAstralBtn = qs('#closeAstralTreeUnlockBtn');
+  const astralOverlay = qs('#astralTreeUnlockOverlay');
+  const astralBackdrop = astralOverlay?.querySelector('.modal-backdrop');
+  if (closeAstralBtn) closeAstralBtn.addEventListener('click', hideAstralTreeUnlockOverlay);
+  if (astralBackdrop) astralBackdrop.addEventListener('click', hideAstralTreeUnlockOverlay);
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -3,7 +3,7 @@
 
 // Way of Ascension — Modular JS
 
-import { configReport } from '../src/config.js';
+import { configReport, isProd, featureFlags } from '../src/config.js';
 import { mountDiagnostics } from '../src/ui/diagnostics.js';
 import { S, defaultState, save, setState, validateState } from '../src/shared/state.js';
 import {
@@ -14,7 +14,8 @@ import {
   foundationGainPerSec,
   powerMult,
   calculatePlayerCombatAttack,
-  calculatePlayerAttackRate
+  calculatePlayerAttackRate,
+  mortalStage
 } from '../src/features/progression/selectors.js';
 import { refillShieldFromQi } from '../src/features/combat/logic.js';
 import {
@@ -721,7 +722,17 @@ window.addEventListener('load', ()=>{
   mountKarmaUI(S);
   mountSectUI(S);
   mountMindReadingUI(S);
-  mountAstralTreeUI(S);
+  const btn = document.getElementById('openAstralTree');
+  const mini = document.getElementById('astralInsightMini');
+  const astralUnlocked = featureFlags.astralTree && (!isProd || mortalStage(S) >= 2);
+  if (astralUnlocked) {
+    if (btn) btn.style.display = '';
+    if (mini) mini.style.display = '';
+    mountAstralTreeUI(S);
+  } else {
+    if (btn) btn.style.display = 'none';
+    if (mini) mini.style.display = 'none';
+  }
   mountDiagnostics(S);
   renderMindMainTab(document.getElementById('mindMainTab'), S);
   renderMindReadingTab(document.getElementById('mindReadingTab'), S);


### PR DESCRIPTION
## Summary
- Hide astral tree button in production until mortal stage 2 is reached
- After stage 2 breakthrough, show Astral Tree unlock overlay and reveal tree button
- Add markup for unlock overlay
- Only enable astral tree when FEATURE_ASTRAL_TREE flag is true

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation and timer warnings)


------
https://chatgpt.com/codex/tasks/task_e_68bb543296f88326b8af28628fe295d0