### PR TITLE
Implement feature nav visibility gating

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -357,6 +357,7 @@ way-of-ascension/
 ├── src/features/automation/state.js
 ├── src/features/combat/index.js
 ├── src/features/karma/index.js
+├── src/features/law/index.js
 ├── src/features/mining/index.js
 ├── src/features/gathering/index.js
 ├── src/features/gathering/logic.js
@@ -376,9 +377,11 @@ way-of-ascension/
 ├── src/features/agility/state.js
 ├── src/features/agility/ui/agilityDisplay.js
 ├── src/features/agility/ui/trainingGame.js
+├── src/features/astralTree/index.js
 ├── src/features/catching/
 │   ├── data/
 │   │   └── icons.js
+│   ├── index.js
 │   ├── logic.js
 │   ├── mutators.js
 │   ├── state.js
@@ -1090,6 +1093,7 @@ Paths added:
 - `src/features/agility/index.js` – Agility feature descriptor.
 
 ### Catching Feature (`src/features/catching/`)
+- `src/features/catching/index.js` – Catching feature descriptor.
 - `src/features/catching/state.js` – Tracks caught creatures, hunger, and taming progress.
 - `src/features/catching/logic.js` – Handles hunger decay and catch timers.
 - `src/features/catching/mutators.js` – Starts catch attempts, consuming nets and scheduling completion.
@@ -1184,6 +1188,12 @@ Paths added:
 - `src/features/automation/mutators.js` – Toggles automation options like auto-meditate and auto-adventure.
 - `src/features/automation/selectors.js` – Reads automation settings from state.
 
+### Astral Tree Feature (`src/features/astralTree/`)
+- `src/features/astralTree/index.js` – Astral Tree feature descriptor controlling nav visibility.
+
+### Law Feature (`src/features/law/`)
+- `src/features/law/index.js` – Law feature descriptor gating law navigation on Qi-refining.
+
 ### Feature Migration Files
 - `src/features/ability/migrations.js` – Save migrations for ability feature.
 - `src/features/adventure/migrations.js` – Save migrations for adventure feature.
@@ -1222,3 +1232,9 @@ Paths added:
 - `src/features/weaponGeneration/index.js` – Weapon generation feature descriptor.
 - `src/features/agility/index.js` – Agility feature descriptor.
 - `src/features/sideLocations/index.js` – Side locations feature descriptor.
+ - `src/features/gathering/index.js` – Gathering feature descriptor.
+ - `src/features/forging/index.js` – Forging feature descriptor.
+ - `src/features/catching/index.js` – Catching feature descriptor.
+ - `src/features/mind/index.js` – Mind feature descriptor.
+ - `src/features/astralTree/index.js` – Astral Tree feature descriptor.
+ - `src/features/law/index.js` – Law feature descriptor.

--- a/src/features/ability/index.js
+++ b/src/features/ability/index.js
@@ -3,4 +3,9 @@ import { abilityState } from "./state.js";
 export const AbilityFeature = {
   key: "ability",
   initialState: () => ({ ...abilityState, _v: 0 }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/features/activity/index.js
+++ b/src/features/activity/index.js
@@ -12,4 +12,9 @@ export const ActivityFeature = {
     catching: false,
     _v: 0,
   }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/features/adventure/index.js
+++ b/src/features/adventure/index.js
@@ -1,6 +1,13 @@
 import { adventureState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectProgress } from "../../shared/selectors.js";
 
 export const AdventureFeature = {
   key: "adventure",
   initialState: () => ({ ...adventureState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.proficiency && selectProgress.mortalStage(root) >= 5;
+    },
+  },
 };

--- a/src/features/affixes/index.js
+++ b/src/features/affixes/index.js
@@ -3,4 +3,9 @@ import { affixState } from "./state.js";
 export const AffixesFeature = {
   key: "affixes",
   initialState: () => ({ ...affixState, _v: 0 }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/features/agility/index.js
+++ b/src/features/agility/index.js
@@ -1,6 +1,13 @@
 import { agilityState } from './state.js';
+import { featureFlags } from '../../config.js';
+import { selectAstral } from '../../shared/selectors.js';
 
 export const AgilityFeature = {
   key: 'agility',
   initialState: () => ({ ...agilityState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.agility && selectAstral.isNodeUnlocked(4062, root);
+    },
+  },
 };

--- a/src/features/alchemy/index.js
+++ b/src/features/alchemy/index.js
@@ -1,6 +1,13 @@
 import { alchemyState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectSect } from "../../shared/selectors.js";
 
 export const AlchemyFeature = {
   key: "alchemy",
   initialState: () => ({ ...alchemyState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.alchemy && selectSect.isBuildingBuilt('alchemy', root);
+    },
+  },
 };

--- a/src/features/astralTree/index.js
+++ b/src/features/astralTree/index.js
@@ -1,0 +1,13 @@
+import { featureFlags } from '../../config.js';
+import { selectProgress } from '../../shared/selectors.js';
+
+export const AstralTreeFeature = {
+  key: 'astralTree',
+  initialState: () => ({ _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.astralTree && selectProgress.realmStage(root) >= 2;
+    },
+  },
+};
+

--- a/src/features/automation/index.js
+++ b/src/features/automation/index.js
@@ -3,4 +3,9 @@ import { initialState } from "./state.js";
 export const AutomationFeature = {
   key: "auto",
   initialState,
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/features/catching/index.js
+++ b/src/features/catching/index.js
@@ -1,0 +1,14 @@
+import { catchingState } from './state.js';
+import { featureFlags } from '../../config.js';
+import { selectAstral } from '../../shared/selectors.js';
+
+export const CatchingFeature = {
+  key: 'catching',
+  initialState: () => ({ ...catchingState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.catching && selectAstral.isNodeUnlocked(4062, root);
+    },
+  },
+};
+

--- a/src/features/combat/index.js
+++ b/src/features/combat/index.js
@@ -5,6 +5,11 @@ import { registerFeature } from "../registry.js";
 export const CombatFeature = {
   key: "combat",
   initialState: () => ({ ...combatState, _v: 0 }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };
 
 registerFeature({

--- a/src/features/cooking/index.js
+++ b/src/features/cooking/index.js
@@ -1,6 +1,13 @@
 import { cookingState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectSect } from "../../shared/selectors.js";
 
 export const CookingFeature = {
   key: "cooking",
   initialState: () => ({ ...cookingState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.cooking && selectSect.isBuildingBuilt('kitchen', root);
+    },
+  },
 };

--- a/src/features/forging/index.js
+++ b/src/features/forging/index.js
@@ -1,6 +1,13 @@
 import { forgingState } from './state.js';
+import { featureFlags } from '../../config.js';
+import { selectAstral } from '../../shared/selectors.js';
 
 export const ForgingFeature = {
   key: 'forging',
   initialState: () => ({ ...forgingState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.forging && selectAstral.isNodeUnlocked(4062, root);
+    },
+  },
 };

--- a/src/features/gathering/index.js
+++ b/src/features/gathering/index.js
@@ -1,5 +1,13 @@
 import { gatheringState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectAstral } from "../../shared/selectors.js";
+
 export const GatheringFeature = {
   key: "gathering",
   initialState: () => ({ ...gatheringState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.gathering && selectAstral.isNodeUnlocked(4061, root);
+    },
+  },
 };

--- a/src/features/inventory/index.js
+++ b/src/features/inventory/index.js
@@ -3,4 +3,9 @@ import { inventoryState } from "./state.js";
 export const InventoryFeature = {
   key: "inventory",
   initialState: () => ({ ...inventoryState, _v: 0 }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/features/karma/index.js
+++ b/src/features/karma/index.js
@@ -1,6 +1,12 @@
 import { karmaState } from "./state.js";
+import { featureFlags } from "../../config.js";
 
 export const KarmaFeature = {
   key: "karma",
   initialState: () => ({ ...karmaState, _v: 0 }),
+  nav: {
+    visible() {
+      return featureFlags.karma;
+    },
+  },
 };

--- a/src/features/law/index.js
+++ b/src/features/law/index.js
@@ -1,0 +1,13 @@
+import { featureFlags } from '../../config.js';
+import { selectProgress } from '../../shared/selectors.js';
+
+export const LawFeature = {
+  key: 'law',
+  initialState: () => ({ _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.law && selectProgress.isQiRefiningReached(root);
+    },
+  },
+};
+

--- a/src/features/loot/index.js
+++ b/src/features/loot/index.js
@@ -3,4 +3,9 @@ import { lootState } from "./state.js";
 export const LootFeature = {
   key: "loot",
   initialState: () => ({ ...lootState, _v: 0 }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/features/mind/index.js
+++ b/src/features/mind/index.js
@@ -1,5 +1,9 @@
 // src/features/mind/index.js
 
+import { defaultMindState, ensureMindState } from './state.js';
+import { featureFlags } from '../../config.js';
+import { selectAstral } from '../../shared/selectors.js';
+
 export { defaultMindState, ensureMindState } from './state.js';
 
 export {
@@ -28,4 +32,14 @@ export {
   currentMindLevel,
   currentMindXp,
 } from './selectors.js';
+
+export const MindFeature = {
+  key: 'mind',
+  initialState: () => ({ ...defaultMindState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.mind && selectAstral.isNodeUnlocked(4061, root);
+    },
+  },
+};
 

--- a/src/features/mining/index.js
+++ b/src/features/mining/index.js
@@ -1,6 +1,13 @@
 import { miningState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectAstral } from "../../shared/selectors.js";
 
 export const MiningFeature = {
   key: "mining",
   initialState: () => ({ ...miningState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.mining && selectAstral.isNodeUnlocked(4060, root);
+    },
+  },
 };

--- a/src/features/physique/index.js
+++ b/src/features/physique/index.js
@@ -1,6 +1,13 @@
 import { physiqueState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectAstral } from "../../shared/selectors.js";
 
 export const PhysiqueFeature = {
   key: "physique",
   initialState: () => ({ ...physiqueState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.physique && selectAstral.isNodeUnlocked(4060, root);
+    },
+  },
 };

--- a/src/features/proficiency/index.js
+++ b/src/features/proficiency/index.js
@@ -1,6 +1,13 @@
 import { proficiencyState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectProgress } from "../../shared/selectors.js";
 
 export const ProficiencyFeature = {
   key: "proficiency",
   initialState: () => ({ ...proficiencyState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.proficiency && selectProgress.mortalStage(root) >= 5;
+    },
+  },
 };

--- a/src/features/progression/index.js
+++ b/src/features/progression/index.js
@@ -1,8 +1,14 @@
 import { progressionState } from "./state.js";
+import { featureFlags } from "../../config.js";
 
 export const ProgressionFeature = {
   key: "progression",
   initialState: () => ({ ...progressionState, _v: 0 }),
+  nav: {
+    visible() {
+      return featureFlags.cultivation;
+    },
+  },
 };
 
 export {

--- a/src/features/progression/selectors.js
+++ b/src/features/progression/selectors.js
@@ -85,6 +85,11 @@ export function mortalStage(state = progressionState) {
   return realm.stage || 0;
 }
 
+export function realmStage(state = progressionState) {
+  const slice = state.progression || state;
+  return slice.realm?.stage || 0;
+}
+
 export function isQiRefiningReached(state = progressionState) {
   const slice = state.progression || state;
   return (slice.realm?.tier ?? 0) >= 1;

--- a/src/features/sect/index.js
+++ b/src/features/sect/index.js
@@ -1,6 +1,13 @@
 import { sectState } from "./state.js";
+import { featureFlags } from "../../config.js";
+import { selectProgress } from "../../shared/selectors.js";
 
 export const SectFeature = {
   key: "sect",
   initialState: () => ({ ...sectState, _v: 0 }),
+  nav: {
+    visible(root) {
+      return featureFlags.sect && selectProgress.mortalStage(root) >= 3;
+    },
+  },
 };

--- a/src/features/sideLocations/index.js
+++ b/src/features/sideLocations/index.js
@@ -3,4 +3,9 @@ import { sideLocationState } from './state.js';
 export const SideLocationFeature = {
   key: 'sideLocations',
   initialState: () => ({ ...sideLocationState, _v: 0 }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/features/weaponGeneration/index.js
+++ b/src/features/weaponGeneration/index.js
@@ -3,4 +3,9 @@ import { weaponGenerationState } from "./state.js";
 export const WeaponGenerationFeature = {
   key: "weaponGen",
   initialState: () => ({ ...weaponGenerationState, _v: 0 }),
+  nav: {
+    visible() {
+      return true;
+    },
+  },
 };

--- a/src/shared/selectors.js
+++ b/src/shared/selectors.js
@@ -1,4 +1,9 @@
-import { mortalStage, isQiRefiningReached, isNodeUnlocked } from '../features/progression/selectors.js';
+import {
+  mortalStage,
+  realmStage,
+  isQiRefiningReached,
+  isNodeUnlocked,
+} from '../features/progression/selectors.js';
 import { isBuildingBuilt } from '../features/sect/selectors.js';
 
 export * from '../features/ability/selectors.js';
@@ -17,6 +22,6 @@ export * from '../features/progression/selectors.js';
 export * from '../features/sect/selectors.js';
 export * from '../features/weaponGeneration/selectors.js';
 
-export const selectProgress = { mortalStage, isQiRefiningReached };
+export const selectProgress = { mortalStage, realmStage, isQiRefiningReached };
 export const selectAstral = { isNodeUnlocked };
 export const selectSect = { isBuildingBuilt };


### PR DESCRIPTION
## Summary
- add `realmStage` selector and expose via `selectProgress`
- gate Astral Tree navigation by realm stage to fix unlock condition

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and DOM access warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb767abc1c8326a063db455968158b