### PR TITLE
feat: move save options to sidebar settings tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,12 +92,6 @@
         </div>
         <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
       </div>
-      <div class="right-actions">
-        <button class="btn small ghost" id="saveBtn">💾 Save</button>
-        <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
-        <button class="btn small ghost" id="importBtn">⬆️ Import</button>
-        <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
-      </div>
     </div>
   </div>
   </header>
@@ -129,6 +123,17 @@
       <div class="activity-selector" id="sectSelector" data-activity="sect">
         <div class="activity-name">🏛️ Sect</div>
         <div class="activity-info" id="sectInfo">0 Buildings</div>
+      </div>
+
+      <!-- Settings -->
+      <div class="activity-group">
+        <h4 class="group-title">Settings</h4>
+        <div class="settings-actions">
+          <button class="btn small ghost" id="saveBtn">💾 Save</button>
+          <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
+          <button class="btn small ghost" id="importBtn">⬆️ Import</button>
+          <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
+        </div>
       </div>
     </aside>
 

--- a/style.css
+++ b/style.css
@@ -4195,6 +4195,8 @@ tr:last-child td {
 .badge{display:inline-block; padding:3px 8px; font-size:11px; border-radius:999px; border:1px solid #2a3758; color:#bfdbfe; background:#0a1224}
 
 .right-actions{display:flex; gap:8px; align-items:center}
+.settings-actions{display:flex;flex-direction:column;gap:8px}
+.settings-actions .btn{width:100%}
 .progress-wrap{display:flex; align-items:center; gap:10px}
 
 /* Equipment Panel */


### PR DESCRIPTION
## Summary
- relocate save, export, import, and reset buttons into a Settings section at the bottom of the sidebar
- style settings actions to stack vertically and fill width

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation and DOM usage warnings)


------
https://chatgpt.com/codex/tasks/task_e_68bba9cf067083268e31bbe0b0bdafbe