### PR TITLE
feat(ui): add settings tab for save controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,12 +92,7 @@
         </div>
         <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
       </div>
-      <div class="right-actions">
-        <button class="btn small ghost" id="saveBtn">💾 Save</button>
-        <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
-        <button class="btn small ghost" id="importBtn">⬆️ Import</button>
-        <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
-      </div>
+      
     </div>
   </div>
   </header>
@@ -129,6 +124,11 @@
       <div class="activity-selector" id="sectSelector" data-activity="sect">
         <div class="activity-name">🏛️ Sect</div>
         <div class="activity-info" id="sectInfo">0 Buildings</div>
+      </div>
+
+      <!-- Settings Selector -->
+      <div class="activity-selector" id="settingsSelector" data-activity="settings">
+        <div class="activity-name">⚙️ Settings</div>
       </div>
     </aside>
 
@@ -1116,6 +1116,20 @@
         <div id="mindReadingTab" class="mind-tab-content tab-content" style="display:none;"></div>
         <div id="mindStatsTab" class="mind-tab-content tab-content" style="display:none;"></div>
         <div id="mindPuzzlesTab" class="mind-tab-content tab-content" style="display:none;"></div>
+      </section>
+
+      <section id="activity-settings" class="activity-content tab-content" style="display:none;">
+        <h2>⚙️ Settings</h2>
+        <div class="cards">
+          <div class="card">
+            <div class="settings-buttons">
+              <button class="btn small ghost" id="saveBtn">💾 Save</button>
+              <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
+              <button class="btn small ghost" id="importBtn">⬆️ Import</button>
+              <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
+            </div>
+          </div>
+        </div>
       </section>
 
       <section id="tab-combat">

--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -24,6 +24,7 @@ export function mountActivityUI(root) {
   document.getElementById('gatheringSelector')?.addEventListener('click', () => handle('gathering'));
   document.getElementById('adventureSelector')?.addEventListener('click', () => handle('adventure'));
   document.getElementById('sectSelector')?.addEventListener('click', () => handle('sect'));
+  document.getElementById('settingsSelector')?.addEventListener('click', () => handle('settings'));
   document.getElementById('catchingSelector')?.addEventListener('click', () => handle('catching'));
 
   // Initial paint
@@ -155,6 +156,9 @@ export function updateActivitySelectors(root) {
   // Sect tab indicator (simple)
   const sectSelector = document.getElementById('sectSelector');
   sectSelector?.classList.toggle('active', selected === 'sect');
+
+  const settingsSelector = document.getElementById('settingsSelector');
+  settingsSelector?.classList.toggle('active', selected === 'settings');
 
   updateCurrentTaskDisplay(root);
 }


### PR DESCRIPTION
## Summary
- move save, export, import and reset buttons into a new Settings tab
- add Settings option to sidebar for relocated buttons

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bba9cf067083268e31bbe0b0bdafbe