### PR TITLE
Relocate reduce motion toggle, remove weapon status chip

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,6 @@
           </div>
           <span id="hpA11y" class="sr-only">HP 100/100, Shield 0/0</span>
         </div>
-        <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
       </div>
       
     </div>
@@ -1128,6 +1127,9 @@
               <button class="btn small ghost" id="importBtn">⬆️ Import</button>
               <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
             </div>
+          </div>
+          <div class="card">
+            <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
           </div>
         </div>
       </section>

--- a/ui/index.js
+++ b/ui/index.js
@@ -30,8 +30,6 @@ import { qs, setText, setFill, log } from '../src/shared/utils/dom.js';
 import { fmt } from '../src/shared/utils/number.js';
 import { emit } from '../src/shared/events.js';
 import { createProgressBar, updateProgressBar } from './components/progressBar.js';
-import { initializeWeaponChip } from '../src/features/inventory/ui/weaponChip.js';
-import { WEAPONS } from '../src/features/weaponGeneration/data/weapons.js';
 import {
   updateActivityAdventure,
   updateAdventureCombat,
@@ -127,10 +125,6 @@ function initUI(){
 
   mountAllFeatureUIs(S);
 
-  const mh = S.equipment?.mainhand;
-  const mhKey = typeof mh === 'string' ? mh : mh?.key || 'fist';
-  const mhName = WEAPONS[mhKey]?.displayName || (mhKey === 'fist' ? 'Fists' : mhKey);
-  initializeWeaponChip({ key: mhKey, name: mhName });
   setupAbilityUI();
 
   // Assign buttons


### PR DESCRIPTION
## Summary
- Move the "Reduce Motion" setting out of the status bar into the Settings tab
- Drop the dynamic weapon chip so weapon info no longer appears in the status bar

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI changes blocked until validation passes)*

------
https://chatgpt.com/codex/tasks/task_e_68bbacc2f54483268776aa851ffec66a