### PR TITLE
Move HP and Qi indicators to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,46 +61,42 @@
         <div class="sub">Idle xianxia cultivation • autosaves</div>
       </div>
     </div>
-  </div>
-  <div class="status-row" id="statusRow" data-open="false">
-    <button id="statusToggle" class="status-toggle" aria-controls="statusCluster" aria-expanded="false">Status ▾</button>
-    <div id="statusCluster" class="status-cluster">
-      <div class="topbar" id="top-chips">
-        <div class="chip" id="taskChip">Task: <span id="currentTask">Idle</span></div>
-        <div class="chip" id="realmChip">Realm: <span id="realmName">Mortal 1</span></div>
-        <div class="chip" id="qiChip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span></div>
-        <div class="chip" id="stonesChip">Stones: <span id="stonesVal">0</span></div>
-        <div class="chip hp-chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span>
-          <div class="hp-bar">
-            <div class="fill" id="hpFill"></div>
-            <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
-              <defs>
-                <linearGradient id="shieldGradient">
-                  <stop offset="0%" stop-color="rgba(255,255,255,0)" />
-                  <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
-                  <stop offset="100%" stop-color="rgba(255,255,255,0)" />
-                </linearGradient>
-              </defs>
-              <mask id="hpMask">
-                <rect id="hpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
-              </mask>
-              <rect id="shieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#hpMask)" />
-              <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#hpMask)" fill="url(#shieldGradient)" />
-            </svg>
-          </div>
-          <span id="hpA11y" class="sr-only">HP 100/100, Shield 0/0</span>
-        </div>
-      </div>
-      
     </div>
   </div>
   </header>
 
   <div id="drawerScrim" class="drawer-scrim" hidden></div>
   <main>
-    <aside class="left" id="sidebar">
-      
-      <!-- Leveling Activities Group -->
+      <aside class="left" id="sidebar">
+        <div class="resource-chips">
+          <div class="chip hp-chip">HP: <span id="hpVal">100</span>/<span id="hpMax">100</span>
+            <div class="hp-bar">
+              <div class="fill" id="hpFill"></div>
+              <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
+                <defs>
+                  <linearGradient id="shieldGradient">
+                    <stop offset="0%" stop-color="rgba(255,255,255,0)" />
+                    <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
+                    <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+                  </linearGradient>
+                </defs>
+                <mask id="hpMask">
+                  <rect id="hpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
+                </mask>
+                <rect id="shieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#hpMask)" />
+                <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#hpMask)" fill="url(#shieldGradient)" />
+              </svg>
+            </div>
+            <span id="hpA11y" class="sr-only">HP 100/100, Shield 0/0</span>
+          </div>
+          <div class="chip qi-chip">Qi: <span id="qiVal">0</span>/<span id="qiCap">100</span>
+            <div class="qi-bar">
+              <div class="qi-fill" id="qiFill"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Leveling Activities Group -->
       <div class="activity-group">
         <h4 class="group-title"><iconify-icon icon="ri:hand-line" class="ui-icon" width="20"></iconify-icon> Training & Skills</h4>
         <div class="activities leveling-activities" id="levelingActivities"></div>

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@
   --radius: 16px;
   --gap: 20px;
   --pad: 16px;
-  --header-h: 76px;
+    --header-h: 64px;
   --log-h: 0px;
   --tabs-h: 48px;
   --safe-bottom: env(safe-area-inset-bottom,0px);
@@ -1568,10 +1568,7 @@ header{
   position:relative; z-index:2;
 }
 .primary-row{display:flex; align-items:center; gap:20px;}
-.status-row{display:flex; align-items:center; gap:20px; margin-left:auto;}
-.status-toggle{display:none;}
-.status-cluster{display:flex; align-items:center; gap:20px;}
-.brand{display:flex; gap:14px; align-items:center}
+  .brand{display:flex; gap:14px; align-items:center}
 .qi-orb{
   background:linear-gradient(135deg, var(--foundation-primary), var(--foundation-secondary)); 
   width:84px; 
@@ -1709,9 +1706,13 @@ h1{font-size:20px; margin:0; letter-spacing:.5px}
 .topbar{display:flex; gap:14px; flex-wrap:wrap}
 /* STYLE-GUIDE-UPDATE: Parchment chip style */
 .chip{background:var(--panel); border:1px solid var(--accent); padding:8px 12px; border-radius:999px; font-size:12px; box-shadow: inset 0 1px 3px rgba(139, 117, 95, 0.2);}
+.resource-chips{display:flex; flex-direction:column; gap:var(--gap); margin-bottom:var(--gap);}
 .hp-chip{display:flex; flex-direction:column; align-items:flex-start;}
+.qi-chip{display:flex; flex-direction:column; align-items:flex-start;}
 .hp-chip .hp-bar{position:relative; width:100px; height:8px; background:rgba(239,68,68,0.3); border-radius:4px; margin-top:2px;}
 .hp-chip .hp-bar .fill{height:100%; background:linear-gradient(90deg,#ef4444,#f87171); border-radius:4px; transition:width 0.3s ease; width:0%;}
+.qi-chip .qi-bar{position:relative; width:100px; height:8px; background:rgba(37,99,235,0.3); border-radius:4px; margin-top:2px;}
+.qi-chip .qi-bar .qi-fill{height:100%; background:linear-gradient(90deg,#3b82f6,#60a5fa); border-radius:4px; transition:width 0.3s ease; width:0%;}
 .shield-overlay{position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none; transition:width 0.2s linear;}
 .shield-fill{fill:rgba(0,255,255,0.6); height:100%; transition:width 0.2s linear;}
 .shield-shimmer{height:100%; transition:width 0.2s linear; animation:shield-shimmer 1.5s linear infinite; opacity:0.6;}
@@ -1719,7 +1720,7 @@ h1{font-size:20px; margin:0; letter-spacing:.5px}
 html.reduce-motion .shield-overlay,html.reduce-motion .shield-fill,html.reduce-motion .shield-shimmer{transition:none;}
 html.reduce-motion .shield-shimmer{animation:none;}
 
-main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - 76px)}
+  main{display:grid; grid-template-columns: 280px 1fr; height:calc(100% - var(--header-h))}
 
 /* STYLE-GUIDE-UPDATE: Left stats panel with parchment texture */
 .left{
@@ -4424,17 +4425,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   .title-wrap .sub{display:none;}
   .qi-orb{width:40px;height:40px;}
   .hamburger{display:block;}
-  .status-row{width:100%;display:flex;flex-direction:column;align-items:flex-start;}
-  .status-toggle{display:block;background:var(--panel);border:1px solid var(--accent);border-radius:999px;padding:calc(var(--pad)/2) var(--pad);min-height:44px;}
-  .status-row:not([data-open="true"]) .status-cluster{display:none;}
-  .status-row[data-open="true"] .status-cluster{display:flex;flex-wrap:wrap;gap:var(--gap);margin-top:var(--gap);}
-  .status-row[data-open="true"] #top-chips,
-  .status-row[data-open="true"] .right-actions{display:flex;flex-wrap:wrap;gap:var(--gap);width:100%;}
-  .status-row[data-open="true"] #top-chips > *,
-  .status-row[data-open="true"] .right-actions > *{flex:1 1 calc(50% - var(--gap));}
-  .status-row[data-open="true"] .btn{min-height:44px;}
-  #taskChip,#realmChip,#stonesChip{display:none;}
-  main{display:block;height:auto;}
+    main{display:block;height:auto;}
   #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);}
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
@@ -4442,7 +4433,7 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
   .activity-content{padding:var(--pad);height:calc(100dvh - var(--header-h) - var(--tabs-h));overflow-y:auto;-webkit-overflow-scrolling:touch;padding-bottom:calc(var(--log-h) + env(safe-area-inset-bottom,0px));}
   .activity-content::after{content:"";display:block;height:var(--log-h);}
   img,canvas{max-width:100%;height:auto;}
-  .hp-chip .hp-bar{width:100%;max-width:100%;}
+    .hp-chip .hp-bar,.qi-chip .qi-bar{width:100%;max-width:100%;}
   .chip{padding:calc(var(--pad)/2) var(--pad);min-height:44px;}
 
   .log-toggle{display:flex;align-items:center;justify-content:center;width:100%;height:48px;background:none;border:none;font-family:inherit;font-size:1rem;}

--- a/ui/index.js
+++ b/ui/index.js
@@ -589,38 +589,6 @@ function setupMobileUI() {
   apply(mq);
 }
 
-function setupStatusToggle() {
-  const row = qs('#statusRow');
-  const toggle = qs('#statusToggle');
-  const cluster = qs('#statusCluster');
-  if (!row || !toggle || !cluster) return;
-  function firstFocusable() {
-    return cluster.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-  }
-  function close() {
-    row.setAttribute('data-open', 'false');
-    toggle.setAttribute('aria-expanded', 'false');
-    document.removeEventListener('click', outside, true);
-    window.removeEventListener('keydown', esc);
-    toggle.textContent = 'Status \u25BE';
-    toggle.focus();
-  }
-  function open() {
-    row.setAttribute('data-open', 'true');
-    toggle.setAttribute('aria-expanded', 'true');
-    const f = firstFocusable();
-    f && f.focus();
-    toggle.textContent = 'Status \u25B4';
-    document.addEventListener('click', outside, true);
-    window.addEventListener('keydown', esc);
-  }
-  function esc(e) { if (e.key === 'Escape') close(); }
-  function outside(e) { if (!row.contains(e.target)) close(); }
-  toggle.addEventListener('click', () => {
-    row.getAttribute('data-open') === 'true' ? close() : open();
-  });
-}
-
 function setupLogSheet() {
   const sheet = qs('#logSheet');
   const toggle = qs('#logToggle');
@@ -681,12 +649,11 @@ function enableLayoutDebug() {
 
 
 // Init
-window.addEventListener('load', ()=>{
-  initUI();
-  setupMobileUI();
-  setupStatusToggle();
-  setupLogSheet();
-  enableLayoutDebug();
+  window.addEventListener('load', ()=>{
+    initUI();
+    setupMobileUI();
+    setupLogSheet();
+    enableLayoutDebug();
   initLawSystem();
   mountActivityUI(S);
   mountAdventureControls(S);


### PR DESCRIPTION
## Summary
- relocate HP and Qi chips to the left sidebar
- drop obsolete status row and cleanup JS
- tighten header sizing and add styles for resource chips

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: verification violations)

------
https://chatgpt.com/codex/tasks/task_e_68bbc7a761e48326bc37a940df3f10f8