### PR TITLE
Ensure astral node tracking uses a Set

### DIFF
--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -157,6 +157,11 @@ export function meditate(root) {
 }
 
 export function unlockAstralNode(id, state = progressionState) {
-  state.astralUnlockedNodes = state.astralUnlockedNodes || new Set();
-  state.astralUnlockedNodes.add(id);
+  let set = state.astralUnlockedNodes;
+  if (!(set instanceof Set)) {
+    if (Array.isArray(set)) set = new Set(set);
+    else set = new Set();
+    state.astralUnlockedNodes = set;
+  }
+  set.add(id);
 }


### PR DESCRIPTION
## Summary
- prevent runtime TypeError when unlocking astral nodes by guaranteeing `astralUnlockedNodes` is a Set

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violation: src/features/progression/ui/lawDisplay.js imports S from shared/state.js; UI state violation: src/features/progression/ui/qiDisplay.js imports S from shared/state.js; UI state violation: src/features/progression/ui/qiOrb.js imports S from shared/state.js; UI state violation: src/features/progression/ui/realm.js imports S from shared/state.js; DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js; UI timer: src/features/adventure/ui/adventureDisplay.js uses timers/RAF — prefer feature.tick and RENDER; UI timer: src/features/agility/ui/trainingGame.js uses timers/RAF — prefer feature.tick and RENDER; UI rule: src/features/catching/ui/catchingDisplay.js uses Math.random() — move randomness to logic.js; UI rule: src/features/combat/ui/floatingText.js uses Math.random() — move randomness to logic.js; UI timer: src/features/combat/ui/fx.js uses timers/RAF — prefer feature.tick and RENDER; UI timer: src/features/physique/ui/trainingGame.js uses timers/RAF — prefer feature.tick and RENDER; UI timer: src/features/progression/ui/astralTree.js uses timers/RAF — prefer feature.tick and RENDER; UI rule: src/features/progression/ui/realm.js uses Math.random() — move randomness to logic.js; UI timer: src/features/progression/ui/realm.js uses timers/RAF — prefer feature.tick and RENDER)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3061bc2c8326a6152d07316b4745