### PR TITLE
Refactor activity rendering into Activity UI

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -1,6 +1,10 @@
 // src/features/activity/ui/activityUI.js
 import { selectActivity } from "../mutators.js";
-import { getActiveActivity } from "../selectors.js";
+import { getActiveActivity, getSelectedActivity } from "../selectors.js";
+import { updateActivityCultivation } from "../../progression/ui/realm.js";
+import { updateActivityAdventure } from "../../adventure/logic.js";
+import { renderEquipmentPanel } from "../../inventory/ui/CharacterPanel.js";
+import { updateActivityCooking } from "../../cooking/ui/cookingDisplay.js";
 import { fCap, qCap } from "../../progression/selectors.js";
 import { getBuildingLevel } from "../../sect/selectors.js";
 
@@ -8,9 +12,7 @@ export function mountActivityUI(root) {
   const handle = name => {
     selectActivity(root, name);
     updateActivitySelectors(root);
-    if (typeof globalThis.updateActivityContent === 'function') {
-      globalThis.updateActivityContent();
-    }
+    renderActiveActivity(root);
   };
 
   // Click handlers (new compact sidebar + legacy)
@@ -180,4 +182,21 @@ export function updateCurrentTaskDisplay(root) {
   };
   const active = getActiveActivity(root);
   el.textContent = active ? (map[active] || 'Idle') : 'Idle';
+}
+
+export function renderActiveActivity(root) {
+  updateActivityCultivation();
+  const selected = getSelectedActivity(root);
+  switch (selected) {
+    case 'adventure':
+      updateActivityAdventure();
+      break;
+    case 'character':
+      renderEquipmentPanel();
+      break;
+    case 'cooking':
+      updateActivityCooking();
+      break;
+    // other activities intentionally no-op
+  }
 }


### PR DESCRIPTION
## Summary
- add `renderActiveActivity` in Activity UI to update cultivation and dispatch rendering for adventure, character, and cooking
- simplify `ui/index.js` by removing legacy update helpers and using `renderActiveActivity`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)*

------
https://chatgpt.com/codex/tasks/task_e_68bc392b90a0832691c98f8285328b8a