### PR TITLE
refactor: remove window activity hooks

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -40,6 +40,7 @@ import {
 import { updateZoneButtons, updateAreaGrid } from './ui/zoneUI.js';
 import { updateAdventureProgressBar } from './ui/progressBar.js';
 import { updateFoodSlots } from '../cooking/ui/cookControls.js';
+import { stopActivity as stopActivityMut } from '../activity/mutators.js';
 
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 
@@ -748,11 +749,7 @@ export function updateAdventureCombat() {
             forfeitSessionLoot(); // EQUIP-CHAR-UI
             updateLootTab(); // EQUIP-CHAR-UI
             S.qi = 0;
-            if (typeof globalThis.stopActivity === 'function') {
-              globalThis.stopActivity('adventure');
-            } else {
-              S.activities.adventure = false;
-            }
+            stopActivityMut(S, 'adventure');
             const btn = document.getElementById('startBattleButton');
             if (btn) {
               btn.textContent = '⚔️ Start Battle';

--- a/src/features/adventure/mutators.js
+++ b/src/features/adventure/mutators.js
@@ -13,6 +13,7 @@ import { S } from '../../shared/state.js';
 import { initializeFight } from '../combat/mutators.js';
 import { adventureState } from './state.js';
 import { log } from '../../shared/utils/dom.js';
+import { stopActivity as stopActivityMut } from '../activity/mutators.js';
 
 export {
   selectZone,
@@ -49,11 +50,7 @@ export function retreatFromCombat(state = S) {
   baseRetreatFromCombat();
   const loss = Math.floor(qCap(state) * 0.25);
   state.qi = Math.max(0, state.qi - loss);
-  if (typeof globalThis.stopActivity === 'function') {
-    globalThis.stopActivity('adventure');
-  } else if (state.activities) {
-    state.activities.adventure = false;
-  }
+  stopActivityMut(state, 'adventure');
   log(`Retreated from combat. Lost ${loss} Qi.`, 'neutral');
 }
 

--- a/src/features/adventure/ui/adventureDisplay.js
+++ b/src/features/adventure/ui/adventureDisplay.js
@@ -4,6 +4,7 @@ import { ZONES } from '../data/zones.js';
 import { startAdventure, startAdventureCombat, startBossCombat, progressToNextArea, retreatFromCombat, resetQiOnRetreat } from '../mutators.js';
 import { updateActivityAdventure, progressDungeonEncounter } from '../logic.js';
 import { clamp } from '../../progression/selectors.js';
+import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 
 export function updateAdventureProgress(state = S) {
   if (!state.adventure) return;
@@ -40,7 +41,7 @@ export function mountAdventureControls(root) {
         btn.disabled = false;
         btn.classList.remove('warn'); btn.classList.add('primary');
         btn.textContent = '⚔️ Start Battle';
-        (globalThis.stopActivity?.('adventure'));
+        stopActivityMut(root, 'adventure');
         resetQiOnRetreat(root);
         updateActivityAdventure();
         return;
@@ -63,8 +64,8 @@ export function mountAdventureControls(root) {
   startBtn?.addEventListener('click', () => {
     if (root.adventure && root.adventure.inCombat) { startRetreatCountdown(); return; }
     startAdventure();
-    if (!root.activities?.adventure && typeof globalThis.startActivity === 'function') {
-      globalThis.startActivity('adventure');
+    if (!root.activities?.adventure) {
+      startActivityMut(root, 'adventure');
     }
     startAdventureCombat();
     updateActivityAdventure();
@@ -81,8 +82,8 @@ export function mountAdventureControls(root) {
   });
   document.getElementById('challengeBossButton')?.addEventListener('click', () => {
     startAdventure();
-    if (!root.activities?.adventure && typeof globalThis.startActivity === 'function') {
-      globalThis.startActivity('adventure');
+    if (!root.activities?.adventure) {
+      startActivityMut(root, 'adventure');
     }
     startBossCombat();
     updateActivityAdventure();

--- a/src/features/agility/ui/trainingGame.js
+++ b/src/features/agility/ui/trainingGame.js
@@ -1,6 +1,7 @@
 import { on } from '../../../shared/events.js';
 import { setText, log } from '../../../shared/utils/dom.js';
 import { startTrainingSession, hitTrainingTarget, trainAgility, moveTrainingCursor } from '../mutators.js';
+import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import {
   getAgilityLevel,
   getAgilityExp,
@@ -68,7 +69,7 @@ function render(state){
   const startBtn = document.getElementById('startAgilityActivity');
   if(startBtn){
     startBtn.textContent = state.activities?.agility ? '🛑 Stop Training' : '🏃 Start Training';
-    startBtn.onclick = () => state.activities?.agility ? globalThis.stopActivity('agility') : globalThis.startActivity('agility');
+    startBtn.onclick = () => state.activities?.agility ? stopActivityMut(state, 'agility') : startActivityMut(state, 'agility');
   }
 }
 

--- a/src/features/catching/logic.js
+++ b/src/features/catching/logic.js
@@ -1,3 +1,5 @@
+import { stopActivity as stopActivityMut } from '../activity/mutators.js';
+
 export function advanceCatching(state){
   const root = state.catching || state;
   if(!root) return;
@@ -13,7 +15,7 @@ export function advanceCatching(state){
       cc.progress = Math.min(1, elapsed / cc.duration);
       if(elapsed >= cc.duration){
         root.currentCatch = null;
-        if(typeof globalThis.stopActivity === 'function') globalThis.stopActivity('catching');
+        stopActivityMut(state, 'catching');
         if(Math.random() < cc.chance){
           root.creatures.push({
             id: `${cc.area.id}-${now}`,

--- a/src/features/catching/mutators.js
+++ b/src/features/catching/mutators.js
@@ -1,5 +1,6 @@
 import { ZONES } from '../adventure/data/zones.js';
 import { getCatchingIcon } from './data/icons.js';
+import { startActivity as startActivityMut } from '../activity/mutators.js';
 function getRoot(state){
   return state.catching || state;
 }
@@ -19,6 +20,6 @@ export function startCatch(state, zi, ai){
   const icon = getCatchingIcon(area.enemy);
   root.nets -= 1;
   root.currentCatch = { start: Date.now(), duration, chance, stage, area, enemy: area.enemy, icon, progress: 0 };
-  if(typeof globalThis.startActivity === 'function') globalThis.startActivity('catching');
+  startActivityMut(state, 'catching');
   return true;
 }

--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -4,6 +4,7 @@ import { on } from '../../../shared/events.js';
 import { startForging } from '../mutators.js';
 import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
 import { GEAR_BASES } from '../../gearGeneration/data/gearBases.js';
+import { startActivity as startActivityMut } from '../../activity/mutators.js';
 
 function displayName(it) {
   if (!it) return '';
@@ -91,7 +92,7 @@ function updateForgeSlot(state = S) {
     alignBtn.onclick = () => {
       const element = elementSel.value;
       startForging(item.id, element, state);
-      window.startActivity('forging');
+      startActivityMut(state, 'forging');
       updateForgeSlot(state);
       updateForgeInventory(state);
     };
@@ -103,7 +104,7 @@ function updateForgeSlot(state = S) {
     imbBtn.onclick = () => {
       const element = item.element || elementSel.value;
       startForging(item.id, element, state);
-      window.startActivity('forging');
+      startActivityMut(state, 'forging');
       updateForgeSlot(state);
       updateForgeInventory(state);
     };

--- a/src/features/gathering/ui/gatheringDisplay.js
+++ b/src/features/gathering/ui/gatheringDisplay.js
@@ -2,6 +2,7 @@ import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
 import { on } from '../../../shared/events.js';
 import { getGatheringRate } from '../logic.js';
+import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 
 export function updateActivityGathering(state = S) {
   if (!state.gathering) return;
@@ -21,7 +22,7 @@ export function updateActivityGathering(state = S) {
   const startBtn = document.getElementById('startGatheringActivity');
   if (startBtn) {
     startBtn.textContent = state.activities.gathering ? '🛑 Stop Gathering' : '🪓 Start Gathering';
-    startBtn.onclick = () => state.activities.gathering ? window.stopActivity('gathering') : window.startActivity('gathering');
+    startBtn.onclick = () => state.activities.gathering ? stopActivityMut(state, 'gathering') : startActivityMut(state, 'gathering');
   }
 
   const selectedRadio = document.querySelector(`input[name="gatheringResource"][value="${state.gathering.selectedResource}"]`);

--- a/src/features/mining/ui/miningDisplay.js
+++ b/src/features/mining/ui/miningDisplay.js
@@ -2,6 +2,7 @@ import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
 import { on } from '../../../shared/events.js';
 import { getMiningRate } from '../logic.js';
+import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 
 export function updateActivityMining(state = S) {
   if (!state.mining) return;
@@ -21,7 +22,7 @@ export function updateActivityMining(state = S) {
   const startBtn = document.getElementById('startMiningActivity');
   if (startBtn) {
     startBtn.textContent = state.activities.mining ? '🛑 Stop Mining' : '⛏️ Start Mining';
-    startBtn.onclick = () => state.activities.mining ? window.stopActivity('mining') : window.startActivity('mining');
+    startBtn.onclick = () => state.activities.mining ? stopActivityMut(state, 'mining') : startActivityMut(state, 'mining');
   }
 
   const ironOption = document.getElementById('ironOption');

--- a/src/features/physique/ui/trainingGame.js
+++ b/src/features/physique/ui/trainingGame.js
@@ -1,6 +1,7 @@
 import { on } from '../../../shared/events.js';
 import { setText, log } from '../../../shared/utils/dom.js';
 import { startTrainingSession, hitTrainingTarget, trainPhysique, moveTrainingCursor } from '../mutators.js';
+import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import {
   getPhysiqueLevel,
   getPhysiqueExp,
@@ -72,7 +73,7 @@ function render(state){
   const startBtn = document.getElementById('startPhysiqueActivity');
   if(startBtn){
     startBtn.textContent = state.activities?.physique ? '🛑 Stop Training' : '💪 Start Training';
-    startBtn.onclick = () => state.activities?.physique ? globalThis.stopActivity('physique') : globalThis.startActivity('physique');
+    startBtn.onclick = () => state.activities?.physique ? stopActivityMut(state, 'physique') : startActivityMut(state, 'physique');
   }
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -99,10 +99,6 @@ function selectActivity(activityType) { selectActivityMut(S, activityType); }
 function startActivity(activityName)  { startActivityMut(S, activityName); }
 function stopActivity(activityName)   { stopActivityMut(S, activityName); }
 
-// Back-compat for older UI
-window.startActivity = startActivity;
-window.stopActivity  = stopActivity;
-
 
 
 


### PR DESCRIPTION
## Summary
- remove window.startActivity/stopActivity assignments
- call activity mutators directly throughout UI and logic
- update adventure retreat and controls to use activity mutators

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation warnings)


------
https://chatgpt.com/codex/tasks/task_e_68bc3b17fd90832690dcada19086f006