### PR TITLE
refactor: move law init to progression

### DIFF
--- a/src/features/progression/migrations.js
+++ b/src/features/progression/migrations.js
@@ -1,17 +1,26 @@
+import { checkLawUnlocks } from './mutators.js';
+
+export function ensureLaws(root){
+  if(!root.laws){
+    root.laws = {
+      selected: null,
+      unlocked: [],
+      points: 0,
+      trees: {
+        sword: {},
+        formation: {},
+        alchemy: {},
+      },
+    };
+  }
+  if(typeof checkLawUnlocks === 'function'){
+    checkLawUnlocks(root);
+  }
+}
+
 export const migrations = [
   save => {
-    if(!save.laws){
-      save.laws = {
-        selected: null,
-        unlocked: [],
-        points: 0,
-        trees: {
-          sword: {},
-          formation: {},
-          alchemy: {},
-        },
-      };
-    }
+    ensureLaws(save);
     if(!save.cultivation){
       save.cultivation = {
         talent: 1.0,

--- a/ui/index.js
+++ b/ui/index.js
@@ -24,8 +24,8 @@ import {
   updateActivityCultivation,
   updateBreakthrough,
   initRealmUI,
-  checkLawUnlocks,
 } from '../src/features/progression/index.js';
+import { ensureLaws } from '../src/features/progression/migrations.js';
 import { qs, setText, setFill, log } from '../src/shared/utils/dom.js';
 import { fmt } from '../src/shared/utils/number.js';
 import { emit } from '../src/shared/events.js';
@@ -273,27 +273,6 @@ function updateAll(){
   emit('RENDER');
 }
 
-// Initialize law system on game start
-function initLawSystem(){
-  // Ensure laws object exists
-  if(!S.laws) {
-    S.laws = {
-      selected: null,
-      unlocked: [],
-      points: 0,
-      trees: {
-        sword: {},
-        formation: {},
-        alchemy: {}
-      }
-    };
-  }
-  
-  // Check for any laws that should already be unlocked
-  checkLawUnlocks();
-}
-
-
 // Upgrades
 function canPay(cost){ return Object.entries(cost).every(([k,v])=> (S[k]||0) >= v); }
 function pay(cost){ if(!canPay(cost)) return false; Object.entries(cost).forEach(([k,v])=> S[k]-=v); return true; }
@@ -508,25 +487,25 @@ function enableLayoutDebug() {
     setupMobileUI();
     setupLogSheet();
     enableLayoutDebug();
-  initLawSystem();
-  mountActivityUI(S);
-  mountAdventureControls(S);
-  setupAdventureTabs();
-  setupMindTabs();
-  setupEquipmentTab(); // EQUIP-CHAR-UI
-  // Ensure derived stats like Qi shield are initialized based on equipped gear
-  recomputePlayerTotals(S);
-  mountDiagnostics(S);
-  renderMindMainTab(document.getElementById('mindMainTab'), S);
-  renderMindReadingTab(document.getElementById('mindReadingTab'), S);
-  renderMindStatsTab(document.getElementById('mindStatsTab'), S);
-  renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
-  selectActivity('cultivation'); // Start with cultivation selected
-  updateAll();
-  tick();
-  log('Welcome, cultivator.');
-  setInterval(tick, 1000);
-  setInterval(() => {
+    ensureLaws(S);
+    mountActivityUI(S);
+    mountAdventureControls(S);
+    setupAdventureTabs();
+    setupMindTabs();
+    setupEquipmentTab(); // EQUIP-CHAR-UI
+    // Ensure derived stats like Qi shield are initialized based on equipped gear
+    recomputePlayerTotals(S);
+    mountDiagnostics(S);
+    renderMindMainTab(document.getElementById('mindMainTab'), S);
+    renderMindReadingTab(document.getElementById('mindReadingTab'), S);
+    renderMindStatsTab(document.getElementById('mindStatsTab'), S);
+    renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
+    selectActivity('cultivation'); // Start with cultivation selected
+    updateAll();
+    tick();
+    log('Welcome, cultivator.');
+    setInterval(tick, 1000);
+    setInterval(() => {
     const junk = S.junk || [];
     const total = junk.reduce((sum, it) => sum + (it.qty || 1), 0);
     if (junk.length === 0) {


### PR DESCRIPTION
## Summary
- add ensureLaws migration helper to initialize law state and invoke unlock checks
- load UI law system by calling ensureLaws instead of dedicated init function

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3cf88be88326ac7019e3f7cf9483