### PR TITLE
refactor: centralize game loop in controller

### DIFF
--- a/src/game/GameController.js
+++ b/src/game/GameController.js
@@ -78,3 +78,35 @@ export function createGameController() {
 
   return { state, start, setMode, pause, resume, step, getSpeed, setSpeed };
 }
+
+export class GameController {
+  // If class exists, extend it; otherwise create it.
+  constructor(root, stepMs = 1000) {
+    this.root = root;
+    this.stepMs = stepMs;
+    this.timer = null;
+    this.frame = null;   // (root, dtMs) => void
+  }
+
+  /**
+   * Set the frame function to run each tick.
+   * fn signature: (root, dtMs) => void
+   */
+  setFrame(fn) {
+    this.frame = fn;
+    return this;
+  }
+
+  start() {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      if (this.frame) this.frame(this.root, this.stepMs);
+    }, this.stepMs);
+  }
+
+  stop() {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+}

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -8,6 +8,7 @@ import { mountDiagnostics } from './diagnostics.js';
 import { mountAllFeatureUIs, runAllFeatureTicks } from '../features/index.js';
 import { applyDevUnlockPreset } from '../features/devUnlock.js';
 import { S, defaultState, save, setState, validateState } from '../shared/state.js';
+import { GameController } from '../game/GameController.js';
 import {
   updateRealmUI,
   initRealmUI,
@@ -244,9 +245,10 @@ if (ascendBtn) {
 
 
 /* Loop */
-function tick() {
-  S.time++;
-  runAllFeatureTicks(S, 1000);
+// Controller-driven frame
+function frame(root, dtMs) {
+  root.time = (root.time || 0) + 1;
+  runAllFeatureTicks(root, dtMs);
   updateAll();
   updateAbilityBar();
 }
@@ -392,9 +394,10 @@ function enableLayoutDebug() {
     renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
     selectActivity('cultivation'); // Start with cultivation selected
     updateAll();
-    tick();
     log('Welcome, cultivator.');
-    setInterval(tick, 1000);
+    // Own the loop via GameController (fixed 1000ms for now)
+    const controller = new GameController(S, 1000).setFrame(frame);
+    controller.start();
     setInterval(() => {
     const junk = S.junk || [];
     const total = junk.reduce((sum, it) => sum + (it.qty || 1), 0);


### PR DESCRIPTION
## Summary
- route game tick through GameController with simple frame loop
- let app.js use GameController instead of local tick()/setInterval

## Testing
- `npm test` (fails: no test specified)
- `npm run validate` (fails: verification failed)


------
https://chatgpt.com/codex/tasks/task_e_68bc6bf614e883268636d97ce43bed9c