### PR TITLE
feat: show XP values on sidebar progress bars

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -7,6 +7,7 @@ import { renderEquipmentPanel } from "../../inventory/ui/CharacterPanel.js";
 import { updateActivityCooking } from "../../cooking/ui/cookingDisplay.js";
 import { fCap, qCap } from "../../progression/selectors.js";
 import { getBuildingLevel } from "../../sect/selectors.js";
+import { fmt } from "../../../shared/utils/number.js";
 
 export function mountActivityUI(root) {
   const handle = name => {
@@ -96,6 +97,8 @@ export function updateActivitySelectors(root) {
     const expPct = (root.physique.exp / root.physique.expMax) * 100;
     physFill.style.width = `${expPct}%`;
     physInfo.textContent = root.activities?.physique ? 'Training...' : `Level ${root.physique.level}`;
+    const physText = document.getElementById('physiqueProgressTextSidebar');
+    if (physText) physText.textContent = `${fmt(root.physique.exp)} / ${fmt(root.physique.expMax)}`;
   }
 
   const agiSel = document.getElementById('agilitySelector');
@@ -107,6 +110,8 @@ export function updateActivitySelectors(root) {
     const expPct = (root.agility.exp / root.agility.expMax) * 100;
     agiFill.style.width = `${expPct}%`;
     agiInfo.textContent = root.activities?.agility ? 'Training...' : `Level ${root.agility.level}`;
+    const agiText = document.getElementById('agilityProgressTextSidebar');
+    if (agiText) agiText.textContent = `${fmt(root.agility.exp)} / ${fmt(root.agility.expMax)}`;
   }
 
   // Mining
@@ -119,6 +124,8 @@ export function updateActivitySelectors(root) {
     const expPct = (root.mining.exp / root.mining.expMax) * 100;
     miningFill.style.width = `${expPct}%`;
     miningInfo.textContent = root.activities?.mining ? 'Mining...' : `Level ${root.mining.level}`;
+    const miningText = document.getElementById('miningProgressText');
+    if (miningText) miningText.textContent = `${fmt(root.mining.exp)} / ${fmt(root.mining.expMax)}`;
   }
 
   // Gathering
@@ -131,6 +138,8 @@ export function updateActivitySelectors(root) {
     const expPct = (root.gathering.exp / root.gathering.expMax) * 100;
     gatheringFill.style.width = `${expPct}%`;
     gatheringInfo.textContent = root.activities?.gathering ? 'Gathering...' : `Level ${root.gathering.level}`;
+    const gatheringText = document.getElementById('gatheringProgressText');
+    if (gatheringText) gatheringText.textContent = `${fmt(root.gathering.exp)} / ${fmt(root.gathering.expMax)}`;
   }
 
   // Catching
@@ -143,6 +152,8 @@ export function updateActivitySelectors(root) {
     const expPct = (root.catching.exp / root.catching.expMax) * 100;
     catchFill.style.width = `${expPct}%`;
     catchInfo.textContent = root.activities?.catching ? 'Catching...' : `Level ${root.catching.level}`;
+    const catchText = document.getElementById('catchingProgressTextSidebar');
+    if (catchText) catchText.textContent = `${fmt(root.catching.exp)} / ${fmt(root.catching.expMax)}`;
   }
 
   // Adventure

--- a/src/features/cooking/ui/cookingDisplay.js
+++ b/src/features/cooking/ui/cookingDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText, setFill } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { getCookingYieldBonus } from '../selectors.js';
 import { cookMeat, equipFood, useFoodSlot } from '../mutators.js';
@@ -30,7 +31,7 @@ export function updateCookingSidebar(state = S) {
   if (!state.cooking) return;
   setText('cookingLevelSidebar', `Level ${state.cooking.level}`);
   setFill('cookingProgressFillSidebar', state.cooking.exp / state.cooking.expMax);
-  setText('cookingProgressTextSidebar', `${state.cooking.exp} / ${state.cooking.expMax} XP`);
+  setText('cookingProgressTextSidebar', `${fmt(state.cooking.exp)} / ${fmt(state.cooking.expMax)}`);
 }
 
 export function mountCookingUI(state = S) {

--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { startForging } from '../mutators.js';
 import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
@@ -119,8 +120,9 @@ function updateForgingSidebar(state = S) {
   if (fill) {
     const pct = (state.forging.exp / state.forging.expMax) * 100;
     fill.style.width = pct + '%';
-    setText('forgingProgressTextSidebar', pct.toFixed(0) + '%');
   }
+  const text = document.getElementById('forgingProgressTextSidebar');
+  if (text) text.textContent = `${fmt(state.forging.exp)} / ${fmt(state.forging.expMax)}`;
 }
 
 export function mountForgingUI(state = S) {

--- a/src/features/gathering/ui/gatheringDisplay.js
+++ b/src/features/gathering/ui/gatheringDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { getGatheringRate } from '../logic.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
@@ -61,8 +62,9 @@ export function updateGatheringSidebar(state = S) {
   if (fill) {
     const progressPct = Math.floor(state.gathering.exp / state.gathering.expMax * 100);
     fill.style.width = progressPct + '%';
-    setText('gatheringProgressText', progressPct + '%');
   }
+  const gatherText = document.getElementById('gatheringProgressText');
+  if (gatherText) gatherText.textContent = `${fmt(state.gathering.exp)} / ${fmt(state.gathering.expMax)}`;
 }
 
 export function mountGatheringUI(state = S) {

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -77,14 +77,49 @@ const coreFeatures = new Set([
 ]);
 
 const activityMeta = {
-  physique: { icon: 'mdi:arm-flex', infoId: 'physiqueInfo', fillId: 'physiqueSelectorFill' },
-  agility: { icon: 'mdi:run-fast', infoId: 'agilityInfo', fillId: 'agilitySelectorFill' },
-  mining: { icon: 'mdi:pickaxe', infoId: 'miningInfo', fillId: 'miningSelectorFill' },
-  gathering: { icon: 'mdi:leaf', infoId: 'gatheringInfo', fillId: 'gatheringSelectorFill' },
-  forging: { icon: 'mdi:anvil', infoId: 'forgingLevelSidebar', fillId: 'forgingProgressFillSidebar', textId: 'forgingProgressTextSidebar' },
-  catching: { icon: 'mdi:butterfly-outline', infoId: 'catchingLevel', fillId: 'catchingProgressFill' },
+  physique: {
+    icon: 'mdi:arm-flex',
+    infoId: 'physiqueInfo',
+    fillId: 'physiqueSelectorFill',
+    textId: 'physiqueProgressTextSidebar'
+  },
+  agility: {
+    icon: 'mdi:run-fast',
+    infoId: 'agilityInfo',
+    fillId: 'agilitySelectorFill',
+    textId: 'agilityProgressTextSidebar'
+  },
+  mining: {
+    icon: 'mdi:pickaxe',
+    infoId: 'miningInfo',
+    fillId: 'miningSelectorFill',
+    textId: 'miningProgressText'
+  },
+  gathering: {
+    icon: 'mdi:leaf',
+    infoId: 'gatheringInfo',
+    fillId: 'gatheringSelectorFill',
+    textId: 'gatheringProgressText'
+  },
+  forging: {
+    icon: 'mdi:anvil',
+    infoId: 'forgingLevelSidebar',
+    fillId: 'forgingProgressFillSidebar',
+    textId: 'forgingProgressTextSidebar'
+  },
+  catching: {
+    icon: 'mdi:butterfly-outline',
+    infoId: 'catchingLevel',
+    fillId: 'catchingProgressFill',
+    textId: 'catchingProgressTextSidebar'
+  },
   adventure: { icon: 'mdi:map', infoId: 'adventureInfo' },
-  cooking: { icon: 'mdi:chef-hat' },
+  cooking: {
+    icon: 'mdi:chef-hat',
+    infoId: 'cookingLevelSidebar',
+    fillId: 'cookingProgressFillSidebar',
+    textId: 'cookingProgressTextSidebar'
+  },
   alchemy: { icon: 'mdi:flask-round-bottom' },
   character: { icon: 'mdi:account' },
 };

--- a/src/features/mining/ui/miningDisplay.js
+++ b/src/features/mining/ui/miningDisplay.js
@@ -1,5 +1,6 @@
 import { S } from '../../../shared/state.js';
 import { setText, log } from '../../../shared/utils/dom.js';
+import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { getMiningRate } from '../logic.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
@@ -61,8 +62,9 @@ export function updateMiningSidebar(state = S) {
   if (miningFill) {
     const progressPct = Math.floor(state.mining.exp / state.mining.expMax * 100);
     miningFill.style.width = progressPct + '%';
-    setText('miningProgressText', progressPct + '%');
   }
+  const miningText = document.getElementById('miningProgressText');
+  if (miningText) miningText.textContent = `${fmt(state.mining.exp)} / ${fmt(state.mining.expMax)}`;
 }
 
 export function mountMiningUI(state = S) {


### PR DESCRIPTION
## Summary
- add progress text elements for all sidebar activities and cooking
- show current and required XP inside each sidebar progress bar
- standardize sidebar progress bars to a consistent size

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68bc704097cc8326ba6309aa47e70f08