### PR TITLE
Move pill logic to alchemy feature

### DIFF
--- a/src/features/alchemy/mutators.js
+++ b/src/features/alchemy/mutators.js
@@ -1,6 +1,7 @@
 import { alchemyState } from './state.js';
 import { ALCHEMY_RECIPES } from './data/recipes.js';
 import { getMaxSlots, getSuccessChance } from './selectors.js';
+import { qCap, clamp } from '../progression/selectors.js';
 
 function slice(state){
   return state.alchemy || alchemyState;
@@ -37,4 +38,25 @@ export function completeBrew(state, index){
 export function unlockRecipe(state, key){
   const alch = slice(state);
   if(!alch.knownRecipes.includes(key)) alch.knownRecipes.push(key);
+}
+
+export function usePill(root, type) {
+  root.pills ??= { qi: 0, body: 0, ward: 0 };
+  if ((root.pills[type] ?? 0) <= 0) return { ok: false, reason: 'none' };
+
+  if (type === 'qi') {
+    const add = Math.floor(qCap(root) * 0.25);
+    root.qi = clamp(root.qi + add, 0, qCap(root));
+  }
+  if (type === 'body') {
+    root.tempAtk = (root.tempAtk || 0) + 4;
+    root.tempArmor = (root.tempArmor || 0) + 3;
+    // NOTE: timer remains in UI for now; long-term move to a timed effect system
+  }
+  if (type === 'ward') {
+    // consumed during breakthrough
+  }
+
+  root.pills[type]--;
+  return { ok: true, type };
 }

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -2,7 +2,7 @@ import { S, save } from '../../shared/state.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
-import { qCap, clamp } from '../progression/selectors.js';
+export { usePill } from '../alchemy/mutators.js'; // deprecated shim
 
 export function addToInventory(item, state = S) {
   state.inventory = state.inventory || [];
@@ -79,23 +79,3 @@ export function unequip(slot, state = S) {
   return payload;
 }
 
-export function usePill(root, type) {
-  root.pills ??= { qi: 0, body: 0, ward: 0 };
-  if ((root.pills[type] ?? 0) <= 0) return { ok: false, reason: 'none' };
-
-  if (type === 'qi') {
-    const add = Math.floor(qCap(root) * 0.25);
-    root.qi = clamp(root.qi + add, 0, qCap(root));
-  }
-  if (type === 'body') {
-    root.tempAtk = (root.tempAtk || 0) + 4;
-    root.tempArmor = (root.tempArmor || 0) + 3;
-    // NOTE: timer remains in UI for now; long-term move to a timed effect system
-  }
-  if (type === 'ward') {
-    // consumed during breakthrough
-  }
-
-  root.pills[type]--;
-  return { ok: true, type };
-}

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -46,7 +46,8 @@ import { isAutoMeditate, isAutoAdventure } from '../features/automation/selector
 import { selectActivity as selectActivityMut, startActivity as startActivityMut, stopActivity as stopActivityMut } from '../features/activity/mutators.js';
 import { mountActivityUI, updateActivitySelectors, renderActiveActivity } from '../features/activity/ui/activityUI.js';
 import { meditate } from '../features/progression/mutators.js';
-import { usePill, sellJunk } from '../features/inventory/mutators.js';
+import { sellJunk } from '../features/inventory/mutators.js';
+import { usePill } from '../features/alchemy/mutators.js';
 import { initSideLocations } from '../features/sideLocations/logic.js';
 
 const report = configReport();


### PR DESCRIPTION
## Summary
- Move `usePill` mutator into alchemy feature
- Re-export a deprecated shim from inventory mutators
- Update UI to import `usePill` from alchemy

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: verification failed, multiple violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7084ea40832691212d78b883e43e