### PR TITLE
feat: improve environment detection and flag defaults

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,98 +1,77 @@
 // Environment and feature flag utilities
 
-const hasImportMeta = typeof import.meta !== 'undefined' && !!import.meta.env;
-const env = hasImportMeta
-  ? import.meta.env
-  : typeof process !== 'undefined'
-  ? process.env
-  : typeof window !== 'undefined'
-  ? window.__ENV__
-  : {};
+let provider = 'default';
+let env = {};
+if (typeof import.meta !== 'undefined' && import.meta.env) {
+  env = import.meta.env;
+  provider = 'import.meta.env';
+} else if (typeof process !== 'undefined' && process?.env) {
+  env = process.env;
+  provider = 'process.env';
+} else if (typeof window !== 'undefined' && window.__ENV__) {
+  env = window.__ENV__;
+  provider = 'window.__ENV__';
+}
 
-// Determine mode and source
-const rawEnv = env?.VERCEL_ENV || env?.NODE_ENV || (env?.PROD ? 'production' : '');
-const modeSrc = env?.VERCEL_ENV
-  ? 'VERCEL_ENV'
-  : env?.NODE_ENV
-  ? 'NODE_ENV'
-  : env?.PROD
-  ? 'import.meta.env.PROD'
-  : 'default';
-const vercelEnv = String(rawEnv || '').toLowerCase();
-const mode = ['production', 'prod', 'main'].includes(vercelEnv)
-  ? 'production'
-  : vercelEnv || 'development';
-
+const modeRaw = String(env.NODE_ENV || env.MODE || '').toLowerCase();
+const hasWindow = typeof window !== 'undefined';
+const isLocalhost =
+  hasWindow && ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname);
+let mode = modeRaw;
+if (provider === 'window.__ENV__' && !mode) {
+  mode = isLocalhost ? 'development' : 'production';
+}
 export const isProd = mode === 'production';
-export const isPreview = mode === 'preview';
-export const isDev = !isProd && !isPreview;
 
-// Coerce env values
+const defaults = {
+  TUTORIALS_ENABLED: false,
+  DEV_UNLOCK_PRESET: '',
+  DISCOVERY_RATE_MULT: 1,
+  TIMERS_SPEED_MULT: 1,
+  // default locked in prod; gameplay unlocks them via progression/buildings
+  FEATURE_PROFICIENCY: false,
+  FEATURE_SECT: false,
+  FEATURE_KARMA: false,
+  FEATURE_ALCHEMY: false,
+  FEATURE_COOKING: false,
+  FEATURE_MINING: false,
+  FEATURE_GATHERING: false,
+  FEATURE_FORGING: false,
+  FEATURE_PHYSIQUE: false,
+  FEATURE_AGILITY: false,
+  FEATURE_CATCHING: false,
+  FEATURE_LAW: false,
+  FEATURE_MIND: false
+};
+
 function coerce(value, fallback) {
   if (value === undefined) return fallback;
-  const str = String(value).toLowerCase();
+  const str = String(value).trim().toLowerCase();
   if (str === 'true' || str === '1') return true;
   if (str === 'false' || str === '0') return false;
-  const num = Number(value);
+  if (str === '') return '';
+  const num = Number(str);
   if (!Number.isNaN(num)) return num;
   return value;
 }
 
-function readFlag(name, fallback) {
-  const order = [
-    { prefix: 'VITE_', source: 'VITE', provider: hasImportMeta ? import.meta.env : undefined },
-    {
-      prefix: 'NEXT_PUBLIC_',
-      source: 'NEXT_PUBLIC',
-      provider: typeof process !== 'undefined' ? process.env : undefined
-    },
-    {
-      prefix: 'REACT_APP_',
-      source: 'REACT_APP',
-      provider: typeof process !== 'undefined' ? process.env : undefined
-    },
-    {
-      prefix: '',
-      source: 'window.__ENV__',
-      provider: typeof window !== 'undefined' ? window.__ENV__ : undefined
-    }
-  ];
-
-  for (const { prefix, source, provider } of order) {
-    const key = prefix + name;
-    if (provider && Object.prototype.hasOwnProperty.call(provider, key)) {
-      const raw = provider[key];
-      return { rawValue: raw, parsedValue: coerce(raw, fallback), source };
-    }
-  }
-  return { rawValue: undefined, parsedValue: fallback, source: 'default' };
-}
-
-const flagNames = [
-  'TUTORIALS_ENABLED',
-  'DEV_UNLOCK_PRESET',
-  'DISCOVERY_RATE_MULT',
-  'TIMERS_SPEED_MULT',
-  'FEATURE_PROFICIENCY',
-  'FEATURE_SECT',
-  'FEATURE_KARMA',
-  'FEATURE_ALCHEMY',
-  'FEATURE_COOKING',
-  'FEATURE_MINING',
-  'FEATURE_GATHERING',
-  'FEATURE_FORGING',
-  'FEATURE_PHYSIQUE',
-  'FEATURE_AGILITY',
-  'FEATURE_CATCHING',
-  'FEATURE_LAW',
-  'FEATURE_MIND',
-];
-
 const flags = {};
-for (const name of flagNames) {
-  const fallback = name.startsWith('FEATURE_') ? false : undefined;
-  flags[name] = readFlag(name, fallback);
+for (const [name, def] of Object.entries(defaults)) {
+  const raw = env?.[name];
+  flags[name] = {
+    rawValue: raw,
+    parsedValue: coerce(raw, def),
+    source: raw === undefined ? 'default' : provider
+  };
 }
+
+if (!isProd && String(env.DEV_UNLOCK_PRESET || '').toLowerCase() === 'all') {
+  for (const k of Object.keys(flags)) {
+    if (k.startsWith('FEATURE_')) flags[k].parsedValue = true;
+  }
+}
+
+export const devUnlockPreset = flags.DEV_UNLOCK_PRESET.parsedValue;
 
 export const featureFlags = {
   cultivation: true,
@@ -108,20 +87,8 @@ export const featureFlags = {
   agility: flags.FEATURE_AGILITY.parsedValue,
   catching: flags.FEATURE_CATCHING.parsedValue,
   law: flags.FEATURE_LAW.parsedValue,
-  mind: flags.FEATURE_MIND.parsedValue,
+  mind: flags.FEATURE_MIND.parsedValue
 };
-
-export const devUnlockPreset = flags.DEV_UNLOCK_PRESET.parsedValue;
-
-// When unlocking everything for dev/preview builds, force all feature flags on
-if (devUnlockPreset === 'all') {
-  for (const key of Object.keys(featureFlags)) {
-    if (key === 'cultivation') continue;
-    featureFlags[key] = true;
-    const flagKey = 'FEATURE_' + key.toUpperCase();
-    if (flags[flagKey]) flags[flagKey].parsedValue = true;
-  }
-}
 
 export function configReport() {
   const missingKeys = Object.entries(flags)
@@ -129,49 +96,19 @@ export function configReport() {
     .map(([k]) => k);
   const allKnownKeysFound = missingKeys.length === 0;
 
-  const envProvider = hasImportMeta
-    ? 'vite import.meta.env'
-    : typeof process !== 'undefined'
-    ? 'process.env'
+  const bundler = typeof import.meta !== 'undefined' && import.meta?.env
+    ? 'vite'
+    : typeof process !== 'undefined' && process?.versions?.node
+    ? 'node'
     : typeof window !== 'undefined'
-    ? 'window.__ENV__'
+    ? 'browser'
     : 'unknown';
 
-  let bundlerGuess = 'unknown';
-  const envKeys = Object.keys(env || {});
-  const hasVite = envKeys.some((k) => k.startsWith('VITE_'));
-  const hasNext = envKeys.some((k) => k.startsWith('NEXT_PUBLIC_'));
-  const hasCra = envKeys.some((k) => k.startsWith('REACT_APP_'));
-  if (hasImportMeta) bundlerGuess = 'vite';
-  else if (hasNext) bundlerGuess = 'next';
-  else if (hasCra) bundlerGuess = 'cra';
-
-  const warnings = [];
-  if (bundlerGuess === 'vite') {
-    if (hasNext || hasCra) warnings.push('Mixing VITE_* with other prefixes');
-    for (const key of missingKeys) {
-      if (envKeys.includes('NEXT_PUBLIC_' + key)) {
-        warnings.push(`Expected VITE_${key} but NEXT_PUBLIC_${key} is set`);
-      }
-      if (envKeys.includes('REACT_APP_' + key)) {
-        warnings.push(`Expected VITE_${key} but REACT_APP_${key} is set`);
-      }
-    }
-  }
-  if (bundlerGuess === 'next') {
-    if (hasCra || hasVite) warnings.push('Mixing NEXT_PUBLIC_* with other prefixes');
-  }
-  if (bundlerGuess === 'cra') {
-    if (hasNext || hasVite) warnings.push('Mixing REACT_APP_* with other prefixes');
-  }
-
   return {
-    mode,
-    modeSource: modeSrc,
     isProd,
-    envProvider,
-    bundlerGuess,
-    warnings,
+    mode,
+    provider,
+    bundler,
     flags,
     allKnownKeysFound,
     missingKeys


### PR DESCRIPTION
## Summary
- add robust env provider and mode detection that works without a bundler
- lock feature flags by default and ignore DEV_UNLOCK_PRESET in production
- expose config report with provider, bundler, and parsed flag metadata

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and warnings)*
- `npm run lint:balance`

------
https://chatgpt.com/codex/tasks/task_e_68bc761943cc83268f4e3db9a827cb8f