### PR TITLE
Improve env detection and feature flag safety

### DIFF
--- a/src/ui/diagnostics.js
+++ b/src/ui/diagnostics.js
@@ -42,13 +42,13 @@ export function mountDiagnostics(state) {
     overlay.appendChild(container);
 
     const summary = document.createElement("pre");
-    summary.textContent = `mode: ${report.mode}\nprovider: ${report.envProvider}\nbundler: ${report.bundlerGuess}`;
+    summary.textContent = `mode: ${report.mode}\nprovider: ${report.provider}\nbundler: ${report.bundler}`;
     container.appendChild(summary);
 
-    if (report.warnings.length) {
+    if (report.missingKeys && report.missingKeys.length) {
       const warn = document.createElement("div");
       warn.style.color = "yellow";
-      warn.textContent = "Warnings:\n" + report.warnings.join("\n");
+      warn.textContent = "Missing env vars:\n" + report.missingKeys.join("\n");
       container.appendChild(warn);
     }
 


### PR DESCRIPTION
## Summary
- add portable env provider detection that defaults to localhost-based development when only window is available
- lock features by default and overlay env values with parsing
- ignore DEV_UNLOCK_PRESET in production and report flags with provider/bundler metadata
- fix diagnostics overlay to display new config report fields and missing env vars

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: VERIFICATION FAILED - MUST fix before proceeding)*

------
https://chatgpt.com/codex/tasks/task_e_68bc761943cc83268f4e3db9a827cb8f