### PR TITLE
Handle preview build feature flags

### DIFF
--- a/src/features/activity/ui/activityUI.js
+++ b/src/features/activity/ui/activityUI.js
@@ -8,6 +8,7 @@ import { updateActivityCooking } from "../../cooking/ui/cookingDisplay.js";
 import { fCap, qCap } from "../../progression/selectors.js";
 import { getBuildingLevel } from "../../sect/selectors.js";
 import { fmt } from "../../../shared/utils/number.js";
+import { configReport } from "../../../config.js";
 
 export function mountActivityUI(root) {
   const handle = name => {
@@ -43,6 +44,34 @@ export function updateActivitySelectors(root) {
   root.gathering ??= { level: 1, exp: 0, expMax: 100 };
   root.catching ??= { level: 1, exp: 0, expMax: 100 };
 
+  const { flags } = configReport();
+  const enabled = {
+    cultivation:  true,
+    character:    true,
+    adventure:    true,
+    mining:       !!flags.FEATURE_MINING?.parsedValue,
+    gathering:    !!flags.FEATURE_GATHERING?.parsedValue,
+    forging:      !!flags.FEATURE_FORGING?.parsedValue,
+    cooking:      !!flags.FEATURE_COOKING?.parsedValue,
+    alchemy:      !!flags.FEATURE_ALCHEMY?.parsedValue,
+    physique:     !!flags.FEATURE_PHYSIQUE?.parsedValue,
+    agility:      !!flags.FEATURE_AGILITY?.parsedValue,
+    catching:     !!flags.FEATURE_CATCHING?.parsedValue,
+    sect:         !!flags.FEATURE_SECT?.parsedValue,
+    karma:        !!flags.FEATURE_KARMA?.parsedValue,
+    law:          !!flags.FEATURE_LAW?.parsedValue,
+    mind:         !!flags.FEATURE_MIND?.parsedValue,
+    proficiency:  !!flags.FEATURE_PROFICIENCY?.parsedValue,
+  };
+  document.querySelectorAll('.activity-item[data-activity]').forEach(el => {
+    const act = el.dataset.activity;
+    const show = enabled[act] !== false;
+    el.style.display = show ? '' : 'none';
+    if (!show && root.ui?.selectedActivity === act) {
+      root.ui.selectedActivity = 'cultivation';
+    }
+  });
+
   const kitchenBuilt = getBuildingLevel('kitchen', root) > 0;
   const forgingBuilt = getBuildingLevel('forging_room', root) > 0;
   let selected = root.ui?.selectedActivity || 'cultivation';
@@ -52,9 +81,9 @@ export function updateActivitySelectors(root) {
   }
 
   const cookItem = document.querySelector('.activity-item[data-activity="cooking"]');
-  if (cookItem) cookItem.style.display = kitchenBuilt ? '' : 'none';
+  if (cookItem) cookItem.style.display = enabled.cooking && kitchenBuilt ? '' : 'none';
   const forgeItem = document.querySelector('.activity-item[data-activity="forging"]');
-  if (forgeItem) forgeItem.style.display = forgingBuilt ? '' : 'none';
+  if (forgeItem) forgeItem.style.display = enabled.forging && forgingBuilt ? '' : 'none';
 
   // Generic highlight for dynamically rendered sidebar items
   document.querySelectorAll('.activity-item[data-activity]')

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -152,36 +152,6 @@ export function mountAllFeatureUIs(state) {
     container.appendChild(item);
   };
 
-  if (devUnlockPreset === 'all') {
-    mountCultivationSidebar(state);
-    mountProficiencyUI(state);
-    mountSectUI(state);
-    mountKarmaUI(state);
-    mountAlchemyUI(state);
-    mountCookingUI(state);
-    mountMiningUI(state);
-    mountGatheringUI(state);
-    mountForgingUI(state);
-    mountPhysiqueUI(state);
-    mountPhysiqueTrainingUI(state);
-    mountAgilityUI(state);
-    mountAgilityTrainingUI(state);
-    mountCatchingUI(state);
-    mountLawDisplay(state);
-    mountMindReadingUI(state);
-    mountAstralTreeUI(state);
-    ensure('managementActivities', 'characterSelector', 'character', 'Character');
-    ensure('levelingActivities', 'physiqueSelector', 'physique', 'Physique');
-    ensure('levelingActivities', 'agilitySelector', 'agility', 'Agility');
-    ensure('levelingActivities', 'miningSelector', 'mining', 'Mining');
-    ensure('levelingActivities', 'gatheringSelector', 'gathering', 'Gathering');
-    ensure('levelingActivities', 'forgingSelector', 'forging', 'Forging');
-    ensure('levelingActivities', 'catchingSelector', 'catching', 'Catching');
-    ensure('managementActivities', 'adventureSelector', 'adventure', 'Adventure');
-    ensure('managementActivities', 'cookingSelector', 'cooking', 'Cooking');
-    ensure('managementActivities', 'alchemySelector', 'alchemy', 'Alchemy');
-    return;
-  }
   const vis = debugFeatureVisibility(state);
   if (vis.character?.visible) ensure('managementActivities', 'characterSelector', 'character', 'Character');
   if (vis.cultivation?.visible) mountCultivationSidebar(state);


### PR DESCRIPTION
## Summary
- Detect Netlify and Vercel preview hosts, default tutorials on outside production, and auto-unlock all features in non-production builds
- Hide activity sidebar entries when their feature flags are disabled
- Rely on feature visibility logic to mount only enabled feature UIs

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations, timers, randomness warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7f34309483269e8b18e53a4f65ae