### PR TITLE
Restrict dev unlock to non-production builds

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -133,9 +133,12 @@ export const featureFlags = {
   mind: flags.FEATURE_MIND.parsedValue,
 };
 
-const envDevUnlock = flags.DEV_UNLOCK_PRESET.parsedValue;
+// Respect development unlocks only for non-production contexts
+// or when explicitly requested via environment variable in those contexts.
+const envDevUnlock = isProd ? undefined : flags.DEV_UNLOCK_PRESET.parsedValue;
 const wantDevUnlock =
-  (!isProd && (isLocalhost || isDeployPreview || isBranchDeploy || isVercelPreview)) ||
+  isLocalhost ||
+  isPreview ||
   String(envDevUnlock).toLowerCase() === 'all';
 export const devUnlockPreset = wantDevUnlock ? 'all' : envDevUnlock;
 


### PR DESCRIPTION
## Summary
- Prevent DEV unlock presets from triggering on production builds
- Limit automatic feature unlocking to local or preview environments

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: verification errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8347e22883269d965ade5c6a8860