### PR TITLE
Ensure modal overlays stay within viewport

### DIFF
--- a/style.css
+++ b/style.css
@@ -2737,6 +2737,7 @@ html.reduce-motion .shield-shimmer{animation:none;}
   align-items: center;
   justify-content: center;
   padding: 20px;
+  box-sizing: border-box;
 }
 
 .modal-backdrop {
@@ -2750,6 +2751,9 @@ html.reduce-motion .shield-shimmer{animation:none;}
 .modal-content {
     position: relative;
     z-index: 1;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 /* Map Overlay Modal - MAP-UI-UPDATE */


### PR DESCRIPTION
## Summary
- Prevent modal overlays from overflowing the viewport by including padding within fixed dimensions
- Constrain modal content to the viewport width on small screens

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violation and timer warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc971eda8c83268d9d3635531dcef9