### PR TITLE
Focus breakthrough scene with progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,14 +262,20 @@
                 <div class="qi-display">
                   <span class="foundation-inline"><span id="foundValSilhouette">0</span>/<span id="foundCapSilhouette">60</span></span>
                   <span id="qiText">Qi <span id="qiValSilhouette">0</span>/<span id="qiCapSilhouette">100</span></span>
-                  <div class="qi-bar-silhouette">
-                    <div class="qi-fill-silhouette" id="qiFillSilhouette"></div>
-                  </div>
+                <div class="qi-bar-silhouette">
+                  <div class="qi-fill-silhouette" id="qiFillSilhouette"></div>
                 </div>
               </div>
+              </div>
+              <!-- Breakthrough overlay elements -->
+              <div class="breakthrough-vignette"></div>
+              <div class="breakthrough-progress" id="breakthroughProgress">
+                <div class="breakthrough-progress-fill" id="breakthroughProgressFill"></div>
+              </div>
             </div>
-            
-            <div class="card cultivation-controls-card">
+          </div>
+
+          <div class="card cultivation-controls-card">
               <div class="realm-node current" id="currentRealmNode">
                 <div class="realm-icon" id="currentRealmIcon">🌱</div>
                 <div class="realm-info">

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -97,21 +97,35 @@ export function updateActivityCultivation() {
   }
 
   const btBtn = document.getElementById('breakthroughBtnActivity');
-  if (btBtn) {
-    if (S.breakthrough && S.breakthrough.inProgress) {
-      btBtn.textContent = `Breakthrough in Progress... (${Math.ceil(S.breakthrough.timeRemaining)}s)`;
-      btBtn.disabled = true;
-      btBtn.classList.add('disabled');
-    } else {
-      btBtn.textContent = 'Attempt Breakthrough';
-      btBtn.disabled = false;
-      btBtn.classList.remove('disabled');
+    if (btBtn) {
+      if (S.breakthrough && S.breakthrough.inProgress) {
+        btBtn.textContent = `Breakthrough in Progress... (${Math.ceil(S.breakthrough.timeRemaining)}s)`;
+        btBtn.disabled = true;
+        btBtn.classList.add('disabled');
+      } else {
+        btBtn.textContent = 'Attempt Breakthrough';
+        btBtn.disabled = false;
+        btBtn.classList.remove('disabled');
+      }
+
+      btBtn.onclick = () => {
+        tryBreakthrough();
+      };
     }
 
-    btBtn.onclick = () => {
-      tryBreakthrough();
-    };
-  }
+    const layout = document.querySelector('.cultivation-layout');
+    const progress = document.getElementById('breakthroughProgress');
+    const progressFill = document.getElementById('breakthroughProgressFill');
+    if (S.breakthrough && S.breakthrough.inProgress) {
+      layout?.classList.add('breakthrough-mode');
+      if (progress && progressFill && S.breakthrough.totalTime) {
+        const pct = (1 - S.breakthrough.timeRemaining / S.breakthrough.totalTime) * 100;
+        progressFill.style.width = pct + '%';
+      }
+    } else {
+      layout?.classList.remove('breakthrough-mode');
+      if (progressFill) progressFill.style.width = '0%';
+    }
 
   const statsCard = document.getElementById('cultivationStatsCard');
   if (statsCard) {

--- a/style.css
+++ b/style.css
@@ -1101,17 +1101,70 @@ html.reduce-motion .rune-ring .orbit {
   border: 1px solid rgba(30, 144, 255, 0.3);
 }
 
-.qi-fill-silhouette {
+  .qi-fill-silhouette {
+    height: 100%;
+    background: linear-gradient(90deg,
+      rgba(135, 206, 250, 0.9) 0%,
+      rgba(30, 144, 255, 0.9) 50%,
+      rgba(0, 191, 255, 0.9) 100%
+    );
+    width: 0%;
+    transition: width 1.5s cubic-bezier(0.23, 1, 0.32, 1);
+    border-radius: 2px;
+    box-shadow: 0 0 8px rgba(30, 144, 255, 0.4);
+  }
+
+/* Breakthrough vignette and progress bar */
+.breakthrough-vignette {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(0,0,0,0) 40%, rgba(0,0,0,0.8) 100%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s;
+  z-index: 7;
+}
+
+.breakthrough .breakthrough-vignette {
+  opacity: 1;
+}
+
+.breakthrough-progress {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60%;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  overflow: hidden;
+  display: none;
+  z-index: 8;
+}
+
+.breakthrough .breakthrough-progress {
+  display: block;
+}
+
+.breakthrough-progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, 
-    rgba(135, 206, 250, 0.9) 0%,
-    rgba(30, 144, 255, 0.9) 50%,
-    rgba(0, 191, 255, 0.9) 100%
-  );
   width: 0%;
-  transition: width 1.5s cubic-bezier(0.23, 1, 0.32, 1);
-  border-radius: 2px;
-  box-shadow: 0 0 8px rgba(30, 144, 255, 0.4);
+  background: var(--accent);
+  transition: width 0.3s linear;
+}
+
+/* Center visualization during breakthrough */
+.cultivation-layout.breakthrough-mode {
+  justify-content: center;
+}
+
+.cultivation-layout.breakthrough-mode .cultivation-controls-card {
+  display: none;
+}
+
+.cultivation-layout.breakthrough-mode .cultivation-visualization-container {
+  margin: 0 auto;
 }
 
 /* Cultivation controls card */


### PR DESCRIPTION
## Summary
- Center cultivation silhouette and hide controls during breakthroughs
- Add dark vignette and visual progress bar while a breakthrough is underway
- Update realm UI logic to animate breakthrough progress

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68bc9983fb8c83268c92944b5771bdca