### PR TITLE
Add basic tutorial system

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -54,6 +54,7 @@ way-of-ascension/
 │   ├── proficiency.md
 │   ├── parameters-and-formulas.md
 │   ├── side-location-discovery.md
+│   ├── tutorial.md
 │   ├── project-structure.md
 │   └── ARCHITECTURE.md
 ├── node_modules/
@@ -307,6 +308,9 @@ way-of-ascension/
 │   │       ├── mutators.js
 │   │       ├── selectors.js
 │   │       └── state.js
+│   │   ├── tutorial/
+│   │   │   ├── logic.js
+│   │   │   └── state.js
 │   ├── game/
 │   │   ├── GameController.js
 │   │   └── migrations.js
@@ -329,7 +333,8 @@ way-of-ascension/
 │       ├── dev/
 │       │   ├── balanceTuner.js
 │       │   └── devQuickMenu.js
-│       └── sidebar.js
+│       ├── sidebar.js
+│       └── tutorialBox.js
 ├── ui/
 │   └── index.js
 ├── README.md
@@ -1230,5 +1235,12 @@ Paths added:
  - `src/features/forging/index.js` – Forging feature descriptor.
  - `src/features/catching/index.js` – Catching feature descriptor.
  - `src/features/mind/index.js` – Mind feature descriptor.
- - `src/features/astralTree/index.js` – Astral Tree feature descriptor.
- - `src/features/law/index.js` – Law feature descriptor.
+- `src/features/astralTree/index.js` – Astral Tree feature descriptor.
+- `src/features/law/index.js` – Law feature descriptor.
+
+## Tutorial Feature
+
+- `docs/tutorial.md` – explains the tutorial flow and reset options.
+- `src/features/tutorial/state.js` – stores tutorial step and completion flag.
+- `src/features/tutorial/logic.js` – evaluates player actions and advances steps.
+- `src/ui/tutorialBox.js` – displays on-screen guidance during the tutorial.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,0 +1,13 @@
+# Tutorial Flow
+
+The game includes a simple tutorial that guides new players through the opening steps of cultivation.
+
+1. **Start cultivating** – toggle the cultivation activity.
+2. **Gain foundation** – accumulate any amount of foundation.
+3. **Attempt a breakthrough** – begin a breakthrough once ready.
+4. **Reach stage 1 of the next realm** – succeeding the breakthrough completes the tutorial.
+
+The current progress is stored in `state.tutorial.step` and `state.tutorial.completed`.
+
+To disable the tutorial, set `state.tutorial.completed = true` in the console.
+To restart, set `state.tutorial = { step: 0, completed: false }` or call `resetTutorial(state)` from `src/features/tutorial/logic.js`.

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -37,6 +37,7 @@ import { updateBreakthrough } from "./progression/index.js";
 import { updateAdventureCombat } from "./adventure/logic.js";
 import { onTick as mindOnTick } from "./mind/index.js";
 import { log } from "../shared/utils/dom.js";
+import { mountTutorialBox } from "../ui/tutorialBox.js";
 
 
 // Example placeholder for later:
@@ -126,6 +127,7 @@ const activityMeta = {
 
 export function mountAllFeatureUIs(state) {
   applyDevUnlockPreset(state);
+  mountTutorialBox(state);
   const { flags } = configReport();
   const ensure = (containerId, id, activity, label) => {
     const container = document.getElementById(containerId);

--- a/src/features/tutorial/logic.js
+++ b/src/features/tutorial/logic.js
@@ -1,0 +1,44 @@
+import { log } from '../../shared/utils/dom.js';
+
+const STEP_TEXT = [
+  'Begin cultivating to start your journey.',
+  'Foundation grows. Accumulate enough to advance.',
+  'Attempt a breakthrough when you are ready.',
+  'Reach Stage 1 of the next realm to finish.',
+];
+
+export function tickTutorial(state) {
+  const t = state.tutorial;
+  if (!t || t.completed) return;
+  switch (t.step) {
+    case 0:
+      if (state.activities?.cultivation) {
+        t.step = 1;
+        log?.(STEP_TEXT[1], 'good');
+      }
+      break;
+    case 1:
+      if (state.foundation > 0) {
+        t.step = 2;
+        log?.(STEP_TEXT[2], 'good');
+      }
+      break;
+    case 2:
+      if (state.breakthrough?.inProgress) {
+        t.step = 3;
+        log?.(STEP_TEXT[3], 'good');
+      }
+      break;
+    case 3:
+      if ((state.realm?.tier ?? 0) >= 1) {
+        t.completed = true;
+        t.step = 4;
+        log?.('Tutorial complete!', 'good');
+      }
+      break;
+  }
+}
+
+export function resetTutorial(state) {
+  state.tutorial = { step: 0, completed: false };
+}

--- a/src/features/tutorial/state.js
+++ b/src/features/tutorial/state.js
@@ -1,0 +1,4 @@
+export const tutorialState = {
+  step: 0,
+  completed: false,
+};

--- a/src/game/GameController.js
+++ b/src/game/GameController.js
@@ -6,6 +6,7 @@ import { ensureMindState, onTick as mindOnTick } from "../features/mind/index.js
 import { sideLocationState } from "../features/sideLocations/state.js";
 import { initSideLocations } from "../features/sideLocations/logic.js";
 import { applyDevUnlockPreset } from "../features/devUnlock.js";
+import { tickTutorial } from "../features/tutorial/logic.js";
 
 // Register feature hooks
 import "../features/proficiency/index.js";
@@ -50,6 +51,7 @@ export function createGameController() {
     while (acc >= stepMs) {
       tickFeatures(state, stepMs);
       mindOnTick(state, stepMs / 1000);
+      tickTutorial(state);
 
       // --- New world: per-feature listeners advance here ---
       emit("TICK", { stepMs, now });
@@ -67,6 +69,7 @@ export function createGameController() {
   function step() {
     tickFeatures(state, stepMs);
     mindOnTick(state, stepMs / 1000);
+    tickTutorial(state);
     emit("TICK", { stepMs, now: performance.now() });
     emit("RENDER");
     saveDebounced(state);

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -11,6 +11,7 @@ import { gatheringState } from '../features/gathering/state.js';
 import { agilityState } from '../features/agility/state.js';
 import { catchingState } from '../features/catching/state.js';
 import { sideLocationState } from '../features/sideLocations/state.js';
+import { tutorialState } from '../features/tutorial/state.js';
 
 export function loadSave(){
   try{
@@ -165,6 +166,7 @@ export const defaultState = () => {
   },
   sect: structuredClone(sectState),
   sideLocations: structuredClone(sideLocationState),
+  tutorial: structuredClone(tutorialState),
   };
 };
 
@@ -203,6 +205,7 @@ S.physique = { ...structuredClone(physiqueState), ...S.physique };
 S.agility = { ...structuredClone(agilityState), ...S.agility };
 S.catching = { ...structuredClone(catchingState), ...S.catching };
 S.sideLocations = { ...structuredClone(sideLocationState), ...S.sideLocations };
+S.tutorial = { ...structuredClone(tutorialState), ...S.tutorial };
 recalculateBuildingBonuses(S);
 
 // Map resource properties to inventory entries so the inventory is the

--- a/src/ui/tutorialBox.js
+++ b/src/ui/tutorialBox.js
@@ -1,0 +1,37 @@
+import { on } from '../shared/events.js';
+
+const STEP_MESSAGES = [
+  'Start cultivating to begin the tutorial.',
+  'Foundation is accumulating. Keep cultivating!',
+  'Try a breakthrough once you have enough foundation.',
+  'Reach Stage 1 of the next realm.',
+  'Tutorial complete!'
+];
+
+export function mountTutorialBox(state) {
+  if (document.getElementById('tutorialBox')) return;
+  const box = document.createElement('div');
+  box.id = 'tutorialBox';
+  box.style.position = 'fixed';
+  box.style.bottom = '10px';
+  box.style.left = '10px';
+  box.style.padding = '8px';
+  box.style.background = 'rgba(0,0,0,0.7)';
+  box.style.color = '#fff';
+  box.style.borderRadius = '4px';
+  box.style.zIndex = '1000';
+  document.body.appendChild(box);
+
+  function render() {
+    const t = state.tutorial;
+    if (!t || t.completed) {
+      box.style.display = 'none';
+      return;
+    }
+    box.textContent = STEP_MESSAGES[t.step] || '';
+    box.style.display = 'block';
+  }
+
+  on('RENDER', render);
+  render();
+}


### PR DESCRIPTION
## Summary
- Introduce tutorial state and logic to guide early player actions
- Render tutorial messages via new tutorial box UI
- Wire tutorial tick into game loop and document flow/reset options

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: verification report with existing violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bc99a1be908326b8ba991c1b2334da