### PR TITLE
feat: add parchment tutorial overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,8 @@
           </div>
         </div>
 
+        <div id="currentObjective" class="current-objective" style="display:none;"></div>
+
         <!-- Leveling Activities Group -->
       <div class="activity-group">
         <h4 class="group-title"><iconify-icon icon="ri:hand-line" class="ui-icon" width="20"></iconify-icon> Training & Skills</h4>

--- a/src/features/tutorial/logic.js
+++ b/src/features/tutorial/logic.js
@@ -1,44 +1,22 @@
-import { log } from '../../shared/utils/dom.js';
-
-const STEP_TEXT = [
-  'Begin cultivating to start your journey.',
-  'Foundation grows. Accumulate enough to advance.',
-  'Attempt a breakthrough when you are ready.',
-  'Reach Stage 1 of the next realm to finish.',
-];
+import { fCap, realmStage } from '../progression/selectors.js';
 
 export function tickTutorial(state) {
   const t = state.tutorial;
   if (!t || t.completed) return;
-  switch (t.step) {
-    case 0:
-      if (state.activities?.cultivation) {
-        t.step = 1;
-        log?.(STEP_TEXT[1], 'good');
-      }
-      break;
-    case 1:
-      if (state.foundation > 0) {
-        t.step = 2;
-        log?.(STEP_TEXT[2], 'good');
-      }
-      break;
-    case 2:
-      if (state.breakthrough?.inProgress) {
-        t.step = 3;
-        log?.(STEP_TEXT[3], 'good');
-      }
-      break;
-    case 3:
-      if ((state.realm?.tier ?? 0) >= 1) {
-        t.completed = true;
-        t.step = 4;
-        log?.('Tutorial complete!', 'good');
-      }
-      break;
+  if (t.step === 0) {
+    if (!t.rewardReady && state.foundation >= fCap(state) * 0.99) {
+      t.rewardReady = true;
+      t.showOverlay = true;
+    }
+  } else if (t.step === 1) {
+    if (!t.rewardReady && realmStage(state) >= 2) {
+      t.rewardReady = true;
+      t.showOverlay = true;
+    }
   }
 }
 
 export function resetTutorial(state) {
-  state.tutorial = { step: 0, completed: false };
+  state.tutorial = { step: 0, completed: false, showOverlay: true, rewardReady: false };
 }
+

--- a/src/features/tutorial/state.js
+++ b/src/features/tutorial/state.js
@@ -1,4 +1,6 @@
 export const tutorialState = {
   step: 0,
   completed: false,
+  showOverlay: true,
+  rewardReady: false,
 };

--- a/src/ui/tutorialBox.js
+++ b/src/ui/tutorialBox.js
@@ -1,37 +1,137 @@
 import { on } from '../shared/events.js';
 
-const STEP_MESSAGES = [
-  'Start cultivating to begin the tutorial.',
-  'Foundation is accumulating. Keep cultivating!',
-  'Try a breakthrough once you have enough foundation.',
-  'Reach Stage 1 of the next realm.',
-  'Tutorial complete!'
+const STEPS = [
+  {
+    title: 'Journey to immortality',
+    text: 'Begin your practice by pressing the start cultivating button. While cultivating, you will gain foundation, which will accumulate until reaching max. Once you reach max you will be able to attempt breakthrough.',
+    req: 'Objective: Reach 100% foundation on stage 1.',
+    reward: 'Reward: 1 breakthrough pill.',
+    highlight: 'startCultivationActivity',
+    applyReward(state) {
+      state.pills = state.pills || { qi: 0, body: 0, ward: 0 };
+      state.pills.ward = (state.pills.ward || 0) + 1;
+    },
+  },
+  {
+    title: 'Breakthrough to stage 2',
+    text: 'When enough foundation in practice has been gained, you can attempt to ascend to higher states of being. This is called a breakthrough, and only the boldest of spirit may attempt to pursue. Every breakthrough has a chance to be succesfull. However, there are ways to increase this that will become available as you progress. Each breakthrough is more difficult than the previous one. A breakthrough pill will help in increasing odds',
+    req: 'Objective: Attempt breakthrough. Breakthrough chances can be viewed in the "stats" sub tab in cultivation.',
+    reward: 'Reward: Unlock astral tree. 50 insight.',
+    highlight: 'breakthroughBtnActivity',
+    applyReward(state) {
+      state.astralPoints = (state.astralPoints || 0) + 50;
+      const btn = document.getElementById('openAstralTree');
+      if (btn) btn.style.display = 'block';
+    },
+  },
 ];
 
 export function mountTutorialBox(state) {
-  if (document.getElementById('tutorialBox')) return;
-  const box = document.createElement('div');
-  box.id = 'tutorialBox';
-  box.style.position = 'fixed';
-  box.style.bottom = '10px';
-  box.style.left = '10px';
-  box.style.padding = '8px';
-  box.style.background = 'rgba(0,0,0,0.7)';
-  box.style.color = '#fff';
-  box.style.borderRadius = '4px';
-  box.style.zIndex = '1000';
-  document.body.appendChild(box);
+  if (document.getElementById('tutorialOverlay')) return;
+  const overlay = document.createElement('div');
+  overlay.id = 'tutorialOverlay';
+  overlay.className = 'modal-overlay';
+  overlay.style.display = 'none';
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'modal-backdrop';
+
+  const card = document.createElement('div');
+  card.className = 'modal-content tutorial-card';
+
+  const header = document.createElement('div');
+  header.className = 'card-header';
+  const titleEl = document.createElement('h4');
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'btn small ghost';
+  closeBtn.textContent = '×';
+  header.appendChild(titleEl);
+  header.appendChild(closeBtn);
+  card.appendChild(header);
+
+  const bodyEl = document.createElement('p');
+  const reqEl = document.createElement('p');
+  const rewardEl = document.createElement('p');
+  rewardEl.className = 'reward';
+  const claimBtn = document.createElement('button');
+  claimBtn.id = 'claimTutorialReward';
+  claimBtn.className = 'btn primary';
+  claimBtn.textContent = 'Claim Reward';
+  claimBtn.disabled = true;
+  card.append(bodyEl, reqEl, rewardEl, claimBtn);
+
+  overlay.append(backdrop, card);
+  document.body.appendChild(overlay);
+
+  function renderObjective() {
+    const el = document.getElementById('currentObjective');
+    if (!el) return;
+    if (state.tutorial.completed) {
+      el.style.display = 'none';
+      return;
+    }
+    const step = STEPS[state.tutorial.step];
+    el.textContent = step.title;
+    el.style.display = 'block';
+  }
+
+  function updateHighlight() {
+    ['startCultivationActivity', 'breakthroughBtnActivity'].forEach(id => {
+      document.getElementById(id)?.classList.remove('tutorial-highlight');
+    });
+    if (state.tutorial.completed) return;
+    const id = STEPS[state.tutorial.step].highlight;
+    document.getElementById(id)?.classList.add('tutorial-highlight');
+  }
 
   function render() {
     const t = state.tutorial;
-    if (!t || t.completed) {
-      box.style.display = 'none';
+    if (!t) return;
+    if (t.completed) {
+      overlay.style.display = 'none';
+      updateHighlight();
+      renderObjective();
       return;
     }
-    box.textContent = STEP_MESSAGES[t.step] || '';
-    box.style.display = 'block';
+    if (t.showOverlay) {
+      const step = STEPS[t.step];
+      titleEl.textContent = step.title;
+      bodyEl.textContent = step.text;
+      reqEl.textContent = step.req;
+      rewardEl.textContent = step.reward;
+      claimBtn.disabled = !t.rewardReady;
+      overlay.style.display = 'flex';
+    } else {
+      overlay.style.display = 'none';
+    }
+    updateHighlight();
+    renderObjective();
   }
+
+  function closeOverlay() {
+    state.tutorial.showOverlay = false;
+    render();
+  }
+
+  closeBtn.addEventListener('click', closeOverlay);
+  backdrop.addEventListener('click', closeOverlay);
+
+  claimBtn.addEventListener('click', () => {
+    if (!state.tutorial.rewardReady) return;
+    const step = STEPS[state.tutorial.step];
+    step.applyReward(state);
+    state.tutorial.step++;
+    state.tutorial.rewardReady = false;
+    if (state.tutorial.step >= STEPS.length) {
+      state.tutorial.completed = true;
+      state.tutorial.showOverlay = false;
+    } else {
+      state.tutorial.showOverlay = true;
+    }
+    render();
+  });
 
   on('RENDER', render);
   render();
 }
+

--- a/style.css
+++ b/style.css
@@ -4940,3 +4940,48 @@ html.reduce-motion .log-sheet{transition:none;}
 .building-card{border:1px solid #374151;background:var(--secondary-bg);padding:12px;border-radius:6px;width:100%;box-sizing:border-box}
 @media(min-width:768px){.building-card{width:40%}}
 .building-card .materials{margin:8px 0;color:#6b7280;font-size:.9rem}
+
+.tutorial-highlight {
+  animation: tutorialPulse 1s infinite alternate;
+  box-shadow: 0 0 8px 2px gold;
+}
+
+@keyframes tutorialPulse {
+  from { box-shadow: 0 0 8px 2px gold; }
+  to { box-shadow: 0 0 2px 1px gold; }
+}
+
+#tutorialOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+#tutorialOverlay .modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+}
+
+#tutorialOverlay .tutorial-card {
+  background: var(--parchment-light);
+  border: 2px solid #b38b5d;
+  padding: 20px;
+  max-width: 400px;
+  text-align: center;
+  z-index: 1;
+}
+
+.current-objective {
+  margin: 10px 0;
+  padding: 6px;
+  background: var(--parchment-light);
+  border: 1px solid #c8b68c;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add parchment-styled tutorial overlay with objectives and reward claims
- track current objective in sidebar and highlight relevant buttons
- expand tutorial state and logic for foundation and breakthrough steps

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68bcb671870083269da5094aeab1c25f