### PR TITLE
feat: focus breakthrough silhouette

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
           <div class="cultivation-layout">
           <div class="cultivation-visualization-container">
               <div class="cultivation-visualization" id="cultivationVisualization">
+                <div class="breakthrough-progress" id="breakthroughProgress"><div class="fill" id="breakthroughProgressFill"></div></div>
                 <button id="openAstralTree" class="astral-tree-btn" aria-label="Astral Tree" style="display:none;"></button>
                 <div id="astralInsightMini" class="astral-insight-mini" style="display:none;"></div>
 

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -461,6 +461,9 @@ export function tryBreakthrough(){
   S.breakthrough.timeRemaining = duration;
   S.breakthrough.totalTime = duration;
 
+  const progressFill = document.getElementById('breakthroughProgressFill');
+  if (progressFill) progressFill.style.width = '0%';
+
   if(S.pills.ward>0){ S.pills.ward--; }
 
   log(`Breakthrough initiated! Duration: ${duration.toFixed(1)} seconds...`, 'neutral');
@@ -470,6 +473,12 @@ export function updateBreakthrough() {
   if(!S.breakthrough || !S.breakthrough.inProgress) return;
 
   S.breakthrough.timeRemaining -= 1;
+
+  const progressFill = document.getElementById('breakthroughProgressFill');
+  if (progressFill && S.breakthrough.totalTime > 0) {
+    const pct = (1 - (S.breakthrough.timeRemaining / S.breakthrough.totalTime)) * 100;
+    progressFill.style.width = Math.max(0, Math.min(100, pct)) + '%';
+  }
 
   if(S.breakthrough.timeRemaining <= 0) {
     const ch = breakthroughChance(S);

--- a/style.css
+++ b/style.css
@@ -559,6 +559,55 @@ html.reduce-motion .rune-ring .orbit {
   stroke-linejoin: round;
 }
 
+/* Breakthrough focus vignette */
+.breakthrough {
+  overflow: visible;
+}
+
+.breakthrough::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at center, rgba(0,0,0,0) 30%, rgba(0,0,0,0.85) 100%),
+    rgba(0,0,0,0.5);
+  pointer-events: none;
+  z-index: 2000;
+}
+
+.breakthrough .lotus-silhouette {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2001;
+}
+
+.breakthrough-progress {
+  display: none;
+  position: fixed;
+  top: calc(50% + 120px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 300px;
+  height: 12px;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  overflow: hidden;
+  z-index: 2002;
+}
+
+.breakthrough-progress .fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(to right, var(--accent-2), var(--accent));
+}
+
+.breakthrough .breakthrough-progress {
+  display: block;
+}
+
 /* MYSTIC-REALM-UPDATE: Lotus silhouette with breathing animation */
 .lotus-silhouette {
   position: absolute;


### PR DESCRIPTION
## Summary
- Center the cultivation silhouette and add a dark vignette during breakthrough attempts
- Display a breakthrough progress bar beneath the silhouette with dynamic fill
- Update breakthrough logic to drive the progress bar
- Deepen the breakthrough overlay to dim the entire screen for emphasis

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9983fb8c83268c92944b5771bdca