### PR TITLE
feat: add clickable current objective label

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,8 @@
           </div>
         </div>
 
-        <div id="currentObjective" class="current-objective" style="display:none;"></div>
+        <div id="currentObjectiveLabel" class="current-objective-label" style="display:none;">current objective</div>
+        <div id="currentObjective" class="current-objective" style="display:none;" role="button" tabindex="0"></div>
 
         <!-- Leveling Activities Group -->
       <div class="activity-group">

--- a/src/ui/tutorialBox.js
+++ b/src/ui/tutorialBox.js
@@ -65,14 +65,17 @@ export function mountTutorialBox(state) {
 
   function renderObjective() {
     const el = document.getElementById('currentObjective');
-    if (!el) return;
+    const label = document.getElementById('currentObjectiveLabel');
+    if (!el || !label) return;
     if (state.tutorial.completed) {
       el.style.display = 'none';
+      label.style.display = 'none';
       return;
     }
     const step = STEPS[state.tutorial.step];
     el.textContent = step.title;
     el.style.display = 'block';
+    label.style.display = 'block';
   }
 
   function updateHighlight() {
@@ -106,6 +109,21 @@ export function mountTutorialBox(state) {
     }
     updateHighlight();
     renderObjective();
+  }
+
+  const objectiveEl = document.getElementById('currentObjective');
+  if (objectiveEl) {
+    const openOverlay = () => {
+      state.tutorial.showOverlay = true;
+      render();
+    };
+    objectiveEl.addEventListener('click', openOverlay);
+    objectiveEl.addEventListener('keypress', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openOverlay();
+      }
+    });
   }
 
   function closeOverlay() {

--- a/style.css
+++ b/style.css
@@ -4984,4 +4984,11 @@ html.reduce-motion .log-sheet{transition:none;}
   background: var(--parchment-light);
   border: 1px solid #c8b68c;
   font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.current-objective-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 10px 0 0;
 }


### PR DESCRIPTION
## Summary
- add "current objective" label above sidebar objective
- make objective element clickable and focusable, opening tutorial overlay
- style objective and label for pointer cursor and small heading

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd51efbe483268e561a4e97b0ca7e