### PR TITLE
feat: track tutorial objectives and rewards

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -310,7 +310,8 @@ way-of-ascension/
 │   │       └── state.js
 │   │   ├── tutorial/
 │   │   │   ├── logic.js
-│   │   │   └── state.js
+│   │   │   ├── state.js
+│   │   │   └── steps.js
 │   ├── game/
 │   │   ├── GameController.js
 │   │   └── migrations.js
@@ -1243,4 +1244,5 @@ Paths added:
 - `docs/tutorial.md` – explains the tutorial flow and reset options.
 - `src/features/tutorial/state.js` – stores tutorial step and completion flag.
 - `src/features/tutorial/logic.js` – evaluates player actions and advances steps.
+- `src/features/tutorial/steps.js` – lists objectives and rewards for each tutorial step.
 - `src/ui/tutorialBox.js` – displays on-screen guidance during the tutorial.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -3,7 +3,7 @@
 The game includes a simple tutorial that guides new players through the opening steps of cultivation.
 
 1. **Start cultivating** – toggle the cultivation activity.
-2. **Gain foundation** – accumulate any amount of foundation.
+2. **Reach 100% foundation** – fill the foundation bar to its maximum.
 3. **Attempt a breakthrough** – begin a breakthrough once ready.
 4. **Reach stage 1 of the next realm** – succeeding the breakthrough completes the tutorial.
 

--- a/src/features/tutorial/logic.js
+++ b/src/features/tutorial/logic.js
@@ -1,18 +1,13 @@
-import { fCap, realmStage } from '../progression/selectors.js';
+import { TUTORIAL_STEPS } from './steps.js';
 
 export function tickTutorial(state) {
   const t = state.tutorial;
   if (!t || t.completed) return;
-  if (t.step === 0) {
-    if (!t.rewardReady && state.foundation >= fCap(state) * 0.99) {
-      t.rewardReady = true;
-      t.showOverlay = true;
-    }
-  } else if (t.step === 1) {
-    if (!t.rewardReady && realmStage(state) >= 2) {
-      t.rewardReady = true;
-      t.showOverlay = true;
-    }
+  const step = TUTORIAL_STEPS[t.step];
+  if (!step) return;
+  if (!t.rewardReady && step.check(state)) {
+    t.rewardReady = true;
+    t.showOverlay = true;
   }
 }
 

--- a/src/features/tutorial/steps.js
+++ b/src/features/tutorial/steps.js
@@ -1,0 +1,33 @@
+import { fCap, realmStage } from '../progression/selectors.js';
+
+export const TUTORIAL_STEPS = [
+  {
+    title: 'Journey to immortality',
+    text: 'Begin your practice by pressing the start cultivating button. While cultivating, you will gain foundation, which will accumulate until reaching max. Once you reach max you will be able to attempt breakthrough.',
+    req: 'Objective: Reach 100% foundation.',
+    reward: 'Reward: 1 breakthrough pill.',
+    highlight: 'startCultivationActivity',
+    check(state) {
+      return state.foundation >= fCap(state) * 0.99;
+    },
+    applyReward(state) {
+      state.pills = state.pills || { qi: 0, body: 0, ward: 0 };
+      state.pills.ward = (state.pills.ward || 0) + 1;
+    },
+  },
+  {
+    title: 'Breakthrough to stage 2',
+    text: 'When enough foundation in practice has been gained, you can attempt to ascend to higher states of being. This is called a breakthrough, and only the boldest of spirit may attempt to pursue. Every breakthrough has a chance to be succesfull. However, there are ways to increase this that will become available as you progress. Each breakthrough is more difficult than the previous one. A breakthrough pill will help in increasing odds',
+    req: 'Objective: Attempt breakthrough. Breakthrough chances can be viewed in the "stats" sub tab in cultivation.',
+    reward: 'Reward: Unlock astral tree. 50 insight.',
+    highlight: 'breakthroughBtnActivity',
+    check(state) {
+      return realmStage(state) >= 2;
+    },
+    applyReward(state) {
+      state.astralPoints = (state.astralPoints || 0) + 50;
+      const btn = document.getElementById('openAstralTree');
+      if (btn) btn.style.display = 'block';
+    },
+  },
+];

--- a/src/ui/tutorialBox.js
+++ b/src/ui/tutorialBox.js
@@ -1,30 +1,7 @@
 import { on } from '../shared/events.js';
+import { TUTORIAL_STEPS } from '../features/tutorial/steps.js';
 
-const STEPS = [
-  {
-    title: 'Journey to immortality',
-    text: 'Begin your practice by pressing the start cultivating button. While cultivating, you will gain foundation, which will accumulate until reaching max. Once you reach max you will be able to attempt breakthrough.',
-    req: 'Objective: Reach 100% foundation on stage 1.',
-    reward: 'Reward: 1 breakthrough pill.',
-    highlight: 'startCultivationActivity',
-    applyReward(state) {
-      state.pills = state.pills || { qi: 0, body: 0, ward: 0 };
-      state.pills.ward = (state.pills.ward || 0) + 1;
-    },
-  },
-  {
-    title: 'Breakthrough to stage 2',
-    text: 'When enough foundation in practice has been gained, you can attempt to ascend to higher states of being. This is called a breakthrough, and only the boldest of spirit may attempt to pursue. Every breakthrough has a chance to be succesfull. However, there are ways to increase this that will become available as you progress. Each breakthrough is more difficult than the previous one. A breakthrough pill will help in increasing odds',
-    req: 'Objective: Attempt breakthrough. Breakthrough chances can be viewed in the "stats" sub tab in cultivation.',
-    reward: 'Reward: Unlock astral tree. 50 insight.',
-    highlight: 'breakthroughBtnActivity',
-    applyReward(state) {
-      state.astralPoints = (state.astralPoints || 0) + 50;
-      const btn = document.getElementById('openAstralTree');
-      if (btn) btn.style.display = 'block';
-    },
-  },
-];
+const STEPS = TUTORIAL_STEPS;
 
 export function mountTutorialBox(state) {
   if (document.getElementById('tutorialOverlay')) return;
@@ -79,8 +56,8 @@ export function mountTutorialBox(state) {
   }
 
   function updateHighlight() {
-    ['startCultivationActivity', 'breakthroughBtnActivity'].forEach(id => {
-      document.getElementById(id)?.classList.remove('tutorial-highlight');
+    STEPS.forEach(step => {
+      document.getElementById(step.highlight)?.classList.remove('tutorial-highlight');
     });
     if (state.tutorial.completed) return;
     const id = STEPS[state.tutorial.step].highlight;


### PR DESCRIPTION
## Summary
- centralize tutorial objective definitions
- check objective requirements to enable rewards
- document tutorial steps in project structure
- let first tutorial objective complete when foundation reaches 100% at any stage

## Testing
- `npm test` (fails: no test specified)
- `npm run validate` (fails: app.js imports feature internals, UI state violations, DOM in adventure logic)


------
https://chatgpt.com/codex/tasks/task_e_68bd176414c8832686d5ac3f48d6775f