### PR TITLE
feat: add foundation and breakthrough dev tools

### DIFF
--- a/src/ui/dev/devQuickMenu.js
+++ b/src/ui/dev/devQuickMenu.js
@@ -8,8 +8,11 @@ import { rollWeaponDropForZone } from '../../features/weaponGeneration/selectors
 import { rollGearDropForZone } from '../../features/gearGeneration/selectors.js';
 import { addToInventory } from '../../features/inventory/mutators.js';
 import { ZONES as ZONE_IDS } from '../../features/adventure/data/zoneIds.js';
-import { qCap } from '../../features/progression/selectors.js';
+import { qCap, fCap } from '../../features/progression/selectors.js';
+import { advanceRealm } from '../../features/progression/mutators.js';
+import { mountAllFeatureUIs } from '../../features/index.js';
 import { updateQiAndFoundation } from '../../features/progression/ui/qiDisplay.js';
+import { log } from '../../shared/utils/dom.js';
 
 let mounted = false;
 
@@ -140,6 +143,32 @@ export function mountDevQuickMenu() {
   });
   qiWrap.append(qiBtn);
   panel.appendChild(row("Qi", qiWrap));
+
+  // Foundation helpers
+  const foundationWrap = el("div");
+  foundationWrap.style.display = "flex";
+  foundationWrap.style.gap = "6px";
+  const foundationBtn = smallBtn("Max", () => {
+    S.foundation = fCap(S);
+    updateQiAndFoundation();
+  });
+  foundationWrap.append(foundationBtn);
+  panel.appendChild(row("Foundation", foundationWrap));
+
+  // Breakthrough helpers
+  const btWrap = el("div");
+  btWrap.style.display = "flex";
+  btWrap.style.gap = "6px";
+  const btBtn = smallBtn("Success", () => {
+    const info = advanceRealm(S);
+    S.qi = 0;
+    S.foundation = 0;
+    mountAllFeatureUIs(S);
+    updateQiAndFoundation();
+    log(`[dev] Breakthrough to ${info.realmName} ${info.stage}`, 'good');
+  });
+  btWrap.append(btBtn);
+  panel.appendChild(row("Breakthrough", btWrap));
 
   // Loot generators
   const lootWrap = el("div");

--- a/validation.log
+++ b/validation.log
@@ -5,6 +5,7 @@
 ❌ VERIFICATION FAILED - MUST fix before proceeding
 
 🚨 VIOLATIONS DETECTED:
+   • app.js imports feature internals (mutators/logic/selectors). Only import registry, sidebar, debug, controller.
    • UI write violation: src/features/activity/ui/activityUI.js mutates root.* (use mutators)
    • UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js
    • UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js


### PR DESCRIPTION
## Summary
- extend dev quick menu with buttons to max foundation and trigger successful breakthrough
- update validation log

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: verification protocol violations)


------
https://chatgpt.com/codex/tasks/task_e_68bdafacb0f883268ace6cad1de5cd3d