### PR TITLE
feat: enforce tutorial objective checks

### DIFF
--- a/src/features/tutorial/logic.js
+++ b/src/features/tutorial/logic.js
@@ -1,18 +1,13 @@
-import { fCap, realmStage } from '../progression/selectors.js';
+import { STEPS } from './steps.js';
 
 export function tickTutorial(state) {
   const t = state.tutorial;
   if (!t || t.completed) return;
-  if (t.step === 0) {
-    if (!t.rewardReady && state.foundation >= fCap(state) * 0.99) {
-      t.rewardReady = true;
-      t.showOverlay = true;
-    }
-  } else if (t.step === 1) {
-    if (!t.rewardReady && realmStage(state) >= 2) {
-      t.rewardReady = true;
-      t.showOverlay = true;
-    }
+  const step = STEPS[t.step];
+  if (!step) return;
+  if (!t.rewardReady && step.check(state)) {
+    t.rewardReady = true;
+    t.showOverlay = true;
   }
 }
 

--- a/src/features/tutorial/steps.js
+++ b/src/features/tutorial/steps.js
@@ -1,0 +1,29 @@
+import { fCap, realmStage } from '../progression/selectors.js';
+
+export const STEPS = [
+  {
+    title: 'Journey to immortality',
+    text: 'Begin your practice by pressing the start cultivating button. While cultivating, you will gain foundation, which will accumulate until reaching max. Once you reach max you will be able to attempt breakthrough.',
+    req: 'Objective: Reach 100% foundation on stage 1.',
+    reward: 'Reward: 1 breakthrough pill.',
+    highlight: 'startCultivationActivity',
+    check: state => state.foundation >= fCap(state) * 0.99,
+    applyReward(state) {
+      state.pills = state.pills || { qi: 0, body: 0, ward: 0 };
+      state.pills.ward = (state.pills.ward || 0) + 1;
+    },
+  },
+  {
+    title: 'Breakthrough to stage 2',
+    text: 'When enough foundation in practice has been gained, you can attempt to ascend to higher states of being. This is called a breakthrough, and only the boldest of spirit may attempt to pursue. Every breakthrough has a chance to be succesfull. However, there are ways to increase this that will become available as you progress. Each breakthrough is more difficult than the previous one. A breakthrough pill will help in increasing odds',
+    req: 'Objective: Attempt breakthrough. Breakthrough chances can be viewed in the "stats" sub tab in cultivation.',
+    reward: 'Reward: Unlock astral tree. 50 insight.',
+    highlight: 'breakthroughBtnActivity',
+    check: state => realmStage(state) >= 2,
+    applyReward(state) {
+      state.astralPoints = (state.astralPoints || 0) + 50;
+      const btn = document.getElementById('openAstralTree');
+      if (btn) btn.style.display = 'block';
+    },
+  },
+];

--- a/src/ui/tutorialBox.js
+++ b/src/ui/tutorialBox.js
@@ -1,30 +1,5 @@
 import { on } from '../shared/events.js';
-
-const STEPS = [
-  {
-    title: 'Journey to immortality',
-    text: 'Begin your practice by pressing the start cultivating button. While cultivating, you will gain foundation, which will accumulate until reaching max. Once you reach max you will be able to attempt breakthrough.',
-    req: 'Objective: Reach 100% foundation on stage 1.',
-    reward: 'Reward: 1 breakthrough pill.',
-    highlight: 'startCultivationActivity',
-    applyReward(state) {
-      state.pills = state.pills || { qi: 0, body: 0, ward: 0 };
-      state.pills.ward = (state.pills.ward || 0) + 1;
-    },
-  },
-  {
-    title: 'Breakthrough to stage 2',
-    text: 'When enough foundation in practice has been gained, you can attempt to ascend to higher states of being. This is called a breakthrough, and only the boldest of spirit may attempt to pursue. Every breakthrough has a chance to be succesfull. However, there are ways to increase this that will become available as you progress. Each breakthrough is more difficult than the previous one. A breakthrough pill will help in increasing odds',
-    req: 'Objective: Attempt breakthrough. Breakthrough chances can be viewed in the "stats" sub tab in cultivation.',
-    reward: 'Reward: Unlock astral tree. 50 insight.',
-    highlight: 'breakthroughBtnActivity',
-    applyReward(state) {
-      state.astralPoints = (state.astralPoints || 0) + 50;
-      const btn = document.getElementById('openAstralTree');
-      if (btn) btn.style.display = 'block';
-    },
-  },
-];
+import { STEPS } from '../features/tutorial/steps.js';
 
 export function mountTutorialBox(state) {
   if (document.getElementById('tutorialOverlay')) return;
@@ -73,18 +48,20 @@ export function mountTutorialBox(state) {
       return;
     }
     const step = STEPS[state.tutorial.step];
+    if (!step) return;
     el.textContent = step.title;
     el.style.display = 'block';
     label.style.display = 'block';
   }
 
   function updateHighlight() {
-    ['startCultivationActivity', 'breakthroughBtnActivity'].forEach(id => {
-      document.getElementById(id)?.classList.remove('tutorial-highlight');
+    STEPS.forEach(s => {
+      document.getElementById(s.highlight)?.classList.remove('tutorial-highlight');
     });
     if (state.tutorial.completed) return;
-    const id = STEPS[state.tutorial.step].highlight;
-    document.getElementById(id)?.classList.add('tutorial-highlight');
+    const step = STEPS[state.tutorial.step];
+    if (!step) return;
+    document.getElementById(step.highlight)?.classList.add('tutorial-highlight');
   }
 
   function render() {
@@ -98,10 +75,12 @@ export function mountTutorialBox(state) {
     }
     if (t.showOverlay) {
       const step = STEPS[t.step];
-      titleEl.textContent = step.title;
-      bodyEl.textContent = step.text;
-      reqEl.textContent = step.req;
-      rewardEl.textContent = step.reward;
+      if (step) {
+        titleEl.textContent = step.title;
+        bodyEl.textContent = step.text;
+        reqEl.textContent = step.req;
+        rewardEl.textContent = step.reward;
+      }
       claimBtn.disabled = !t.rewardReady;
       overlay.style.display = 'flex';
     } else {
@@ -135,16 +114,17 @@ export function mountTutorialBox(state) {
   backdrop.addEventListener('click', closeOverlay);
 
   claimBtn.addEventListener('click', () => {
-    if (!state.tutorial.rewardReady) return;
-    const step = STEPS[state.tutorial.step];
-    step.applyReward(state);
-    state.tutorial.step++;
-    state.tutorial.rewardReady = false;
-    if (state.tutorial.step >= STEPS.length) {
-      state.tutorial.completed = true;
-      state.tutorial.showOverlay = false;
+    const t = state.tutorial;
+    if (!t.rewardReady) return;
+    const step = STEPS[t.step];
+    step.applyReward?.(state);
+    t.step++;
+    t.rewardReady = false;
+    if (t.step >= STEPS.length) {
+      t.completed = true;
+      t.showOverlay = false;
     } else {
-      state.tutorial.showOverlay = true;
+      t.showOverlay = true;
     }
     render();
   });

--- a/style.css
+++ b/style.css
@@ -2613,8 +2613,12 @@ html.reduce-motion .shield-shimmer{animation:none;}
 }
 .btn:hover{
   background: linear-gradient(180deg, rgba(250, 245, 225, 0.8), rgba(225, 215, 195, 0.8));
-  transform:translateY(-1px); 
+  transform:translateY(-1px);
   box-shadow: 0 4px 8px rgba(0,0,0,0.15), inset 0 1px 1px rgba(255,255,255,0.6);
+}
+.btn:disabled{
+  opacity:0.5;
+  cursor:not-allowed;
 }
 .btn.primary{background:linear-gradient(90deg,var(--accent-2),var(--accent)); border-color:transparent; color: #f8f5f0;}
 .btn.warn{background:#ebe0c8; border-color:var(--danger); color:var(--danger);}


### PR DESCRIPTION
## Summary
- centralize tutorial step definitions with requirement checks and rewards
- enable claim button when objectives complete and move to next step on claim
- unify highlight handling via shared step data
- gray out claim button until reward is available and safely apply rewards on click

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68bdb2de78808326a5b5ac39d958fd35