### PR TITLE
Ensure tutorial rewards activate

### DIFF
--- a/src/features/index.js
+++ b/src/features/index.js
@@ -35,6 +35,7 @@ import { startActivity } from "./activity/mutators.js";
 import { tickInsight } from "./progression/insight.js";
 import { updateBreakthrough } from "./progression/index.js";
 import { updateAdventureCombat } from "./adventure/logic.js";
+import { tickTutorial } from "./tutorial/logic.js";
 import { onTick as mindOnTick } from "./mind/index.js";
 import { log } from "../shared/utils/dom.js";
 import { mountTutorialBox } from "../ui/tutorialBox.js";
@@ -312,6 +313,8 @@ export function runAllFeatureTicks(state, stepMs) {
   tickInsight(state, stepSec);
 
   updateBreakthrough();
+
+  tickTutorial(state);
 
   if (state.activities.adventure && state.adventure && state.adventure.inCombat) {
     updateAdventureCombat();


### PR DESCRIPTION
## Summary
- Run tutorial tick during each feature update so objectives enable their rewards

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UNDOCUMENTED FILE: src/features/tutorial/steps.js, app.js imports feature internals, UI state violations, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68be21c2432c8326979e8b2d272268a1