### PR TITLE
Improve tutorial overlay readability

### DIFF
--- a/src/ui/tutorialBox.js
+++ b/src/ui/tutorialBox.js
@@ -27,6 +27,7 @@ export function mountTutorialBox(state) {
   const bodyEl = document.createElement('p');
   const reqEl = document.createElement('p');
   const rewardEl = document.createElement('p');
+  reqEl.className = 'objective';
   rewardEl.className = 'reward';
   const claimBtn = document.createElement('button');
   claimBtn.id = 'claimTutorialReward';

--- a/style.css
+++ b/style.css
@@ -5023,12 +5023,18 @@ html.reduce-motion .log-sheet{transition:none;}
 }
 
 #tutorialOverlay .tutorial-card {
-  background: var(--parchment-light);
+  background: #fff;
   border: 2px solid #b38b5d;
   padding: 20px;
   max-width: 400px;
   text-align: center;
   z-index: 1;
+}
+
+#tutorialOverlay .objective,
+#tutorialOverlay .reward {
+  color: #ff8c00;
+  font-style: italic;
 }
 
 .current-objective {


### PR DESCRIPTION
## Summary
- Give the tutorial objective overlay a solid white background
- Highlight objective and reward text in dark orange italics for easy scanning

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68be2359f6f08326ab09ad718fc469d1