### PR TITLE
feat: add alchemy state slice

### DIFF
--- a/src/features/alchemy/logic.js
+++ b/src/features/alchemy/logic.js
@@ -1,20 +1,18 @@
 import { alchemyState } from './state.js';
 
-function slice(state){
+function slice(state) {
   return state.alchemy || alchemyState;
 }
 
-export function tickAlchemy(state, stepMs = 100){
+export function tickAlchemy(state, stepMs = 100) {
   const dt = stepMs / 1000;
   const alch = slice(state);
-  alch.labTimer = (alch.labTimer || 0) + dt;
-  alch.queue.forEach(q => {
-    if(!q.done){
-      q.t -= dt;
-      if(q.t <= 0){
-        q.t = 0;
-        q.done = true;
-      }
+  const lab = alch.lab;
+  if (lab.paused) return;
+  lab.activeJobs.forEach(job => {
+    if (job.remaining > 0) {
+      job.remaining = Math.max(0, job.remaining - dt);
+      if (job.remaining === 0) job.done = true;
     }
   });
 }

--- a/src/features/alchemy/selectors.js
+++ b/src/features/alchemy/selectors.js
@@ -1,28 +1,33 @@
+import { S } from '../../shared/state.js';
 import { alchemyState } from './state.js';
 import { getBuildingBonuses } from '../sect/selectors.js';
 
-function slice(state){
+function slice(state = S) {
   return state.alchemy || alchemyState;
 }
 
-export function getQueue(state = alchemyState){
-  return slice(state).queue || [];
+export function getAlchemyLevel(state = S) {
+  return slice(state).level;
 }
 
-export function getMaxSlots(state = alchemyState){
-  const base = slice(state).maxSlots || 0;
-  return base + (getBuildingBonuses(state).alchemySlots || 0);
+export function getLab(state = S) {
+  return slice(state).lab;
 }
 
-export function getSuccessBonus(state = alchemyState){
-  const alch = slice(state);
+export function getKnownRecipes(state = S) {
+  return slice(state).knownRecipes;
+}
+
+export function getOutputs(state = S) {
+  return slice(state).outputs;
+}
+
+export function getResistanceFor(lineKey, state = S) {
+  return slice(state).resistance?.[lineKey] || { rp: 0, rpCap: 0 };
+}
+
+export function getSuccessBonus(state = S) {
   const building = getBuildingBonuses(state).alchemySuccess || 0;
   const mind = (state.stats?.mind || 10) - 10;
-  const mindBonus = mind * 0.04;
-  return alch.successBonus + building + mindBonus;
-}
-
-export function getSuccessChance(recipe, state = alchemyState){
-  const bonus = getSuccessBonus(state);
-  return Math.min(recipe.base + bonus, 0.95);
+  return building + mind * 0.04;
 }

--- a/src/features/alchemy/state.js
+++ b/src/features/alchemy/state.js
@@ -1,10 +1,14 @@
 export const alchemyState = {
   level: 1,
-  xp: 0,
-  queue: [],
-  maxSlots: 1,
-  successBonus: 0,
-  unlocked: false,
-  knownRecipes: ['qi'],
-  labTimer: 0,
+  exp: 0,
+  expMax: 100,
+  lab: {
+    slots: 2,
+    activeJobs: [],
+    paused: false,
+  },
+  knownRecipes: { qi: true },
+  outputs: {},
+  resistance: {},
+  settings: { qiDrainEnabled: false },
 };

--- a/src/features/alchemy/test.js
+++ b/src/features/alchemy/test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+import { alchemyState } from './state.js';
+import { startConcoct, finishConcoct, cancelConcoct, toggleQiDrain } from './mutators.js';
+import { getAlchemyLevel, getLab, getKnownRecipes, getOutputs, getResistanceFor } from './selectors.js';
+
+const root = { alchemy: structuredClone(alchemyState) };
+
+assert.strictEqual(getAlchemyLevel(root), 1);
+assert.strictEqual(getLab(root).slots, 2);
+assert.deepStrictEqual(getKnownRecipes(root), { qi: true });
+
+const id = startConcoct({ time: 1, output: { itemKey: 'potion', qty: 1, tier: 0 }, exp: 10 }, root);
+assert.strictEqual(getLab(root).activeJobs.length, 1);
+finishConcoct(id, root);
+assert.strictEqual(getLab(root).activeJobs.length, 0);
+assert.strictEqual(getOutputs(root).potion.qty, 1);
+
+const id2 = startConcoct({ time: 1 }, root);
+cancelConcoct(id2, root);
+assert.strictEqual(getLab(root).activeJobs.length, 0);
+
+toggleQiDrain(true, root);
+assert.strictEqual(root.alchemy.settings.qiDrainEnabled, true);
+assert.deepStrictEqual(getResistanceFor('qi', root), { rp: 0, rpCap: 0 });
+
+console.log('alchemy selectors/mutators ok');

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -12,6 +12,7 @@ import { agilityState } from '../features/agility/state.js';
 import { catchingState } from '../features/catching/state.js';
 import { sideLocationState } from '../features/sideLocations/state.js';
 import { tutorialState } from '../features/tutorial/state.js';
+import { alchemyState } from '../features/alchemy/state.js';
 
 export function loadSave(){
   try{
@@ -67,7 +68,7 @@ export const defaultState = () => {
   disciples:1,
   gather:{herbs:0, ore:0, wood:0},
   yieldMult:{herbs:0, ore:0, wood:0},
-  alchemy:{level:1, xp:0, queue:[], maxSlots:1, successBonus:0, unlocked:false, knownRecipes:['qi'], labTimer:0}, // Start with only Qi recipe
+  alchemy: structuredClone(alchemyState),
   abilityCooldowns:{},
   actionQueue:[],
   manualAbilityKeys:[],


### PR DESCRIPTION
## Summary
- define full alchemy state with lab slots, outputs, resistance and settings
- expose selectors and mutators for alchemy operations
- add smoke tests for alchemy selectors and mutators

## Testing
- `node src/features/alchemy/test.js`
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68be45d1ca508326a48d494a4640dc13