### PR TITLE
Add alchemy state slice with lab jobs and resistances

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -142,6 +142,7 @@ way-of-ascension/
 │   │   │   ├── mutators.js
 │   │   │   ├── selectors.js
 │   │   │   ├── state.js
+│   │   │   ├── alchemy.test.js
 │   │   │   ├── index.js
 │   │   │   └── ui/
 │   │   │       ├── cookControls.js
@@ -310,7 +311,8 @@ way-of-ascension/
 │   │       └── state.js
 │   │   ├── tutorial/
 │   │   │   ├── logic.js
-│   │   │   └── state.js
+│   │   │   ├── state.js
+│   │   │   └── steps.js
 │   ├── game/
 │   │   ├── GameController.js
 │   │   └── migrations.js
@@ -1123,11 +1125,12 @@ Paths added:
 ### Alchemy Feature
 - `src/features/alchemy/index.js` – Registers alchemy hooks.
 - `src/features/alchemy/data/recipes.js` – Basic pill recipes with brew times and rewards.
-- `src/features/alchemy/logic.js` – Tick handler that advances brew timers.
-- `src/features/alchemy/mutators.js` – Start/complete brews and unlock new recipes.
-- `src/features/alchemy/selectors.js` – Accessors for brewing queue and success chance calculations.
-- `src/features/alchemy/state.js` – Base alchemy stats including level, XP, and known recipes.
+- `src/features/alchemy/logic.js` – Tick handler that advances concoction timers.
+- `src/features/alchemy/mutators.js` – Start, finish, or cancel concoctions and toggle Qi drain.
+- `src/features/alchemy/selectors.js` – Accessors for alchemy level, lab jobs, recipes, outputs, and resistance data.
+- `src/features/alchemy/state.js` – Base alchemy stats including lab slots, known recipes, outputs, and resistances.
 - `src/features/alchemy/ui/alchemyDisplay.js` – UI for managing the alchemy cauldron.
+- `src/features/alchemy/alchemy.test.js` – Smoke tests for alchemy selectors and mutators.
 
 ### Cooking Feature (`src/features/cooking/`)
 - `src/features/cooking/state.js` – Cooking level, experience, and success bonus.
@@ -1243,4 +1246,5 @@ Paths added:
 - `docs/tutorial.md` – explains the tutorial flow and reset options.
 - `src/features/tutorial/state.js` – stores tutorial step and completion flag.
 - `src/features/tutorial/logic.js` – evaluates player actions and advances steps.
+- `src/features/tutorial/steps.js` – Step definitions used by the tutorial logic.
 - `src/ui/tutorialBox.js` – displays on-screen guidance during the tutorial.

--- a/src/features/alchemy/alchemy.test.js
+++ b/src/features/alchemy/alchemy.test.js
@@ -1,0 +1,36 @@
+import { strict as assert } from 'node:assert';
+import { alchemyState } from './state.js';
+import { getAlchemyLevel, getLab, getKnownRecipes, getOutputs, getResistanceFor } from './selectors.js';
+import { startConcoct, finishConcoct, cancelConcoct, toggleQiDrain } from './mutators.js';
+
+const state = { alchemy: structuredClone(alchemyState) };
+
+// selectors
+assert.equal(getAlchemyLevel(state), 1);
+assert.equal(getLab(state).slots, 2);
+assert.ok(getKnownRecipes(state).qi);
+assert.deepEqual(getResistanceFor('none', state), { rp: 0, rpCap: 0 });
+
+// toggle setting
+toggleQiDrain(state, false);
+assert.equal(state.alchemy.settings.qiDrainEnabled, false);
+
+// mutators
+const job = { id: 'j1', output: 'pill', tier: 1, qty: 2, exp: 50, t: 1 };
+assert.ok(startConcoct(state, job));
+assert.equal(getLab(state).activeJobs.length, 1);
+
+finishConcoct(state, 'j1');
+assert.equal(getLab(state).activeJobs.length, 0);
+assert.equal(getOutputs(state).pill.qty, 2);
+assert.equal(getAlchemyLevel(state), 1);
+
+startConcoct(state, { id: 'j2', output: 'x', t:1 });
+assert.equal(getLab(state).activeJobs.length, 1);
+cancelConcoct(state, 'j2');
+assert.equal(getLab(state).activeJobs.length, 0);
+
+state.alchemy.resistance.qi = { rp: 5, rpCap: 10 };
+assert.deepEqual(getResistanceFor('qi', state), { rp: 5, rpCap: 10 });
+
+console.log('Alchemy tests passed');

--- a/src/features/alchemy/logic.js
+++ b/src/features/alchemy/logic.js
@@ -6,15 +6,13 @@ function slice(state){
 
 export function tickAlchemy(state, stepMs = 100){
   const dt = stepMs / 1000;
-  const alch = slice(state);
-  alch.labTimer = (alch.labTimer || 0) + dt;
-  alch.queue.forEach(q => {
-    if(!q.done){
-      q.t -= dt;
-      if(q.t <= 0){
-        q.t = 0;
-        q.done = true;
-      }
+  const lab = slice(state).lab;
+  lab.activeJobs.forEach(job => {
+    if(job.done) return;
+    job.t -= dt;
+    if(job.t <= 0){
+      job.t = 0;
+      job.done = true;
     }
   });
 }

--- a/src/features/alchemy/selectors.js
+++ b/src/features/alchemy/selectors.js
@@ -5,24 +5,30 @@ function slice(state){
   return state.alchemy || alchemyState;
 }
 
-export function getQueue(state = alchemyState){
-  return slice(state).queue || [];
+export function getAlchemyLevel(state = alchemyState){
+  return slice(state).level;
 }
 
-export function getMaxSlots(state = alchemyState){
-  const base = slice(state).maxSlots || 0;
-  return base + (getBuildingBonuses(state).alchemySlots || 0);
+export function getLab(state = alchemyState){
+  return slice(state).lab;
+}
+
+export function getKnownRecipes(state = alchemyState){
+  return slice(state).knownRecipes;
+}
+
+export function getOutputs(state = alchemyState){
+  return slice(state).outputs;
+}
+
+export function getResistanceFor(lineKey, state = alchemyState){
+  const res = slice(state).resistance || {};
+  return res[lineKey] || { rp: 0, rpCap: 0 };
 }
 
 export function getSuccessBonus(state = alchemyState){
-  const alch = slice(state);
   const building = getBuildingBonuses(state).alchemySuccess || 0;
   const mind = (state.stats?.mind || 10) - 10;
   const mindBonus = mind * 0.04;
-  return alch.successBonus + building + mindBonus;
-}
-
-export function getSuccessChance(recipe, state = alchemyState){
-  const bonus = getSuccessBonus(state);
-  return Math.min(recipe.base + bonus, 0.95);
+  return building + mindBonus;
 }

--- a/src/features/alchemy/state.js
+++ b/src/features/alchemy/state.js
@@ -1,10 +1,16 @@
 export const alchemyState = {
   level: 1,
-  xp: 0,
-  queue: [],
-  maxSlots: 1,
-  successBonus: 0,
-  unlocked: false,
-  knownRecipes: ['qi'],
-  labTimer: 0,
+  exp: 0,
+  expMax: 100,
+  lab: {
+    slots: 2,
+    activeJobs: [],
+    paused: false,
+  },
+  knownRecipes: { qi: true },
+  outputs: {},
+  resistance: {},
+  settings: {
+    qiDrainEnabled: true,
+  },
 };

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -12,6 +12,7 @@ import { agilityState } from '../features/agility/state.js';
 import { catchingState } from '../features/catching/state.js';
 import { sideLocationState } from '../features/sideLocations/state.js';
 import { tutorialState } from '../features/tutorial/state.js';
+import { alchemyState } from '../features/alchemy/state.js';
 
 export function loadSave(){
   try{
@@ -67,7 +68,7 @@ export const defaultState = () => {
   disciples:1,
   gather:{herbs:0, ore:0, wood:0},
   yieldMult:{herbs:0, ore:0, wood:0},
-  alchemy:{level:1, xp:0, queue:[], maxSlots:1, successBonus:0, unlocked:false, knownRecipes:['qi'], labTimer:0}, // Start with only Qi recipe
+  alchemy: structuredClone(alchemyState),
   abilityCooldowns:{},
   actionQueue:[],
   manualAbilityKeys:[],
@@ -201,6 +202,7 @@ export function validateState(candidate) {
 export let S = loadSave() || defaultState();
 S.sect = { ...structuredClone(sectState), ...S.sect };
 S.karma = { ...structuredClone(karmaState), ...S.karma };
+S.alchemy = { ...structuredClone(alchemyState), ...S.alchemy };
 S.physique = { ...structuredClone(physiqueState), ...S.physique };
 S.agility = { ...structuredClone(agilityState), ...S.agility };
 S.catching = { ...structuredClone(catchingState), ...S.catching };


### PR DESCRIPTION
## Summary
- restructure alchemy state to track lab jobs, known recipes, outputs and resistances
- expose selectors and mutators for alchemy level, lab jobs, outputs and settings
- integrate alchemy slice into root state and add smoke tests

## Testing
- `npm test` (fails: no test specified)
- `node src/features/alchemy/alchemy.test.js`
- `npm run validate-fix` (fails: UI state violations)


------
https://chatgpt.com/codex/tasks/task_e_68be45d1ca508326a48d494a4640dc13