### PR TITLE
feat: add temporary pill stacking with exclusivity

### DIFF
--- a/src/features/alchemy/consumableEffects.js
+++ b/src/features/alchemy/consumableEffects.js
@@ -1,0 +1,42 @@
+import { STATUSES } from '../combat/data/status.js';
+import { applyStatus } from '../combat/statusEngine.js';
+
+export function applyConsumableEffect(target, statusKey, state) {
+  const def = STATUSES[statusKey];
+  if (!def) return false;
+
+  const group = def.exclusivityGroup;
+  const tier = def.tier ?? 0;
+
+  target.statuses ??= {};
+
+  let existingKey = null;
+  let existingTier = -Infinity;
+  for (const k of Object.keys(target.statuses)) {
+    const d = STATUSES[k];
+    if (!d) continue;
+    if (d.exclusivityGroup === group) {
+      existingKey = k;
+      existingTier = d.tier ?? 0;
+      break;
+    }
+  }
+
+  if (existingKey) {
+    if (existingKey === statusKey) {
+      applyStatus(target, statusKey, 1, state);
+      return true;
+    }
+    if (existingTier > tier) {
+      // Higher tier already active; ignore
+      return false;
+    }
+    const oldDef = STATUSES[existingKey];
+    oldDef?.onExpire?.({ target });
+    delete target.statuses[existingKey];
+  }
+
+  applyStatus(target, statusKey, 1, state);
+  // TODO: integrate consumable-derived bonus soft caps when system exists
+  return true;
+}

--- a/src/features/alchemy/mutators.js
+++ b/src/features/alchemy/mutators.js
@@ -1,6 +1,7 @@
 import { S, save } from '../../shared/state.js';
 import { alchemyState } from './state.js';
 import { qCap, clamp } from '../progression/selectors.js';
+import { applyConsumableEffect } from './consumableEffects.js';
 
 function slice(state = S) {
   state.alchemy = state.alchemy || structuredClone(alchemyState);
@@ -58,7 +59,7 @@ export function toggleQiDrain(enabled, state = S) {
   return alch.settings.qiDrainEnabled;
 }
 
-export function usePill(root, type) {
+export function usePill(root, type, tier = 1) {
   root.pills ??= { qi: 0, body: 0, ward: 0 };
   if ((root.pills[type] ?? 0) <= 0) return { ok: false, reason: 'none' };
 
@@ -67,14 +68,12 @@ export function usePill(root, type) {
     root.qi = clamp(root.qi + add, 0, qCap(root));
   }
   if (type === 'body') {
-    root.tempAtk = (root.tempAtk || 0) + 4;
-    root.tempArmor = (root.tempArmor || 0) + 3;
-    // NOTE: timer remains in UI for now; long-term move to a timed effect system
+    applyConsumableEffect(root, `pill_body_t${tier}`, root);
   }
   if (type === 'ward') {
-    // consumed during breakthrough
+    applyConsumableEffect(root, `pill_breakthrough_t${tier}`, root);
   }
 
   root.pills[type]--;
-  return { ok: true, type };
+  return { ok: true, type, tier };
 }

--- a/src/features/combat/data/status.js
+++ b/src/features/combat/data/status.js
@@ -43,6 +43,59 @@ export const STATUSES = {
     duration: 0.1,
     maxStacks: 1,
   },
+  // Alchemy pill buffs
+  pill_body_t1: {
+    duration: 30,
+    maxStacks: 1,
+    exclusivityGroup: 'body',
+    tier: 1,
+    onApply: ({ target }) => {
+      target.tempAtk = (target.tempAtk || 0) + 4;
+      target.tempArmor = (target.tempArmor || 0) + 3;
+    },
+    onExpire: ({ target }) => {
+      target.tempAtk = (target.tempAtk || 0) - 4;
+      target.tempArmor = (target.tempArmor || 0) - 3;
+    },
+  },
+  pill_body_t2: {
+    duration: 30,
+    maxStacks: 1,
+    exclusivityGroup: 'body',
+    tier: 2,
+    onApply: ({ target }) => {
+      target.tempAtk = (target.tempAtk || 0) + 8;
+      target.tempArmor = (target.tempArmor || 0) + 6;
+    },
+    onExpire: ({ target }) => {
+      target.tempAtk = (target.tempAtk || 0) - 8;
+      target.tempArmor = (target.tempArmor || 0) - 6;
+    },
+  },
+  pill_breakthrough_t1: {
+    duration: 60,
+    maxStacks: 1,
+    exclusivityGroup: 'breakthrough',
+    tier: 1,
+    onApply: ({ target }) => {
+      target.breakthroughBonus = (target.breakthroughBonus || 0) + 0.1;
+    },
+    onExpire: ({ target }) => {
+      target.breakthroughBonus = (target.breakthroughBonus || 0) - 0.1;
+    },
+  },
+  pill_breakthrough_t2: {
+    duration: 60,
+    maxStacks: 1,
+    exclusivityGroup: 'breakthrough',
+    tier: 2,
+    onApply: ({ target }) => {
+      target.breakthroughBonus = (target.breakthroughBonus || 0) + 0.15;
+    },
+    onExpire: ({ target }) => {
+      target.breakthroughBonus = (target.breakthroughBonus || 0) - 0.15;
+    },
+  },
 };
 
 // Compatibility alias

--- a/src/features/combat/statusEngine.js
+++ b/src/features/combat/statusEngine.js
@@ -8,6 +8,7 @@ export function applyStatus(target, key, power, state, options = {}) { // STATUS
   if (key === 'interrupt' && target.statuses?.[key]) return;
   if (!target.statuses) target.statuses = {};
   const current = target.statuses[key] || { stacks: 0, duration: 0 };
+  const prevStacks = current.stacks;
   current.stacks = Math.min(def.maxStacks ?? Infinity, current.stacks + 1);
   let duration = def.duration;
   if (key === 'stun') {
@@ -17,6 +18,9 @@ export function applyStatus(target, key, power, state, options = {}) { // STATUS
   duration *= 1 - (targetStats.ccResist || 0);
   current.duration = duration;
   target.statuses[key] = current;
+  if (def.onApply && current.stacks !== prevStacks) {
+    def.onApply({ target, stack: current.stacks });
+  }
   if (state?.adventure) {
     state.adventure.combatLog = state.adventure.combatLog || [];
     const targetName = target === state ? 'You' : target.name || 'Enemy';

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -62,7 +62,7 @@ export const defaultState = () => {
   realm: { tier: 0, stage: 1 },
   wood:0, spiritWood:0, cores:0, iron:0, oreDust:0, herbs:0, aromaticHerb:0,
   pills:{qi:0, body:0, ward:0},
-  atkBase:5, armorBase:2, tempAtk:0, tempArmor:0,
+  atkBase:5, armorBase:2, tempAtk:0, tempArmor:0, breakthroughBonus:0,
   // Expanded Stat System
   stats,
   disciples:1,


### PR DESCRIPTION
## Summary
- add helper to manage temporary pill buffs that refresh, upgrade tiers, and enforce exclusivity groups
- wire pills into status engine with onApply/onExpire and breakthrough bonus tracking

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68be4e5430ec8326a92c47c7e7ea2ae2