### PR TITLE
feat: add enemy rarities and core drops

### DIFF
--- a/src/features/affixes/logic.js
+++ b/src/features/affixes/logic.js
@@ -1,9 +1,31 @@
 import { AFFIXES, AFFIX_KEYS } from './data/affixes.js';
 
-export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
-  h.affixes = [];
-  const choices = [...AFFIX_KEYS];
-  for (let i = 0; i < count; i++) {
+// Weighted distribution for how many affixes an enemy can roll
+// The weights sum to 100 for readability
+export const AFFIX_COUNT_WEIGHTS = [
+  { count: 0, weight: 50 },
+  { count: 1, weight: 30 },
+  { count: 2, weight: 15 },
+  { count: 3, weight: 4 },
+  { count: 4, weight: 1 },
+];
+
+function rollAffixCount() {
+  const total = AFFIX_COUNT_WEIGHTS.reduce((s, r) => s + r.weight, 0);
+  const r = Math.random() * total;
+  let acc = 0;
+  for (const row of AFFIX_COUNT_WEIGHTS) {
+    acc += row.weight;
+    if (r < acc) return row.count;
+  }
+  return 0;
+}
+
+export function applyRandomAffixes(h, count) {
+  h.affixes = h.affixes || [];
+  const choices = AFFIX_KEYS.filter(k => !h.affixes.includes(k));
+  const toApply = count == null ? rollAffixCount() : count;
+  for (let i = 0; i < toApply; i++) {
     if (!choices.length) break;
     const idx = Math.floor(Math.random() * choices.length);
     const key = choices.splice(idx, 1)[0];
@@ -11,7 +33,7 @@ export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
     const affix = AFFIXES[key];
     if (affix?.apply) affix.apply(h);
   }
-  return h;
+  return h.affixes.length;
 }
 
 // Future affix-related helpers can be added here

--- a/style.css
+++ b/style.css
@@ -5054,3 +5054,8 @@ html.reduce-motion .log-sheet{transition:none;}
   font-weight: 600;
   margin: 10px 0 0;
 }
+
+.rarity-magic { color: #3b82f6; }
+.rarity-rare { color: #fbbf24; }
+.rarity-epic { color: #a855f7; }
+.rarity-legendary { color: #f87171; }


### PR DESCRIPTION
## Summary
- weight affix count rolls and return applied count
- tag enemies with rarity, color-coded UI, and core drop chances
- drop cores based on enemy rarity and log the result

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68be5ee04d4c83268024e67e6cc7e687