### PR TITLE
feat: add enemy rarities and core drops

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -44,6 +44,34 @@ import { stopActivity as stopActivityMut } from '../activity/mutators.js';
 
 // Use centralized zone data from zones.js - old ADVENTURE_ZONES removed
 
+const RARITY_NAMES = ['normal', 'magic', 'rare', 'epic', 'legendary'];
+
+export const COMMON_CORE_CHANCE = 0.01;
+export const MAGIC_CORE_CHANCE = 0.05;
+export const RARE_CORE_CHANCE = 0.1;
+export const EPIC_CORE_CHANCE = 0.2;
+export const LEGENDARY_CORE_CHANCE = 0.3;
+
+const CORE_DROP_CHANCE = {
+  normal: COMMON_CORE_CHANCE,
+  magic: MAGIC_CORE_CHANCE,
+  rare: RARE_CORE_CHANCE,
+  epic: EPIC_CORE_CHANCE,
+  legendary: LEGENDARY_CORE_CHANCE,
+};
+
+const ENEMY_RARITY_COLORS = {
+  normal: '',
+  magic: '#3b82f6',
+  rare: '#fbbf24',
+  epic: '#a855f7',
+  legendary: '#f87171',
+};
+
+function rarityFromAffixCount(count) {
+  return RARITY_NAMES[Math.min(count, RARITY_NAMES.length - 1)];
+}
+
 const loggedResistTypes = new Set();
 const DUNGEON_COOLDOWN_MS = 60 * 60 * 1000;
 const AILMENT_ICONS = {
@@ -313,7 +341,14 @@ export function updateBattleDisplay() {
     const enemy = S.adventure.currentEnemy;
     const enemyHP = S.adventure.enemyHP || 0;
     const enemyMaxHP = S.adventure.enemyMaxHP || 0;
-    setText('enemyName', enemy.name || 'Unknown Enemy');
+    const nameEl = document.getElementById('enemyName');
+    if (nameEl) {
+      const rarity = enemy.rarity || 'normal';
+      const prefix = rarity !== 'normal' ? `${rarity[0].toUpperCase()}${rarity.slice(1)} ` : '';
+      const color = ENEMY_RARITY_COLORS[rarity];
+      const inner = `${prefix}${enemy.name || 'Unknown Enemy'}`;
+      nameEl.innerHTML = color ? `<span class="rarity-${rarity}">${inner}</span>` : inner;
+    }
     setText('enemyHealthText', `${Math.round(enemyHP)}/${Math.round(enemyMaxHP)}`);
     const enemyAtkEl = document.getElementById('enemyAttack');
     if (enemyAtkEl) enemyAtkEl.title = `ATK: ${Math.round(enemy.attack || 0)}`;
@@ -860,6 +895,16 @@ function defeatEnemy() {
     });
   }
 
+  const coreChance = CORE_DROP_CHANCE[enemy.rarity || 'normal'] || 0;
+  if (Math.random() < coreChance) {
+    const coreItem = { key: 'cores', type: 'material', qty: 1, name: 'core', source: area?.name };
+    addSessionLoot(coreItem);
+    lootEntries.push(['core', 1]);
+    const msg = '💎 A core drops!';
+    S.adventure.combatLog.push(msg);
+    log(msg, 'good');
+  }
+
   if (S.flags?.weaponsEnabled) { // WEAPONS-INTEGRATION
     const tableKey = toLootTableKey(area?.id || zone?.id);
     const drop = rollLoot(tableKey);
@@ -990,11 +1035,12 @@ export function startBossCombat() {
   const { bossData, originalType } = bossInfo;
   const { enemyHP, enemyMax, atk, armor } = initializeFight(bossData);
   const h = { enemyHP, enemyMax, eAtk: atk, eArmor: armor, regen: 0, affixes: [] };
-  
+
   // Bosses get more affixes
   applyRandomAffixes(h);
-  applyRandomAffixes(h); // Apply twice for more challenge
-  
+  const affixCount = applyRandomAffixes(h); // Apply twice for more challenge
+  const rarity = rarityFromAffixCount(affixCount);
+
   S.adventure.inCombat = true;
   S.adventure.isBossFight = true;
   S.adventure.currentEnemy = {
@@ -1004,6 +1050,7 @@ export function startBossCombat() {
     armor: Math.round(h.eArmor),
     regen: h.regen,
     affixes: h.affixes,
+    rarity,
     hpMax: h.enemyMax,
     hp: h.enemyHP
   };
@@ -1041,7 +1088,8 @@ export function startAdventureCombat() {
   }
   const { enemyHP, enemyMax, atk, armor } = initializeFight(enemyData);
   const h = { enemyHP, enemyMax, eAtk: atk, eArmor: armor, regen: 0, affixes: [] };
-  applyRandomAffixes(h);
+  const affixCount = applyRandomAffixes(h);
+  const rarity = rarityFromAffixCount(affixCount);
   S.adventure.inCombat = true;
   S.adventure.isBossFight = false;
   S.adventure.currentEnemy = {
@@ -1051,6 +1099,7 @@ export function startAdventureCombat() {
     armor: Math.round(h.eArmor),
     regen: h.regen,
     affixes: h.affixes,
+    rarity,
     hpMax: h.enemyMax,
     hp: h.enemyHP
   };
@@ -1065,7 +1114,8 @@ export function startAdventureCombat() {
   S.adventure.lastPlayerAttack = 0;
   S.adventure.lastEnemyAttack = 0;
   S.adventure.combatLog = S.adventure.combatLog || [];
-  S.adventure.combatLog.push(`A ${enemyData.name} appears!`);
+  const rarityLabel = rarity !== 'normal' ? `${rarity[0].toUpperCase()}${rarity.slice(1)} ` : '';
+  S.adventure.combatLog.push(`A ${rarityLabel}${enemyData.name} appears!`);
   logEnemyResists(S.adventure.currentEnemy);
 }
 
@@ -1101,7 +1151,8 @@ function startDungeonEncounter() {
   const enemyData = { ...base, hp: base.hp * 2, attack: base.attack * 2, element: dungeon.element };
   const { enemyHP, enemyMax, atk, armor } = initializeFight(enemyData);
   const h = { enemyHP, enemyMax, eAtk: atk, eArmor: armor, regen: 0, affixes: [] };
-  applyRandomAffixes(h);
+  const affixCount = applyRandomAffixes(h);
+  const rarity = rarityFromAffixCount(affixCount);
   S.adventure.inCombat = true;
   S.adventure.isBossFight = !!floor.boss;
   S.adventure.currentEnemy = {
@@ -1111,6 +1162,7 @@ function startDungeonEncounter() {
     armor: Math.round(h.eArmor),
     regen: h.regen,
     affixes: h.affixes,
+    rarity,
     hpMax: h.enemyMax,
     hp: h.enemyHP
   };
@@ -1125,6 +1177,8 @@ function startDungeonEncounter() {
   S.adventure.lastPlayerAttack = 0;
   S.adventure.lastEnemyAttack = 0;
   S.adventure.combatLog = [`Entering ${dungeon.name} - Floor ${ds.floor + 1}`];
+  const rarityLabel = rarity !== 'normal' ? `${rarity[0].toUpperCase()}${rarity.slice(1)} ` : '';
+  S.adventure.combatLog.push(`A ${rarityLabel}${enemyData.name} appears!`);
   logEnemyResists(S.adventure.currentEnemy);
 }
 

--- a/src/features/affixes/logic.js
+++ b/src/features/affixes/logic.js
@@ -1,9 +1,31 @@
 import { AFFIXES, AFFIX_KEYS } from './data/affixes.js';
 
-export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
-  h.affixes = [];
-  const choices = [...AFFIX_KEYS];
-  for (let i = 0; i < count; i++) {
+// Weighted distribution for how many affixes an enemy can roll
+// The weights sum to 100 for readability
+export const AFFIX_COUNT_WEIGHTS = [
+  { count: 0, weight: 50 },
+  { count: 1, weight: 30 },
+  { count: 2, weight: 15 },
+  { count: 3, weight: 4 },
+  { count: 4, weight: 1 },
+];
+
+function rollAffixCount() {
+  const total = AFFIX_COUNT_WEIGHTS.reduce((s, r) => s + r.weight, 0);
+  const r = Math.random() * total;
+  let acc = 0;
+  for (const row of AFFIX_COUNT_WEIGHTS) {
+    acc += row.weight;
+    if (r < acc) return row.count;
+  }
+  return 0;
+}
+
+export function applyRandomAffixes(h, count) {
+  h.affixes = h.affixes || [];
+  const choices = AFFIX_KEYS.filter(k => !h.affixes.includes(k));
+  const toApply = count == null ? rollAffixCount() : count;
+  for (let i = 0; i < toApply; i++) {
     if (!choices.length) break;
     const idx = Math.floor(Math.random() * choices.length);
     const key = choices.splice(idx, 1)[0];
@@ -11,7 +33,7 @@ export function applyRandomAffixes(h, count = Math.floor(Math.random() * 3)) {
     const affix = AFFIXES[key];
     if (affix?.apply) affix.apply(h);
   }
-  return h;
+  return h.affixes.length;
 }
 
 // Future affix-related helpers can be added here

--- a/src/features/loot/ui/lootTab.js
+++ b/src/features/loot/ui/lootTab.js
@@ -9,7 +9,8 @@ export function updateLootTab(state = S) {
   getSessionLoot(state).forEach(item => {
     const row = document.createElement('div');
     row.className = 'loot-row';
-    row.textContent = `${item.qty || 1} ${item.key}`;
+    const name = item.name || item.key;
+    row.textContent = `${item.qty || 1} ${name}`;
     list.appendChild(row);
   });
 }

--- a/style.css
+++ b/style.css
@@ -5054,3 +5054,8 @@ html.reduce-motion .log-sheet{transition:none;}
   font-weight: 600;
   margin: 10px 0 0;
 }
+
+.rarity-magic { color: #3b82f6; }
+.rarity-rare { color: #fbbf24; }
+.rarity-epic { color: #a855f7; }
+.rarity-legendary { color: #f87171; }


### PR DESCRIPTION
## Summary
- weight affix count rolls and return applied count
- tag enemies with rarity, color-coded UI, and core drop chances
- drop cores based on enemy rarity, log the result, and treat cores as proper inventory items

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68be5ee04d4c83268024e67e6cc7e687