### PR TITLE
Show breakthrough chance even when not ready

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -393,6 +393,10 @@ way-of-ascension/
 │       └── catchingDisplay.js
 ├── src/features/forging/index.js
 ├── src/features/physique/index.js
+├── src/features/alchemy/consumableEffects.js
+├── src/features/alchemy/data/pills.js
+├── src/features/alchemy/test.js
+├── src/features/tutorial/steps.js
 └── style.css
 ```
 

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -199,8 +199,6 @@ export function calculatePlayerAttackRate(state = progressionState) {
 }
 
 export function breakthroughChance(state = progressionState){
-  if(state.qi < qCap(state)*0.99 || state.foundation < fCap(state)*0.99) return 0;
-
   const realm = REALMS[state.realm.tier];
   let base = realm.bt;
 

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -334,7 +334,9 @@ export function updateCultivationVisualization() {
 
   // Update breakthrough proximity effects
   const btChance = breakthroughChance(S);
-  if (btChance > 0.7) {
+  const breakthroughReady =
+    S.qi >= qCap(S) * 0.99 && S.foundation >= fCap(S) * 0.99;
+  if (breakthroughReady && btChance > 0.7) {
     cultivationViz.classList.add('near-breakthrough');
   } else {
     cultivationViz.classList.remove('near-breakthrough');


### PR DESCRIPTION
## Summary
- Display breakthrough odds regardless of Qi or Foundation levels
- Highlight breakthrough proximity only when Qi and Foundation are near max
- Document missing feature files in project structure guide

## Testing
- ⚠️ `npm test` (no test specified)
- ✅ `npm run lint:balance`
- ❌ `npm run validate` (UI state violations and DOM usage warnings)

------
https://chatgpt.com/codex/tasks/task_e_68becd6341788326ac662bc910482cb5