### PR TITLE
Refactor sidebar layout for compact mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,29 +59,26 @@
         <svg class="yin-yang-svg" viewBox="0 0 512 512" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false">
           <path d="m 227.55034,388.44776 c -5.225,-0.97914 -13.64517,-3.17238 -18.7115,-4.87385 -5.06632,-1.70148 -12.49132,-4.74353 -16.5,-6.76012 -4.00867,-2.01658 -11.1135,-6.17029 -15.7885,-9.23045 -4.96297,-3.24866 -13.11658,-10.1627 -19.5943,-16.61544 -7.29488,-7.26674 -13.36587,-14.49703 -17.72726,-21.11242 -3.64812,-5.53351 -8.40794,-13.90288 -10.57737,-18.59861 -2.16944,-4.69573 -5.08295,-12.31832 -6.47447,-16.93909 -1.39153,-4.62076 -3.28597,-12.45139 -4.20987,-17.40139 -1.13271,-6.06874 -1.66531,-14.04828 -1.63527,-24.5 0.0325,-11.31859 0.58372,-18.2182 2.0432,-25.57607 1.09926,-5.54185 3.21743,-13.64185 4.70704,-18 1.48961,-4.35816 4.44991,-11.60028 6.57844,-16.09359 2.12853,-4.49332 6.54138,-12.14332 9.80633,-17 3.26496,-4.85669 8.93402,-12.0963 12.59792,-16.08803 3.66391,-3.99172 9.88454,-9.87209 13.82363,-13.06747 3.93909,-3.19539 9.29294,-7.25905 11.89746,-9.03037 2.60451,-1.77131 9.12951,-5.40422 14.5,-8.07313 5.37048,-2.66891 13.15774,-5.97793 17.30501,-7.35337 4.14727,-1.37545 11.34727,-3.33162 16,-4.34705 6.51896,-1.42272 12.70327,-1.84693 26.95951,-1.84924 11.482,-0.002 20.7761,0.49152 24.5,1.3006 3.3,0.71698 10.45125,2.65819 15.89167,4.31379 5.44042,1.6556 14.51867,5.38292 20.17388,8.28294 5.65522,2.90002 13.97144,7.92903 18.4805,11.17558 4.50906,3.24655 11.19341,8.8284 14.85401,12.40411 3.6607,3.57572 9.1569,9.6513 12.2138,13.5013 3.0569,3.85 7.6292,10.375 10.1607,14.5 2.5315,4.125 6.1973,11.23366 8.1463,15.79703 1.9489,4.56336 4.6575,11.98836 6.0191,16.5 1.3615,4.51163 3.1695,12.58563 4.0178,17.94221 0.8482,5.35658 1.5397,15.03158 1.5365,21.5 0,6.83748 -0.7852,16.36558 -1.8678,22.76076 -1.0241,6.05 -3.5193,15.95 -5.5448,22 -2.0256,6.05 -5.7425,14.825 -8.2598,19.5 -2.5173,4.675 -6.8821,11.84667 -9.6994,15.93705 -2.8174,4.09038 -8.9475,11.32758 -13.6225,16.08267 -4.675,4.75509 -10.525,10.23152 -12.99996,12.16984 -2.475,1.93832 -7.05441,5.15628 -10.17647,7.15102 -3.12206,1.99475 -9.77071,5.67962 -14.77478,8.1886 -5.00407,2.50899 -13.37596,5.87854 -18.60419,7.48789 -5.22823,1.60935 -13.42958,3.61244 -18.22522,4.45132 -5.37026,0.93939 -14.28876,1.49028 -23.21934,1.43424 -9.30952,-0.0584 -17.90066,-0.72826 -24,-1.87126 z m -33.19159,-24.28137 c -1.64552,-4.5375 -3.79928,-11.175 -4.78613,-14.75 -0.98684,-3.575 -2.39055,-9.65 -3.11934,-13.5 -0.7288,-3.85 -1.31688,-11.725 -1.30686,-17.5 0.01,-5.775 0.59534,-13.2 1.3007,-16.5 0.70536,-3.3 2.84672,-9.28883 4.75858,-13.30853 2.36784,-4.9784 5.44778,-9.2825 9.66037,-13.5 3.40135,-3.4053 9.10927,-7.89048 12.68427,-9.96705 3.575,-2.07658 10.1,-4.92012 14.5,-6.31898 4.4,-1.39886 14.975,-3.59226 23.5,-4.87422 8.525,-1.28197 18.38528,-3.30523 21.91173,-4.49614 3.52646,-1.19092 8.70146,-3.31494 11.5,-4.72005 2.79855,-1.40511 8.20005,-4.84847 12.00334,-7.65192 4.38388,-3.2314 9.02093,-7.93734 12.66813,-12.85631 3.4035,-4.59031 7.01524,-11.03212 8.84365,-15.77333 1.69983,-4.4078 3.57764,-11.50603 4.17291,-15.77383 0.60917,-4.36739 0.77707,-11.03838 0.38407,-15.25964 -0.38404,-4.125 -1.4922,-10.05339 -2.46259,-13.17421 -0.97039,-3.12082 -3.36038,-8.5282 -5.3111,-12.0164 -1.95071,-3.4882 -5.38286,-8.42811 -7.62699,-10.97758 -2.24413,-2.54947 -6.6684,-6.35673 -9.8317,-8.46059 -3.1633,-2.10385 -9.57645,-5.26059 -14.25145,-7.01496 -4.675,-1.75438 -12.29519,-3.74109 -16.93375,-4.41492 -5.34162,-0.77597 -12.49107,-0.98371 -19.5,-0.56661 -6.08644,0.3622 -14.89125,1.5096 -19.56625,2.54979 -4.675,1.04018 -11.425,2.99562 -15,4.34543 -3.575,1.3498 -10.325,4.36128 -15,6.69217 -4.675,2.33089 -12.98923,7.23046 -18.47607,10.88793 -5.69205,3.79427 -14.08193,10.72954 -19.53727,16.14995 -5.25865,5.225 -12.08257,13.325 -15.16425,18 -3.08168,4.675 -6.95098,11.2 -8.59846,14.5 -1.64747,3.3 -4.42354,10.04904 -6.16904,14.99787 -1.7455,4.94883 -4.04693,14.10605 -5.11428,20.34937 -1.06735,6.24333 -1.93798,15.69429 -1.93474,21.00214 0.003,5.30784 0.68129,14.15062 1.50678,19.65062 0.82548,5.5 2.89128,14.5 4.59065,20 1.69938,5.5 4.54816,13.15 6.33063,17 1.78247,3.85 5.17629,10.15 7.54183,14 2.36554,3.85 6.24489,9.475 8.62077,12.5 2.37589,3.025 6.70111,7.99395 9.61162,11.04211 2.91051,3.04815 8.21683,8.05672 11.79183,11.13014 3.575,3.07342 10.31201,8.11698 14.97113,11.2079 4.65912,3.09092 8.77669,5.61985 9.15014,5.61985 0.37345,0 -0.66733,-3.7125 -2.31286,-8.25 z m 54.00612,-163.73663 c -2.02701,-0.37265 -5.22619,-1.85271 -7.10928,-3.28901 -1.88309,-1.43631 -4.26878,-4.32436 -5.30154,-6.41791 -1.16136,-2.35424 -1.8356,-5.73496 -1.76728,-8.86138 0.0608,-2.78021 0.82625,-6.43911 1.7011,-8.13088 0.87485,-1.69178 2.94536,-4.21589 4.60115,-5.60913 1.65578,-1.39325 4.64941,-3.07407 6.65251,-3.73515 2.00309,-0.66108 5.4217,-0.96326 7.59691,-0.6715 2.1752,0.29175 5.71384,1.69447 7.86365,3.11714 2.14981,1.42268 4.81763,4.36825 5.92849,6.54573 1.26012,2.47004 2.01976,5.91553 2.01976,9.16103 0,3.6879 -0.69911,6.39491 -2.40194,9.30058 -1.34003,2.28659 -4.1032,5.03045 -6.25,6.20633 -2.11644,1.15925 -5.19806,2.32237 -6.84806,2.58472 -1.65,0.26234 -4.65846,0.17209 -6.68547,-0.20057 z m 11.97531,143.08395 c 2.04059,-1.04647 4.70118,-2.96512 5.91243,-4.26365 1.21125,-1.29853 2.89875,-4.02787 3.75,-6.0652 0.85125,-2.03732 1.53785,-5.18118 1.52577,-6.98635 -0.0121,-1.80516 -0.85795,-5.08212 -1.87971,-7.28212 -1.02176,-2.2 -2.8756,-5.06209 -4.11966,-6.3602 -1.24405,-1.29811 -3.75873,-2.98561 -5.58818,-3.75 -1.82944,-0.76439 -5.38364,-1.3898 -7.89821,-1.3898 -2.51458,0 -6.24153,0.85212 -8.28212,1.89359 -2.04059,1.04148 -4.4434,2.72898 -5.33957,3.75 -0.89618,1.02103 -2.40755,3.39106 -3.3586,5.26675 -1.24278,2.45105 -1.6122,5.02753 -1.31332,9.15957 0.29755,4.11355 1.20077,6.9353 3.17474,9.91816 1.71722,2.5949 4.33854,4.88614 6.94273,6.06847 2.30112,1.04475 6.11429,1.90942 8.4737,1.9215 2.35941,0.0121 5.95941,-0.83424 8,-1.88072 z" fill="currentColor"/>
         </svg>
-      </div>
-      <div class="title-wrap">
+        </div>
         <h1>Way of Ascension</h1>
-        <div class="sub">Idle xianxia cultivation • autosaves</div>
       </div>
     </div>
-    </div>
-  </div>
   </header>
 
   <div id="drawerScrim" class="drawer-scrim" hidden></div>
   <main>
       <aside class="left" id="sidebar">
-        <div class="status-card">
-          <h4>Status</h4>
-          <div class="status-metric">
-            <div class="status-row">
-              <div class="status-label"><iconify-icon icon="mdi:cards-heart" width="16"></iconify-icon> HP</div>
-              <div class="status-value"><span id="hpVal">100</span>/<span id="hpMax">100</span></div>
-            </div>
-            <div class="status-bar hp-bar">
-              <div class="fill" id="hpFill"></div>
-              <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
+          <div class="status-card">
+            <h4>Status</h4>
+            <div class="status-task"><div class="task-chip" id="currentTask">Idle</div></div>
+            <div class="status-metric">
+              <div class="status-row">
+                <div class="status-label"><iconify-icon icon="mdi:cards-heart" width="16"></iconify-icon> HP</div>
+                <div class="status-value"><span id="hpVal">100</span>/<span id="hpMax">100</span></div>
+              </div>
+              <div class="status-bar hp-bar">
+                <div class="fill" id="hpFill"></div>
+                <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
                 <defs>
                   <linearGradient id="shieldGradient">
                     <stop offset="0%" stop-color="rgba(255,255,255,0)" />
@@ -113,35 +110,35 @@
         <div id="notificationTray" class="notification-tray"></div>
 
         <!-- Leveling Activities Group -->
-      <div class="activity-group">
-        <h4 class="group-title"><iconify-icon icon="ri:hand-line" class="ui-icon" width="20"></iconify-icon> Training & Skills</h4>
-        <div class="activities leveling-activities" id="levelingActivities"></div>
-      </div>
-
-      <!-- Separator -->
-      <div class="activity-separator">
-        <div class="separator-line"></div>
-        <div class="separator-text">⚔️</div>
-        <div class="separator-line"></div>
-      </div>
-
-      <!-- Exploration & Management Activities Group -->
-      <div class="activity-group">
-        <h4 class="group-title">Exploration & Management</h4>
-        <div class="activities management-activities" id="managementActivities"></div>
-      </div>
-
-      <!-- Sect Selector -->
-      <div class="activity-selector" id="sectSelector" data-activity="sect">
-        <div class="activity-name">🏛️ Sect</div>
-        <div class="activity-info" id="sectInfo">0 Buildings</div>
-      </div>
-
-      <div class="sidebar-footer">
-        <div class="activity-selector" id="settingsSelector" data-activity="settings">
-          <div class="activity-name">⚙️ Settings</div>
+        <div class="activity-group">
+          <h4 class="group-title">Skills</h4>
+          <div class="activities leveling-activities" id="levelingActivities"></div>
         </div>
-      </div>
+
+        <!-- Exploration Activities Group -->
+        <div class="activity-group">
+          <h4 class="group-title">Exploration</h4>
+          <div class="activities management-activities" id="managementActivities"></div>
+        </div>
+
+        <!-- Sect -->
+        <div class="activity-group">
+          <h4 class="group-title">Sect</h4>
+          <div class="activity-selector" id="sectSelector" data-activity="sect">
+            <div class="activity-name">🏛️ Sect</div>
+            <div class="activity-info" id="sectInfo">0 Buildings</div>
+          </div>
+        </div>
+
+        <div class="sidebar-footer">
+          <button id="saveBtn" class="sidebar-btn">💾 Save</button>
+          <button id="exportBtn" class="sidebar-btn">⬇️ Export</button>
+          <button id="importBtn" class="sidebar-btn">⬆️ Import</button>
+          <button id="resetBtn" class="sidebar-btn warn" title="Hard reset">♻️ Reset</button>
+          <div class="activity-selector" id="settingsSelector" data-activity="settings">
+            <div class="activity-name">⚙️ Settings</div>
+          </div>
+        </div>
       </aside>
 
     <section class="content">
@@ -1160,14 +1157,6 @@
       <section id="activity-settings" class="activity-content tab-content" style="display:none;">
         <h2>⚙️ Settings</h2>
         <div class="cards">
-          <div class="card">
-            <div class="settings-buttons">
-              <button class="btn small ghost" id="saveBtn">💾 Save</button>
-              <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
-              <button class="btn small ghost" id="importBtn">⬆️ Import</button>
-              <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
-            </div>
-          </div>
           <div class="card">
             <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
           </div>

--- a/style.css
+++ b/style.css
@@ -18,9 +18,11 @@
   --radius: 16px;
   --gap: 20px;
   --pad: 16px;
-    --header-h: 64px;
+  --gap-sm: 8px;
+  --pad-sm: 8px;
+  --header-h: 48px;
   --log-h: 0px;
-  --tabs-h: 48px;
+  --tabs-h: 40px;
   --safe-bottom: env(safe-area-inset-bottom,0px);
   --float-pad: 0px;
   --card-pad: 12px;
@@ -1610,11 +1612,16 @@ html.reduce-motion .rune-ring .orbit {
 
 /* STYLE-GUIDE-UPDATE: Parchment header */
 header{
-  display:flex; align-items:center; justify-content:space-between; padding:18px 22px; gap:20px;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:var(--pad-sm);
+  gap:var(--gap-sm);
   background: linear-gradient(100deg, var(--panel) 0%, #ebe0c8 60%, #e6d5b8 100%);
   border-bottom:1px solid var(--accent);
   box-shadow: var(--shadow);
-  position:relative; z-index:2;
+  position:relative;
+  z-index:2;
 }
 .primary-row{display:flex; align-items:center; gap:20px;}
   .brand{display:flex; gap:14px; align-items:center}
@@ -4493,19 +4500,19 @@ html.reduce-motion .sprite-stage .sprite{animation:none}
 .log-toggle{display:none;}
 
 @media (max-width:768px){
-  :root{--gap:12px;--pad:12px;--header-h:64px;--tabs-h:48px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--log-h:0px;}
+  :root{--gap:12px;--pad:12px;--gap-sm:8px;--pad-sm:8px;--header-h:48px;--tabs-h:40px;--safe-bottom:env(safe-area-inset-bottom,0px);--float-pad:0px;--log-h:0px;}
   html,body{overflow:hidden;}
   .mist-layer{inset:-10vh 0;}
-  header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap);padding:var(--pad);min-height:var(--header-h);}
-  .primary-row{display:flex;align-items:center;gap:var(--gap);}
-  .brand{flex:1;display:flex;align-items:center;gap:var(--gap);}
+  header{position:sticky;top:0;z-index:1000;flex-direction:column;align-items:stretch;gap:var(--gap-sm);padding:var(--pad-sm);min-height:var(--header-h);}
+  .primary-row{display:flex;align-items:center;gap:var(--gap-sm);}
+  .brand{flex:1;display:flex;align-items:center;gap:var(--gap-sm);}
   .title-wrap{flex:1;min-width:0;}
   .title-wrap h1{font-size:clamp(1.2rem,5vw,1.5rem);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
   .title-wrap .sub{display:none;}
   .qi-orb{width:40px;height:40px;}
   .hamburger{display:block;}
     main{display:block;height:auto;}
-  #sidebar{position:fixed;top:0;left:0;bottom:0;width:250px;max-width:80%;transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad);display:flex;flex-direction:column;}
+  #sidebar{position:fixed;top:0;left:0;bottom:0;width:clamp(300px,88vw,420px);transform:translateX(-100%);transition:transform .3s;background:linear-gradient(180deg,var(--panel),#ebe0c8);z-index:1001;padding:var(--pad-sm);display:flex;flex-direction:column;gap:var(--gap-sm);overflow-x:hidden;}
   #sidebar.open{transform:translateX(0);}
   body.drawer-open{overflow:hidden;}
   .content{padding:var(--pad);padding-bottom:calc(var(--pad) + var(--log-h) + env(safe-area-inset-bottom,0px));}
@@ -5086,3 +5093,115 @@ html.reduce-motion .log-sheet{transition:none;}
 .rarity-rare { color: #fbbf24; }
 .rarity-epic { color: #a855f7; }
 .rarity-legendary { color: #f87171; }
+
+/* Compact sidebar & status */
+.status-task{margin-bottom:var(--gap-sm);}
+.task-chip{
+  display:inline-block;
+  background:var(--panel);
+  border:1px solid var(--accent);
+  border-radius:999px;
+  padding:2px 8px;
+  font-size:12px;
+  max-width:100%;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.group-title{
+  margin:0 0 var(--gap-sm);
+  padding:0;
+  border:none;
+  text-align:left;
+  font-size:14px;
+  font-weight:600;
+}
+
+.sidebar-footer{
+  margin-top:auto;
+  display:flex;
+  flex-direction:column;
+  gap:var(--gap-sm);
+}
+
+.sidebar-footer .sidebar-btn{
+  background:var(--panel);
+  border:1px solid var(--accent);
+  border-radius:6px;
+  padding:0 var(--pad-sm);
+  height:44px;
+  cursor:pointer;
+}
+
+.sidebar-footer .sidebar-btn.warn{
+  border-color:var(--danger);
+  color:var(--danger);
+}
+
+.activity-selector{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  background:var(--panel);
+  border:1px solid var(--accent);
+  border-radius:6px;
+  padding:0 var(--pad-sm);
+  height:48px;
+  margin-bottom:var(--gap-sm);
+}
+
+.activity-selector .activity-name{
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.activity-selector .activity-info{
+  margin-left:auto;
+  text-align:right;
+}
+
+.activity-group .activity-item{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  height:48px;
+  padding:0 var(--pad-sm);
+  margin-bottom:var(--gap-sm);
+  background:var(--panel);
+  border:1px solid var(--accent);
+  border-radius:6px;
+}
+
+.activity-group .activity-item .activity-header{
+  display:flex;
+  align-items:center;
+  gap:var(--gap-sm);
+  flex:1;
+}
+
+.activity-group .activity-item .activity-icon{
+  font-size:20px;
+}
+
+.activity-group .activity-item .activity-info{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  width:100%;
+}
+
+.activity-group .activity-item .activity-name{
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+.activity-group .activity-item .activity-level{
+  text-align:right;
+}
+
+.activity-group .activity-item .activity-progress-bar{
+  display:none;
+}


### PR DESCRIPTION
## Summary
- streamline header to a single-line brand bar
- add compact Status card with current task and slim HP/Qi meters
- simplify sidebar sections and pin save/export/import/reset/settings actions to the footer

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation)


------
https://chatgpt.com/codex/tasks/task_e_68bf0d0cd83c8326acb3a0582cf765b8