### PR TITLE
feat: add recipe book table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1106,7 +1106,20 @@
           <div class="cards">
             <div class="card">
               <h4>Recipes</h4>
-              <ul id="recipeList"></ul>
+              <table id="recipeTable" class="recipe-table">
+                <thead>
+                  <tr>
+                    <th>Recipe</th>
+                    <th>Cost</th>
+                    <th>Qi</th>
+                    <th>Time</th>
+                    <th>Success</th>
+                    <th>Effect</th>
+                    <th>Crafted</th>
+                  </tr>
+                </thead>
+                <tbody id="recipeList"></tbody>
+              </table>
             </div>
           </div>
         </div>

--- a/src/features/alchemy/ui/alchemyDisplay.js
+++ b/src/features/alchemy/ui/alchemyDisplay.js
@@ -5,6 +5,20 @@ import { PILL_LINES } from '../data/pills.js';
 import { usePill, startConcoct } from '../mutators.js';
 import { inspectPillResistance } from '../selectors.js';
 
+function describeEffect(recipe) {
+  const eff = recipe.effects || {};
+  if (eff.qiRestorePct) return `Restores ${eff.qiRestorePct}% Qi`;
+  if (eff.stats) {
+    return Object.entries(eff.stats)
+      .map(([stat, val]) => `+${val} ${stat}`)
+      .join(', ');
+  }
+  if (eff.status === 'pill_body_t1') return 'Boosts attack and armor for 30s';
+  if (eff.status === 'pill_breakthrough_t1') return '+10% breakthrough success for 60s';
+  if (eff.status === 'pill_meridian_opening_t1') return '+20% breakthrough chance for 30s';
+  return '';
+}
+
 function render(state) {
   setText('alchLvl', state.alchemy.level);
   setText('alchXp', state.alchemy.xp);
@@ -48,7 +62,7 @@ function render(state) {
     list.innerHTML = '';
     Object.keys(state.alchemy.knownRecipes || {}).forEach(key => {
       const recipe = ALCHEMY_RECIPES[key];
-      const li = document.createElement('li');
+      const row = document.createElement('tr');
       if (recipe) {
         const tier = recipe.tiers?.[1] || {};
         const cost = Object.entries(tier.inputs || {})
@@ -57,11 +71,12 @@ function render(state) {
         const qi = tier.qiCost ?? 0;
         const time = tier.baseTime ?? 0;
         const crafted = state.alchemy.recipeStats?.[key]?.crafted || 0;
-        li.innerHTML = `<strong>${recipe.name}</strong> - Cost: ${cost} | Qi: ${qi} | Time: ${time}s | Success: 100% | Crafted: ${crafted}`;
+        const effect = describeEffect(recipe);
+        row.innerHTML = `<td>${recipe.name}</td><td>${cost}</td><td>${qi}</td><td>${time}s</td><td>100%</td><td>${effect}</td><td>${crafted}</td>`;
       } else {
-        li.textContent = key;
+        row.innerHTML = `<td colspan="7">${key}</td>`;
       }
-      list.appendChild(li);
+      list.appendChild(row);
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -5003,6 +5003,8 @@ html.reduce-motion .log-sheet{transition:none;}
 .alchemy-tabs{display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap}
 .alchemy-subtab{padding:4px 8px;background:#e5e7eb;border:none;cursor:pointer;border-radius:4px}
 .alchemy-subtab.active{background:#3b82f6;color:#fff}
+.recipe-table{width:100%;border-collapse:collapse;font-size:0.8rem}
+.recipe-table th,.recipe-table td{padding:4px;white-space:nowrap;font-size:0.8rem}
 .creature-entry{border:1px solid #d1d5db;padding:4px;margin-bottom:6px}
 .creature-header{display:flex;align-items:center;gap:4px}
 .creature-actions{margin-top:4px;display:flex;gap:4px}


### PR DESCRIPTION
## Summary
- display alchemy recipes in a styled table with headers for cost, Qi, time, success, effect, and crafted count
- shrink table font and constrain spacing for recipe-book view
- show concise descriptions of pill effects in recipe list

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68bf32aa6ce48326828bd5f270f33a6c