### PR TITLE
Add third tutorial step for astral tree and adventure unlock

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -5,7 +5,7 @@ The game includes a simple tutorial that guides new players through the opening 
 1. **Start cultivating** – toggle the cultivation activity.
 2. **Gain foundation** – accumulate any amount of foundation.
 3. **Attempt a breakthrough** – begin a breakthrough once ready.
-4. **Reach stage 1 of the next realm** – succeeding the breakthrough completes the tutorial.
+4. **Purchase a notable astral tree node** – spend Insight on one of the larger nodes to unlock Adventure and choose a starting weapon.
 
 The current progress is stored in `state.tutorial.step` and `state.tutorial.completed`.
 

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -59,8 +59,8 @@ const unlockMap = {
   cooking: (s) => selectSect.isBuildingBuilt('kitchen', s),
   law: (s) => selectProgress.isQiRefiningReached(s),
   sect: (s) => selectProgress.mortalStage(s) >= 3,
-  adventure: (s) => selectProgress.mortalStage(s) >= 5,
-  proficiency: (s) => selectProgress.mortalStage(s) >= 5,
+  adventure: (s) => selectProgress.mortalStage(s) >= 5 || s.tutorial?.adventureUnlocked,
+  proficiency: (s) => selectProgress.mortalStage(s) >= 5 || s.tutorial?.adventureUnlocked,
 };
 
 const coreFeatures = new Set([

--- a/src/features/tutorial/steps.js
+++ b/src/features/tutorial/steps.js
@@ -1,4 +1,12 @@
 import { fCap, realmStage } from '../progression/selectors.js';
+import { addToInventory, equipItem } from '../inventory/mutators.js';
+import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+
+const NOTABLE_NODE_IDS = [
+  28, 33, 38, 52, 1028, 1033, 1038, 1043, 1052, 2028, 2033, 2038, 2043,
+  2052, 3028, 3033, 3038, 3043, 3052, 4028, 4033, 4038, 4043, 4052, 4060,
+  4061, 4062,
+];
 
 export const STEPS = [
   {
@@ -32,6 +40,43 @@ export const STEPS = [
       state.astralPoints = (state.astralPoints || 0) + 50;
       const btn = document.getElementById('openAstralTree');
       if (btn) btn.style.display = 'block';
+    },
+  },
+  {
+    title: 'Astral Insight',
+    text: 'You have unlocked the astral tree which can be found on the top right of the cultivation menu. Buying astral nodes requieres Insight. Insight is gained by performing cultivation.  Doing other tasks will also increase your insight, at a lower rate. Insight is a precious resource, and each purchase increases the cost of all other nodes in the tree, so use it wisely',
+    req: 'Objective: purchase your first notable (one of the bigger circles in the astral tree)',
+    reward: 'Reward: unlock adventure, select weapon: (dim focus, crude knuckles or crude nunchaku)',
+    highlight: 'openAstralTree',
+    check: state => {
+      const nodes = state.astralUnlockedNodes;
+      if (!nodes) return false;
+      for (const id of nodes) {
+        if (NOTABLE_NODE_IDS.includes(Number(id))) return true;
+      }
+      return false;
+    },
+    applyReward(state) {
+      state.tutorial = state.tutorial || {};
+      state.tutorial.adventureUnlocked = true;
+      const choice = prompt(
+        'Choose your weapon: dim focus, crude knuckles or crude nunchaku'
+      );
+      const key = (choice || '')
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, '');
+      const map = {
+        dimfocus: 'dimFocus',
+        crudeknuckles: 'crudeKnuckles',
+        crudenunchaku: 'crudeNunchaku',
+      };
+      const wKey = map[key];
+      if (wKey && WEAPONS[wKey]) {
+        const id = addToInventory(WEAPONS[wKey], state);
+        const item = state.inventory.find(it => it.id === id);
+        equipItem(item, 'mainhand', state);
+      }
     },
   },
 ];


### PR DESCRIPTION
## Summary
- guide players to buy their first notable node with a new tutorial step
- allow adventure and proficiency UIs after claiming this step's reward
- document updated tutorial flow

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and timers)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4eb8c16c8326810f67bfa26ca2c1