### PR TITLE
feat: show building costs with current stock

### DIFF
--- a/src/features/sect/ui/sectScreen.js
+++ b/src/features/sect/ui/sectScreen.js
@@ -35,8 +35,16 @@ function renderBuildings(state){
       costDiv.textContent = 'Max level';
     } else {
       const cost = getBuildingCost(key, next);
-      const costStr = Object.entries(cost).map(([res, amt]) => `${amt} ${res}`).join(', ');
-      costDiv.textContent = costStr;
+      const nodes = [];
+      Object.entries(cost).forEach(([res, amt], idx, arr) => {
+        const span = document.createElement('span');
+        const cur = state[res] || 0;
+        span.textContent = `${cur}/${amt} ${res}`;
+        span.style.color = cur >= amt ? 'red' : 'green';
+        nodes.push(span);
+        if(idx < arr.length - 1) nodes.push(document.createTextNode(', '));
+      });
+      costDiv.append(...nodes);
     }
     card.appendChild(costDiv);
 


### PR DESCRIPTION
## Summary
- display current and required material amounts for sect building upgrades
- color material counts red when sufficient and green when insufficient

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI CHANGES BLOCKED UNTIL VALIDATION PASSES)*

------
https://chatgpt.com/codex/tasks/task_e_68bf505cbebc8326b456f0cf44d96d9d