### PR TITLE
Add third tutorial step for astral tree and adventure unlock

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -336,7 +336,8 @@ way-of-ascension/
 │       │   └── devQuickMenu.js
 │       ├── notifications.js
 │       ├── sidebar.js
-│       └── tutorialBox.js
+│       ├── tutorialBox.js
+│       └── weaponSelectOverlay.js
 ├── ui/
 │   └── index.js
 ├── README.md
@@ -1258,4 +1259,5 @@ Paths added:
 - `src/features/tutorial/state.js` – stores tutorial step and completion flag.
 - `src/features/tutorial/logic.js` – evaluates player actions and advances steps.
 - `src/ui/tutorialBox.js` – displays on-screen guidance during the tutorial.
+- `src/ui/weaponSelectOverlay.js` – overlay to choose a starting weapon after unlocking Adventure.
 - `src/features/tutorial/steps.js` – Step definitions and triggers for tutorial progression.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -5,7 +5,7 @@ The game includes a simple tutorial that guides new players through the opening 
 1. **Start cultivating** – toggle the cultivation activity.
 2. **Gain foundation** – accumulate any amount of foundation.
 3. **Attempt a breakthrough** – begin a breakthrough once ready.
-4. **Reach stage 1 of the next realm** – succeeding the breakthrough completes the tutorial.
+4. **Purchase a notable astral tree node** – spend Insight on one of the larger nodes to unlock Adventure and choose a starting weapon.
 
 The current progress is stored in `state.tutorial.step` and `state.tutorial.completed`.
 

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -59,8 +59,8 @@ const unlockMap = {
   cooking: (s) => selectSect.isBuildingBuilt('kitchen', s),
   law: (s) => selectProgress.isQiRefiningReached(s),
   sect: (s) => selectProgress.mortalStage(s) >= 3,
-  adventure: (s) => selectProgress.mortalStage(s) >= 5,
-  proficiency: (s) => selectProgress.mortalStage(s) >= 5,
+  adventure: (s) => selectProgress.mortalStage(s) >= 5 || s.tutorial?.adventureUnlocked,
+  proficiency: (s) => selectProgress.mortalStage(s) >= 5 || s.tutorial?.adventureUnlocked,
 };
 
 const coreFeatures = new Set([

--- a/src/features/tutorial/steps.js
+++ b/src/features/tutorial/steps.js
@@ -1,4 +1,11 @@
 import { fCap, realmStage } from '../progression/selectors.js';
+import { showWeaponSelectOverlay } from '../../ui/weaponSelectOverlay.js';
+
+const NOTABLE_NODE_IDS = [
+  28, 33, 38, 52, 1028, 1033, 1038, 1043, 1052, 2028, 2033, 2038, 2043,
+  2052, 3028, 3033, 3038, 3043, 3052, 4028, 4033, 4038, 4043, 4052, 4060,
+  4061, 4062,
+];
 
 export const STEPS = [
   {
@@ -32,6 +39,26 @@ export const STEPS = [
       state.astralPoints = (state.astralPoints || 0) + 50;
       const btn = document.getElementById('openAstralTree');
       if (btn) btn.style.display = 'block';
+    },
+  },
+  {
+    title: 'Astral Insight',
+    text: 'You have unlocked the astral tree which can be found on the top right of the cultivation menu. Buying astral nodes requieres Insight. Insight is gained by performing cultivation.  Doing other tasks will also increase your insight, at a lower rate. Insight is a precious resource, and each purchase increases the cost of all other nodes in the tree, so use it wisely',
+    req: 'Objective: purchase your first notable (one of the bigger circles in the astral tree)',
+    reward: 'Reward: unlock adventure, select weapon: (dim focus, crude knuckles or crude nunchaku)',
+    highlight: 'openAstralTree',
+    check: state => {
+      const nodes = state.astralUnlockedNodes;
+      if (!nodes) return false;
+      for (const id of nodes) {
+        if (NOTABLE_NODE_IDS.includes(Number(id))) return true;
+      }
+      return false;
+    },
+    applyReward(state) {
+      state.tutorial = state.tutorial || {};
+      state.tutorial.adventureUnlocked = true;
+      showWeaponSelectOverlay(state);
     },
   },
 ];

--- a/src/ui/weaponSelectOverlay.js
+++ b/src/ui/weaponSelectOverlay.js
@@ -1,0 +1,52 @@
+import { addToInventory, equipItem } from '../features/inventory/mutators.js';
+import { WEAPONS } from '../features/weaponGeneration/data/weapons.js';
+import { WEAPON_ICONS } from '../features/weaponGeneration/data/weaponIcons.js';
+
+const CHOICES = ['dimFocus', 'crudeKnuckles', 'crudeNunchaku'];
+
+function renderOption(key) {
+  const weapon = WEAPONS[key];
+  const icon = WEAPON_ICONS[weapon.classKey];
+  return `
+    <button class="weapon-option" data-key="${key}">
+      <iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon>
+      <span>${weapon.displayName}</span>
+    </button>
+  `;
+}
+
+export function showWeaponSelectOverlay(state) {
+  let overlay = document.getElementById('weaponSelectOverlay');
+  if (overlay) overlay.remove();
+  overlay = document.createElement('div');
+  overlay.id = 'weaponSelectOverlay';
+  overlay.className = 'modal-overlay';
+  overlay.innerHTML = `
+    <div class="modal-backdrop"></div>
+    <div class="modal-content card weapon-select-card">
+      <div class="card-header">
+        <h4>Select Your Weapon</h4>
+        <button class="btn small ghost close-btn">×</button>
+      </div>
+      <div class="weapon-options">
+        ${CHOICES.map(renderOption).join('')}
+      </div>
+    </div>`;
+  document.body.appendChild(overlay);
+
+  function close() {
+    overlay.remove();
+  }
+  overlay.querySelector('.close-btn').addEventListener('click', close);
+  overlay.querySelector('.modal-backdrop').addEventListener('click', close);
+
+  overlay.querySelectorAll('.weapon-option').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const key = btn.getAttribute('data-key');
+      const id = addToInventory(WEAPONS[key], state);
+      const item = state.inventory.find(it => it.id === id);
+      equipItem(item, 'mainhand', state);
+      close();
+    });
+  });
+}

--- a/style.css
+++ b/style.css
@@ -5088,3 +5088,37 @@ html.reduce-motion .log-sheet{transition:none;}
 .rarity-rare { color: #fbbf24; }
 .rarity-epic { color: #a855f7; }
 .rarity-legendary { color: #f87171; }
+
+#weaponSelectOverlay .weapon-select-card {
+  background: #fff;
+  border: 2px solid #b38b5d;
+  padding: 20px;
+  text-align: center;
+}
+
+#weaponSelectOverlay .weapon-options {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+#weaponSelectOverlay .weapon-option {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px;
+  background: var(--panel);
+  border: 1px solid var(--ink-light);
+  cursor: pointer;
+}
+
+#weaponSelectOverlay .weapon-option:hover {
+  border-color: var(--accent);
+}
+
+#weaponSelectOverlay .weapon-icon {
+  width: 32px;
+  height: 32px;
+  margin: 0 0 4px;
+}


### PR DESCRIPTION
## Summary
- guide players to buy their first notable node with a new tutorial step
- allow adventure and proficiency UIs after claiming this step's reward
- use a modal overlay with weapon icons to choose between Dim Focus, Crude Knuckles, or Crude Nunchaku
- document updated tutorial flow and new UI file

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and structure checks)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4eb8c16c8326810f67bfa26ca2c1