### PR TITLE
Display current/required sect building costs

### DIFF
--- a/src/features/sect/ui/sectScreen.js
+++ b/src/features/sect/ui/sectScreen.js
@@ -1,6 +1,6 @@
 import { SECT_BUILDINGS } from '../data/buildings.js';
 import { getBuildingLevel } from '../selectors.js';
-import { getBuildingCost } from '../logic.js';
+import { getBuildingCost, canUpgrade } from '../logic.js';
 import { upgradeBuilding } from '../mutators.js';
 import { on } from '../../../shared/events.js';
 import { updateActivitySelectors } from '../../activity/ui/activityUI.js';
@@ -35,15 +35,18 @@ function renderBuildings(state){
       costDiv.textContent = 'Max level';
     } else {
       const cost = getBuildingCost(key, next);
-      const costStr = Object.entries(cost).map(([res, amt]) => `${amt} ${res}`).join(', ');
-      costDiv.textContent = costStr;
+      costDiv.innerHTML = Object.entries(cost).map(([res, amt]) => {
+        const current = state[res] || 0;
+        const color = current >= amt ? 'var(--foundation-primary)' : '#a52a2a';
+        return `<span style="color:${color}">${current}/${amt} ${res}</span>`;
+      }).join(', ');
     }
     card.appendChild(costDiv);
 
     const btn = document.createElement('button');
     btn.className = 'btn small';
     btn.textContent = next > b.maxLevel ? 'Max' : 'Upgrade';
-    btn.disabled = next > b.maxLevel;
+    btn.disabled = next > b.maxLevel || !canUpgrade(state.sect.buildings, state, state, key);
     btn.addEventListener('click', () => {
       if(upgradeBuilding(state, key)){
         render(state);


### PR DESCRIPTION
## Summary
- Show current and required materials for sect building upgrades
- Color costs green when affordable and red when lacking
- Disable upgrade button when resources are insufficient

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: VERIFICATION FAILED - MUST fix before proceeding)*

------
https://chatgpt.com/codex/tasks/task_e_68bf515eeaf883268ff3ba01aae41ff7