### PR TITLE
Add tutorial step for equipping first weapon

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,6 +6,7 @@ The game includes a simple tutorial that guides new players through the opening 
 2. **Gain foundation** – accumulate any amount of foundation.
 3. **Attempt a breakthrough** – begin a breakthrough once ready.
 4. **Purchase a notable astral tree node** – spend Insight on one of the larger nodes to unlock Adventure and choose a starting weapon.
+5. **Equip your weapon and defeat an enemy** – open the character menu to equip your weapon, then defeat a foe in the Forest Grove.
 
 The current progress is stored in `state.tutorial.step` and `state.tutorial.completed`.
 

--- a/src/features/tutorial/steps.js
+++ b/src/features/tutorial/steps.js
@@ -61,4 +61,19 @@ export const STEPS = [
       showWeaponSelectOverlay(state);
     },
   },
+  {
+    title: 'Choose your path',
+    text: 'There are 3 primary paths: Disciples of metal and fire use primal strength to brandish enemies and brute force through immortality by sheer resilience. Focus on fist, palms and hammers. Disciples of wood and earth use the knowledge and connection with the spirits to expand into greater horizons of existence. Focus on focus, wands and scepters. Disciples of water, freeflowing and nimble like water, harness the power to adapt any form. Use of spears, nunchaku and chakram. You may equip your weapon in the character menu. Access the menu and equip weapon to aid you in adventure progress',
+    req: 'Objective: equip weapon in character menu and defeat 1 enemy in forest grove',
+    reward: 'Reward: 10 cooked meat',
+    highlight: 'characterSelector',
+    check: state => {
+      const weaponEquipped = state.equipment?.mainhand?.key && state.equipment.mainhand.key !== 'fist';
+      const kills = state.adventure?.totalKills >= 1;
+      return weaponEquipped && kills;
+    },
+    applyReward(state) {
+      state.cookedMeat = (state.cookedMeat || 0) + 10;
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- extend tutorial with new step teaching players to equip a weapon and defeat an enemy
- document new weapon-equipping tutorial step in tutorial flow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf562814dc8326bbb52c7bc061146d