### PR TITLE
Add ability tutorial popup

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -7,6 +7,7 @@ The game includes a simple tutorial that guides new players through the opening 
 3. **Attempt a breakthrough** – begin a breakthrough once ready.
 4. **Purchase a notable astral tree node** – spend Insight on one of the larger nodes to unlock Adventure and choose a starting weapon.
 5. **Equip your weapon and defeat an enemy** – open the character menu to equip your weapon, then defeat a foe in the Forest Grove.
+6. **Use an ability** – activate any ability to learn about the ability system.
 
 The current progress is stored in `state.tutorial.step` and `state.tutorial.completed`.
 

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -58,6 +58,8 @@ export function tryCastAbility(abilityKey, state = S) {
     enqueue();
     processAbilityQueue(state);
   }
+  state.tutorial = state.tutorial || {};
+  state.tutorial.usedAbility = true;
   return true;
 }
 

--- a/src/features/tutorial/migrations.js
+++ b/src/features/tutorial/migrations.js
@@ -1,0 +1,8 @@
+export const migrations = [
+  (save) => {
+    save.tutorial = save.tutorial || {};
+    if (save.tutorial.usedAbility === undefined) {
+      save.tutorial.usedAbility = false;
+    }
+  }
+];

--- a/src/features/tutorial/state.js
+++ b/src/features/tutorial/state.js
@@ -3,4 +3,5 @@ export const tutorialState = {
   completed: false,
   showOverlay: true,
   rewardReady: false,
+  usedAbility: false,
 };

--- a/src/features/tutorial/steps.js
+++ b/src/features/tutorial/steps.js
@@ -76,4 +76,12 @@ export const STEPS = [
       state.cookedMeat = (state.cookedMeat || 0) + 10;
     },
   },
+  {
+    title: 'Abilities',
+    text: 'Each base type weapon comes with an ability. Abilities usually cost qi to use and have a set cooldown before it can be used again. More abilities may be learned or equipped through laws or manuals. Abilities may be equipped in character menu abilities sub tab.',
+    req: 'Objective: Use an ability.',
+    reward: 'Reward: None.',
+    highlight: 'abilityBar',
+    check: state => state.tutorial?.usedAbility,
+  },
 ];

--- a/src/game/migrations.js
+++ b/src/game/migrations.js
@@ -14,6 +14,7 @@ import { migrations as proficiency } from '../features/proficiency/migrations.js
 import { migrations as progression } from '../features/progression/migrations.js';
 import { migrations as sect } from '../features/sect/migrations.js';
 import { migrations as weaponGeneration } from '../features/weaponGeneration/migrations.js';
+import { migrations as tutorial } from '../features/tutorial/migrations.js';
 
 const migrations = [
   ...progression,
@@ -24,6 +25,7 @@ const migrations = [
   ...cooking,
   ...forging,
   ...ability,
+  ...tutorial,
   ...adventure,
   ...affixes,
   ...combat,


### PR DESCRIPTION
## Summary
- Show tutorial overlay when the player uses an ability
- Track ability usage and migrate saves for new flag
- Document the new ability tutorial step

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68bf5eec55148326a4bcef6ae2b1c416