### PR TITLE
feat: add ability tutorial popup

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -337,6 +337,7 @@ way-of-ascension/
 │       ├── notifications.js
 │       ├── sidebar.js
 │       ├── tutorialBox.js
+│       ├── tutorialPopups.js
 │       └── weaponSelectOverlay.js
 ├── ui/
 │   └── index.js
@@ -1259,5 +1260,6 @@ Paths added:
 - `src/features/tutorial/state.js` – stores tutorial step and completion flag.
 - `src/features/tutorial/logic.js` – evaluates player actions and advances steps.
 - `src/ui/tutorialBox.js` – displays on-screen guidance during the tutorial.
+- `src/ui/tutorialPopups.js` – shows contextual tutorial pop ups when actions are performed.
 - `src/ui/weaponSelectOverlay.js` – overlay to choose a starting weapon after unlocking Adventure.
 - `src/features/tutorial/steps.js` – Step definitions and triggers for tutorial progression.

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -80,6 +80,7 @@ export function processAbilityQueue(state = S) {
 }
 
 function applyAbilityResult(abilityKey, res, state) {
+  emit('ABILITY:CAST', { abilityKey });
   if (!res) return;
   const ability = ABILITIES[abilityKey];
   const logs = state.adventure?.combatLog;

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -41,6 +41,7 @@ import { onTick as mindOnTick } from "./mind/index.js";
 import { log } from "../shared/utils/dom.js";
 import { mountTutorialBox } from "../ui/tutorialBox.js";
 import { mountNotificationTray } from "../ui/notifications.js";
+import { mountAbilityTutorialPopup } from "../ui/tutorialPopups.js";
 
 
 // Example placeholder for later:
@@ -132,6 +133,7 @@ export function mountAllFeatureUIs(state) {
   applyDevUnlockPreset(state);
   mountNotificationTray(state);
   mountTutorialBox(state);
+  mountAbilityTutorialPopup(state);
   const { flags } = configReport();
   const ensure = (containerId, id, activity, label) => {
     const container = document.getElementById(containerId);

--- a/src/features/tutorial/state.js
+++ b/src/features/tutorial/state.js
@@ -3,4 +3,5 @@ export const tutorialState = {
   completed: false,
   showOverlay: true,
   rewardReady: false,
+  abilityPopupShown: false,
 };

--- a/src/ui/tutorialPopups.js
+++ b/src/ui/tutorialPopups.js
@@ -1,0 +1,31 @@
+import { on } from '../shared/events.js';
+
+export function mountAbilityTutorialPopup(state) {
+  on('ABILITY:CAST', () => {
+    if (state.tutorial?.abilityPopupShown) return;
+    state.tutorial = state.tutorial || {};
+    state.tutorial.abilityPopupShown = true;
+    showAbilityPopup();
+  });
+}
+
+function showAbilityPopup() {
+  if (document.getElementById('abilityTutorialOverlay')) return;
+  const overlay = document.createElement('div');
+  overlay.id = 'abilityTutorialOverlay';
+  overlay.className = 'modal-overlay';
+  overlay.innerHTML = `
+    <div class="modal-backdrop"></div>
+    <div class="modal-content tutorial-card">
+      <div class="card-header">
+        <h4>Abilities</h4>
+        <button class="btn small ghost close-btn">×</button>
+      </div>
+      <p>Each base type weapon comes with an ability. Abilities usually cost qi to use and have a set cooldown before it can be used again. More abilities may be learned or equipped through laws or manuals. Abilities may be equipped in character menu abilities sub tab</p>
+    </div>`;
+  document.body.appendChild(overlay);
+
+  function close() { overlay.remove(); }
+  overlay.querySelector('.close-btn').addEventListener('click', close);
+  overlay.querySelector('.modal-backdrop').addEventListener('click', close);
+}

--- a/style.css
+++ b/style.css
@@ -5042,8 +5042,9 @@ html.reduce-motion .log-sheet{transition:none;}
   background: rgba(0,0,0,0.6);
 }
 
-#tutorialOverlay .tutorial-card {
-  background: #fff;
+#tutorialOverlay .tutorial-card,
+#abilityTutorialOverlay .tutorial-card {
+  background: #f2ecd8;
   border: 2px solid #b38b5d;
   padding: 20px;
   max-width: 400px;


### PR DESCRIPTION
## Summary
- show contextual tutorial popup after first ability use
- emit ability cast events to trigger tutorial overlays
- document new tutorial popup UI
- style ability tutorial with parchment background

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: UI state violations and DOM warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5eec55148326a4bcef6ae2b1c416