### PR TITLE
fix: ensure hard reset clears all local data

### DIFF
--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -136,8 +136,15 @@ function initUI(){
       if (confirm('Hard reset?')) {
         // Wipe all persisted data so no stray keys survive a reset.
         // This covers older save slots and any feature-specific flags.
+        // Some browsers may block clear(), so remove known keys manually
+        // as a fallback to ensure progress and settings reset.
         try {
           localStorage.clear();
+        } catch {}
+        try {
+          ['woa-save', 'astralTreeAllocated', 'reduce-motion'].forEach(k =>
+            localStorage.removeItem(k)
+          );
         } catch {}
         setState(defaultState());
         save();


### PR DESCRIPTION
## Summary
- hard reset now removes all game-related localStorage keys in addition to clearing storage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement report)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8684c2dc83269d12c03bde36a0d8