### PR TITLE
Clear save data on reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- Hard reset now clears all local data so prior saves or settings don't linger.
+- Hard reset now explicitly removes save keys before clearing storage to ensure progress resets cleanly.
+- Reset button cancels and blocks autosaves to fully wipe progress.
 - Expanded weapon families (Straight Sword, Crude Dagger, etc.) with implicit stat bonuses.
 - Peaceful Lands, Forest Edge, and Meadow Path can now drop these sample weapons at low rates for testing.
 - Generalized weapon proficiency to all weapon types with enemy HP–based XP gains (max HP ÷ 30 per attack).

--- a/src/shared/saveLoad.js
+++ b/src/shared/saveLoad.js
@@ -1,4 +1,23 @@
-const KEY = "woa:save:v1";
-export function loadSave(defaultState){ try{ const raw = localStorage.getItem(KEY); return raw ? {...defaultState, ...JSON.parse(raw)} : defaultState; }catch{ return defaultState; } }
+// Export the save key so other modules can explicitly remove it if needed
+export const SAVE_KEY = "woa:save:v1";
+export function loadSave(defaultState){
+  try{
+    const raw = localStorage.getItem(SAVE_KEY);
+    return raw ? { ...defaultState, ...JSON.parse(raw) } : defaultState;
+  }catch{
+    return defaultState;
+  }
+}
 let saveTimer;
-export function saveDebounced(state){ clearTimeout(saveTimer); saveTimer = setTimeout(() => { try{ localStorage.setItem(KEY, JSON.stringify(state)); }catch{} }, 300); }
+let saveBlocked = false;
+export function saveDebounced(state){
+  if (saveBlocked) return;
+  clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    try{ localStorage.setItem(SAVE_KEY, JSON.stringify(state)); }catch{}
+  }, 300);
+}
+export function cancelSaveDebounce(){
+  saveBlocked = true;
+  clearTimeout(saveTimer);
+}

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -8,6 +8,7 @@ import { mountDiagnostics } from './diagnostics.js';
 import { mountAllFeatureUIs, runAllFeatureTicks } from '../features/index.js';
 import { applyDevUnlockPreset } from '../features/devUnlock.js';
 import { S, defaultState, save, setState, validateState } from '../shared/state.js';
+import { cancelSaveDebounce, SAVE_KEY } from '../shared/saveLoad.js';
 import { GameController } from '../game/GameController.js';
 import {
   updateRealmUI,
@@ -136,7 +137,12 @@ function initUI(){
       if (confirm('Hard reset?')) {
         // Wipe all persisted data so no stray keys survive a reset.
         // This covers older save slots and any feature-specific flags.
+        cancelSaveDebounce();
         try {
+          // Explicitly remove both current and legacy save keys in case
+          // storage.clear() fails in some browsers.
+          localStorage.removeItem(SAVE_KEY);
+          localStorage.removeItem('woa-save');
           localStorage.clear();
         } catch {}
         setState(defaultState());


### PR DESCRIPTION
## Summary
- Export save key so reset logic can remove it directly
- Reset button removes both current and legacy save keys before clearing storage
- Document robust reset behaviour in changelog

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI state violations and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8684c2dc83269d12c03bde36a0d8