### PR TITLE
Stop autosave from repopulating state on reset

### DIFF
--- a/src/shared/saveLoad.js
+++ b/src/shared/saveLoad.js
@@ -2,3 +2,4 @@ const KEY = "woa:save:v1";
 export function loadSave(defaultState){ try{ const raw = localStorage.getItem(KEY); return raw ? {...defaultState, ...JSON.parse(raw)} : defaultState; }catch{ return defaultState; } }
 let saveTimer;
 export function saveDebounced(state){ clearTimeout(saveTimer); saveTimer = setTimeout(() => { try{ localStorage.setItem(KEY, JSON.stringify(state)); }catch{} }, 300); }
+export function cancelSaveDebounce(){ clearTimeout(saveTimer); }


### PR DESCRIPTION
## Summary
- expose running GameController so UI can stop it
- add cancelSaveDebounce to clear pending autosave timers
- halt controller and cancel autosave before wiping save data during hard reset

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: verification failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9c73a5248326acb2dfbe564e2505