### PR TITLE
Enhance tutorial journal entries with clickable colored checkmarks

### DIFF
--- a/src/features/library/ui/libraryDisplay.js
+++ b/src/features/library/ui/libraryDisplay.js
@@ -1,4 +1,5 @@
 import { STEPS } from '../../tutorial/steps.js';
+import { emit } from '../../../shared/events.js';
 
 export function mountLibraryUI(state) {
   updateLibraryJournal(state);
@@ -13,20 +14,38 @@ export function updateLibraryJournal(state) {
   const { step = 0, completed = false } = t;
 
   STEPS.forEach((s, idx) => {
+    if (!completed && idx > step) return;
+
+    const li = document.createElement('li');
+    const mark = document.createElement('span');
+    mark.className = 'checkmark';
+    mark.textContent = '✔';
+
+    const text = document.createElement('span');
+    text.textContent = s.req;
+
+    li.append(mark, text);
+    li.addEventListener('click', () => emit('OPEN_TUTORIAL'));
+
     if (completed || idx < step) {
-      const li = document.createElement('li');
-      li.textContent = `✔ ${s.req}`;
-      list.appendChild(li);
-    } else if (idx === step && !completed) {
-      const li = document.createElement('li');
-      li.textContent = `➤ ${s.req}`;
-      list.appendChild(li);
+      li.classList.add('completed');
+    } else {
+      li.classList.add('current');
     }
+
+    list.appendChild(li);
   });
 
   if (t.abilityPopupShown) {
     const li = document.createElement('li');
-    li.textContent = '✔ Ability tutorial unlocked';
+    const mark = document.createElement('span');
+    mark.className = 'checkmark';
+    mark.textContent = '✔';
+    const text = document.createElement('span');
+    text.textContent = 'Ability tutorial unlocked';
+    li.append(mark, text);
+    li.classList.add('completed');
+    li.addEventListener('click', () => emit('OPEN_TUTORIAL'));
     list.appendChild(li);
   }
 }

--- a/style.css
+++ b/style.css
@@ -5123,3 +5123,29 @@ html.reduce-motion .log-sheet{transition:none;}
   height: 32px;
   margin: 0 0 4px;
 }
+
+/* Journal entries styling */
+#journalEntries {
+  list-style: none;
+  padding-left: 0;
+}
+
+#journalEntries li {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.9em;
+  cursor: pointer;
+}
+
+#journalEntries li .checkmark {
+  font-weight: bold;
+}
+
+#journalEntries li.completed .checkmark {
+  color: var(--foundation-primary);
+}
+
+#journalEntries li.current .checkmark {
+  color: var(--core-primary);
+}


### PR DESCRIPTION
## Summary
- render tutorial journal entries with colored checkmarks and smaller text
- remove bullets and make entries clickable to reopen tutorial overlay
- style journal list for green completed and blue current states

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c0a534ee6083269807685ad0def827