### PR TITLE
fix: mount adventure after tutorial

### DIFF
--- a/src/features/index.js
+++ b/src/features/index.js
@@ -195,6 +195,7 @@ export function mountAllFeatureUIs(state) {
   }
   const vis = debugFeatureVisibility(state);
   if (vis.character?.visible) ensure('managementActivities', 'characterSelector', 'character', 'Character');
+  if (vis.adventure?.visible) ensure('managementActivities', 'adventureSelector', 'adventure', 'Adventure');
   if (vis.cultivation?.visible) mountCultivationSidebar(state);
   if (flags.FEATURE_PROFICIENCY?.parsedValue && vis.proficiency.visible) mountProficiencyUI(state);
   if (flags.FEATURE_SECT?.parsedValue && vis.sect.visible) mountSectUI(state);


### PR DESCRIPTION
## Summary
- mount adventure activity when tutorial unlocks it

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: VERIFICATION FAILED - MUST fix before proceeding)


------
https://chatgpt.com/codex/tasks/task_e_68c0a6fb93c4832683d1c9c10e144662