### PR TITLE
fix: use valid palm icons

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -20,7 +20,8 @@ export const ABILITIES = {
   palmStrike: {
     key: 'palmStrike',
     displayName: 'Palm Strike',
-    icon: 'ph:hand-palm-thin',
+    // Use a game-icons palm to avoid missing phosphor icon rendering
+    icon: 'game-icons:open-palm',
     costQi: 0,
     cooldownMs: 0,
     castTimeMs: 0,

--- a/src/features/combat/ui/fx.js
+++ b/src/features/combat/ui/fx.js
@@ -70,7 +70,8 @@ export function playPalmHit(svg, at) {
   const parent = svg.parentNode;
   if (!parent || reduceMotion || active >= MAX_FX) return;
   const icon = document.createElement('iconify-icon');
-  icon.setAttribute('icon', 'ph:hand-palm-fill');
+  // Use a reliable game-icons palm to ensure the hit effect renders correctly
+  icon.setAttribute('icon', 'game-icons:open-palm');
   icon.setAttribute('aria-hidden', 'true');
   icon.classList.add('fx-palm-hit');
   icon.style.left = `calc(${at.x}% - 12px)`;

--- a/src/features/weaponGeneration/data/weaponIcons.js
+++ b/src/features/weaponGeneration/data/weaponIcons.js
@@ -7,6 +7,7 @@ export const WEAPON_ICONS = {
   spear: 'mdi:spear',
   focus: 'ri:focus-line',
   fist: 'game-icons:fist',
-  palm: 'ph:hand-palm-thin',
+  // Phosphor's hand-palm icon fails to render; use a game-icons palm instead
+  palm: 'game-icons:open-palm',
   nunchaku: 'game-icons:nunchaku',
 };


### PR DESCRIPTION
## Summary
- replace missing phosphor palm icon with game-icons variant for palm strike ability and palm weapon
- ensure palm hit effect uses game-icons palm

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement: app.js imports feature internals...)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a8c7d5708326a17ae1640e7ea574