### PR TITLE
Unlock activities from starting astral notables

### DIFF
--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -595,16 +595,25 @@ function isAllocatable(id, allocated, adj, manifest) {
 
 function applyEffects(id, manifest) {
   const info = manifest[id];
-  if (!info || !info.bonus) return;
+  if (!info) return;
   const bonuses = S.astralTreeBonuses || (S.astralTreeBonuses = {});
-  for (const [k, v] of Object.entries(info.bonus)) {
-    if (typeof v === 'number') {
-      bonuses[k] = (bonuses[k] || 0) + v;
-    } else if (typeof v === 'boolean') {
-      bonuses[k] = bonuses[k] || v;
+  if (info.bonus) {
+    for (const [k, v] of Object.entries(info.bonus)) {
+      if (typeof v === 'number') {
+        bonuses[k] = (bonuses[k] || 0) + v;
+      } else if (typeof v === 'boolean') {
+        bonuses[k] = bonuses[k] || v;
+      }
     }
   }
   renderAstralTreeTotals();
   recomputePlayerTotals(S);
+
+  // Unlock corresponding activities when purchasing starting notables
+  if (id === 4060 || id === 4061 || id === 4062) {
+    import('../../index.js').then(m => {
+      if (typeof m.mountAllFeatureUIs === 'function') m.mountAllFeatureUIs(S);
+    });
+  }
 }
 


### PR DESCRIPTION
## Summary
- Recompute bonuses and update UI whenever astral nodes are purchased
- Unlock mining, gathering, mind, agility, catching activities after buying their starting notables

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UI rule & timer violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a9b6929c8326895571aa04637c3b