### PR TITLE
Update Palm Strike icon

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -20,7 +20,7 @@ export const ABILITIES = {
   palmStrike: {
     key: 'palmStrike',
     displayName: 'Palm Strike',
-    icon: 'ph:hand-palm-thin',
+    icon: 'arcticons:palmpay',
     costQi: 0,
     cooldownMs: 0,
     castTimeMs: 0,


### PR DESCRIPTION
## Summary
- replace Palm Strike ability icon with `arcticons:palmpay`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (UI state violations and warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c0ab76c1b88326a8592c0321dfd7a2