### PR TITLE
Update Palm Strike icon

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -20,7 +20,7 @@ export const ABILITIES = {
   palmStrike: {
     key: 'palmStrike',
     displayName: 'Palm Strike',
-    icon: 'ph:hand-palm-thin',
+    icon: 'arcticons:palmpay',
     costQi: 0,
     cooldownMs: 0,
     castTimeMs: 0,

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -468,6 +468,13 @@ export function updateAbilityBar() {
     'game-icons:mighty-force': '💥',
     'game-icons:fireball': '🔥',
   };
+
+  const renderIcon = (icon) => {
+    if (iconMap[icon]) return iconMap[icon];
+    return icon.includes(':')
+      ? `<iconify-icon icon="${icon}" aria-hidden="true"></iconify-icon>`
+      : icon;
+  };
   let html = '';
   const slotData = [];
   slots.forEach((slot, i) => {
@@ -505,7 +512,7 @@ export function updateAbilityBar() {
           ${dmgLine}
           ${castLine}
         </div>
-        <div class="ability-icon">${iconMap[def.icon] || def.icon}</div>
+        <div class="ability-icon">${renderIcon(def.icon)}</div>
         <div class="qi-badge">${def.costQi} Qi</div>
         <div class="keybind">[${i + 1}]</div>
       `;


### PR DESCRIPTION
## Summary
- replace Palm Strike ability icon with `arcticons:palmpay`
- render ability icons with Iconify so Palm Strike appears correctly

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: verification failed, UI state violations and other warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c0ab76c1b88326a8592c0321dfd7a2