### PR TITLE
feat: add PoE-style gear grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -885,16 +885,47 @@
               <button class="gear-tab-btn" data-tab="gearAbilities">Abilities</button>
             </div>
             <div id="gearEquipSubTab" class="gear-tab-content active">
-              <div class="equip-slots">
-                <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-head"><span class="slot-label">Head</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-body"><span class="slot-label">Body</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-foot"><span class="slot-label">Feet</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring1"><span class="slot-label">Ring 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring2"><span class="slot-label">Ring 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman1"><span class="slot-label">Talisman 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman2"><span class="slot-label">Talisman 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-food"><span class="slot-label">Food</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
+              <div class="gear-grid">
+                <div class="gear-slot size-m" id="slot-head" aria-label="Equip Head" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Head" hidden>✕</button>
+                </div>
+                <div class="gear-slot size-s" id="slot-ring1" aria-label="Equip Accessory" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Accessory" hidden>✕</button>
+                </div>
+                <div class="gear-slot size-m" id="slot-mainhand" aria-label="Equip Weapon" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Weapon" hidden>✕</button>
+                </div>
+                <div class="gear-slot size-l" id="slot-body" aria-label="Equip Body" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Body" hidden>✕</button>
+                </div>
+                <div class="gear-slot size-s" id="slot-talisman1" aria-label="Equip Talisman 1" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Talisman 1" hidden>✕</button>
+                </div>
+                <div class="gear-slot size-s" id="slot-talisman2" aria-label="Equip Talisman 2" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Talisman 2" hidden>✕</button>
+                </div>
+                <div class="gear-slot size-s" id="slot-ring2" aria-label="Equip Talisman 3" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Talisman 3" hidden>✕</button>
+                </div>
+                <div class="gear-slot size-s" id="slot-food" aria-label="Equip Food" tabindex="0">
+                  <div class="slot-icon"></div>
+                  <div class="slot-name">Empty</div>
+                  <button class="unequip-chip" aria-label="Unequip Food" hidden>✕</button>
+                </div>
               </div>
               <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%">🛡 <span id="armorVal">0</span></div>
               <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -105,14 +105,13 @@ function renderStats() {
 
 function renderEquipment() {
   const slots = [
-    { key: 'mainhand', label: 'Weapon' },
     { key: 'head', label: 'Head' },
+    { key: 'ring1', label: 'Accessory' },
+    { key: 'mainhand', label: 'Weapon' },
     { key: 'body', label: 'Body' },
-    { key: 'foot', label: 'Feet' },
-    { key: 'ring1', label: 'Ring 1' },
-    { key: 'ring2', label: 'Ring 2' },
     { key: 'talisman1', label: 'Talisman 1' },
     { key: 'talisman2', label: 'Talisman 2' },
+    { key: 'ring2', label: 'Talisman 3' },
     { key: 'food', label: 'Food' }
   ];
   slots.forEach(s => {
@@ -123,18 +122,18 @@ function renderEquipment() {
     const icon = item?.type === 'weapon'
       ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
       : GEAR_ICONS[item?.slot || item?.type];
-    const stars = QUALITY_STARS[item?.quality] || '';
-    const rarity = item?.rarity;
-    const rarityColor = RARITY_COLORS[rarity] || '';
-    const rarityPrefix = rarity && rarity !== 'normal' ? `${rarity[0].toUpperCase()}${rarity.slice(1)} ` : '';
-    const displayName = rarityPrefix + name;
-    const baseNameHtml = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${displayName}` : displayName;
-    const coloredNameHtml = rarityColor ? `<span style="color:${rarityColor}">${baseNameHtml}</span>` : baseNameHtml;
-    const nameHtml = stars ? `${stars} ${coloredNameHtml}` : coloredNameHtml;
-    el.querySelector('.slot-name').innerHTML = nameHtml;
-    el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
-    el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
+    const iconEl = el.querySelector('.slot-icon');
+    iconEl.innerHTML = item && icon ? `<iconify-icon icon="${icon}"></iconify-icon>` : '';
+    el.querySelector('.slot-name').textContent = item ? name : 'Empty';
+    const chip = el.querySelector('.unequip-chip');
+    chip.hidden = !item;
+    chip.onclick = e => { e.stopPropagation(); unequip(s.key); renderEquipmentPanel(); };
+    chip.setAttribute('aria-label', `Unequip ${s.label}`);
+    el.onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
+    el.setAttribute('aria-label', `Equip ${s.label}`);
     const element = item?.element || item?.imbuement?.element;
+    el.classList.toggle('equipped', !!item);
+    el.classList.toggle('empty', !item);
     el.style.backgroundColor = element ? (ELEMENT_BG_COLORS[element] || '') : '';
   });
   const armorEl = document.getElementById('armorVal');

--- a/style.css
+++ b/style.css
@@ -27,6 +27,11 @@
   --card-gap: 8px;
   --dot-size: 8px;
   --row-h: 48px;
+
+  --slotS: clamp(48px, 15vw, 60px);
+  --slotM: clamp(68px, 20vw, 84px);
+  --slotL-w: calc(var(--slotM) * 1.6);
+  --slotL-h: calc(var(--slotM) * 2);
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
   --mortal-primary: #a66c4c; /* lighter saddle brown */
@@ -2208,6 +2213,126 @@ html.reduce-motion .shield-shimmer{animation:none;}
 
 .gear-tab-content.active {
   display: block;
+}
+
+.gear-grid {
+  display: grid;
+  grid-template-columns: var(--slotS) var(--slotM) var(--slotL-w) var(--slotS);
+  grid-auto-rows: var(--slotS);
+  gap: 8px;
+  justify-content: center;
+}
+
+.gear-slot {
+  position: relative;
+  box-sizing: border-box;
+  width: var(--slotS);
+  height: var(--slotS);
+  border: 1px dashed var(--muted);
+  border-radius: 8px;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  background: transparent;
+  cursor: pointer;
+}
+
+.gear-slot.equipped {
+  border-style: solid;
+}
+
+.gear-slot.empty {
+  color: var(--muted);
+}
+
+.gear-slot .slot-icon {
+  width: 70%;
+  height: 70%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gear-slot .slot-icon iconify-icon {
+  width: 100%;
+  height: 100%;
+}
+
+.gear-slot .slot-name {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gear-slot .unequip-chip {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: var(--panel);
+  border: 1px solid var(--muted);
+  border-radius: 8px;
+  font-size: 10px;
+  line-height: 1;
+  padding: 2px 4px;
+  cursor: pointer;
+}
+
+.gear-slot.size-m {
+  width: var(--slotM);
+  height: var(--slotM);
+}
+
+.gear-slot.size-l {
+  width: var(--slotL-w);
+  height: var(--slotL-h);
+}
+
+#slot-head {
+  grid-column: 2 / span 2;
+  justify-self: center;
+}
+
+#slot-ring1 {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+#slot-mainhand {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+#slot-body {
+  grid-column: 3;
+  grid-row: 2 / span 3;
+}
+
+#slot-talisman1 {
+  grid-column: 4;
+  grid-row: 2;
+}
+
+#slot-talisman2 {
+  grid-column: 4;
+  grid-row: 3;
+}
+
+#slot-ring2 {
+  grid-column: 4;
+  grid-row: 4;
+}
+
+#slot-food {
+  grid-column: 1 / -1;
+  grid-row: 5;
+  justify-self: center;
 }
 
 .ability-slot,


### PR DESCRIPTION
## Summary
- replace vertical equipment list with PoE-style gear grid layout
- add responsive slot sizing tokens and grid styling
- update equipment renderer for slot click and unequip chip behavior

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement)*
- `npm run scan-output`
- `npm run scan-env`
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c0b27716cc83269bb3a61a09f1625e