### PR TITLE
feat: add gear grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -885,16 +885,15 @@
               <button class="gear-tab-btn" data-tab="gearAbilities">Abilities</button>
             </div>
             <div id="gearEquipSubTab" class="gear-tab-content active">
-              <div class="equip-slots">
-                <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-head"><span class="slot-label">Head</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-body"><span class="slot-label">Body</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-foot"><span class="slot-label">Feet</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring1"><span class="slot-label">Ring 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring2"><span class="slot-label">Ring 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman1"><span class="slot-label">Talisman 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman2"><span class="slot-label">Talisman 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-food"><span class="slot-label">Food</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
+              <div class="equip-grid">
+                <div class="equip-slot slot-m" id="slot-head"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
+                <div class="equip-slot slot-s" id="slot-ring1"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
+                <div class="equip-slot slot-m" id="slot-mainhand"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
+                <div class="equip-slot slot-l" id="slot-body"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
+                <div class="equip-slot slot-s" id="slot-ring2"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
+                <div class="equip-slot slot-s" id="slot-talisman1"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
+                <div class="equip-slot slot-s" id="slot-talisman2"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
+                <div class="equip-slot slot-s" id="slot-food"><span class="slot-name">Empty</span><button class="unequip-btn">Unequip</button></div>
               </div>
               <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%">🛡 <span id="armorVal">0</span></div>
               <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -105,14 +105,13 @@ function renderStats() {
 
 function renderEquipment() {
   const slots = [
-    { key: 'mainhand', label: 'Weapon' },
     { key: 'head', label: 'Head' },
+    { key: 'ring1', label: 'Accessory' },
+    { key: 'mainhand', label: 'Weapon' },
     { key: 'body', label: 'Body' },
-    { key: 'foot', label: 'Feet' },
-    { key: 'ring1', label: 'Ring 1' },
-    { key: 'ring2', label: 'Ring 2' },
-    { key: 'talisman1', label: 'Talisman 1' },
-    { key: 'talisman2', label: 'Talisman 2' },
+    { key: 'ring2', label: 'T1' },
+    { key: 'talisman1', label: 'T2' },
+    { key: 'talisman2', label: 'T3' },
     { key: 'food', label: 'Food' }
   ];
   slots.forEach(s => {
@@ -132,10 +131,21 @@ function renderEquipment() {
     const coloredNameHtml = rarityColor ? `<span style="color:${rarityColor}">${baseNameHtml}</span>` : baseNameHtml;
     const nameHtml = stars ? `${stars} ${coloredNameHtml}` : coloredNameHtml;
     el.querySelector('.slot-name').innerHTML = nameHtml;
-    el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
-    el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
+    const unequipBtn = el.querySelector('.unequip-btn');
+    el.onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
+    unequipBtn.onclick = ev => { ev.stopPropagation(); unequip(s.key); renderEquipmentPanel(); };
     const element = item?.element || item?.imbuement?.element;
     el.style.backgroundColor = element ? (ELEMENT_BG_COLORS[element] || '') : '';
+    if (item) {
+      el.classList.add('equipped');
+      unequipBtn.style.display = '';
+    } else {
+      el.classList.remove('equipped');
+      unequipBtn.style.display = 'none';
+      el.querySelector('.slot-name').textContent = 'Empty';
+    }
+    el.setAttribute('aria-label', item ? `${s.label}: ${name}` : `Equip ${s.label}`);
+    unequipBtn.setAttribute('aria-label', `Unequip ${s.label}`);
   });
   const armorEl = document.getElementById('armorVal');
   if (armorEl) armorEl.textContent = S.stats?.armor || 0;

--- a/style.css
+++ b/style.css
@@ -2210,6 +2210,80 @@ html.reduce-motion .shield-shimmer{animation:none;}
   display: block;
 }
 
+/* Equipment grid layout */
+.equip-grid {
+  --slotS: clamp(48px, 15vw, 60px);
+  --slotM: clamp(68px, 20vw, 84px);
+  --slotL-w: calc(var(--slotM) * 1.6);
+  --slotL-h: calc(var(--slotM) * 2.0);
+  display: grid;
+  grid-template-columns: var(--slotS) var(--slotM) var(--slotL-w) var(--slotS);
+  grid-auto-rows: var(--slotM);
+  gap: 8px;
+  justify-content: center;
+}
+
+.equip-slot {
+  position: relative;
+  border: 1px dashed var(--muted);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px;
+  cursor: pointer;
+}
+
+.equip-slot.equipped {
+  border-style: solid;
+}
+
+.slot-s { width: var(--slotS); height: var(--slotS); }
+.slot-m { width: var(--slotM); height: var(--slotM); }
+.slot-l { width: var(--slotL-w); height: var(--slotL-h); }
+
+.equip-slot .slot-name {
+  font-size: 12px;
+  text-align: center;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.equip-slot .unequip-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 10px;
+  padding: 2px 4px;
+  border: none;
+  background: var(--panel);
+  border-radius: 4px;
+  display: none;
+}
+
+.equip-slot.equipped .unequip-btn {
+  display: block;
+}
+
+#slot-head {
+  grid-column: 2 / span 2;
+  grid-row: 1;
+  justify-self: center;
+}
+
+#slot-ring1 { grid-column: 1; grid-row: 2; }
+#slot-mainhand { grid-column: 2; grid-row: 2; }
+#slot-body { grid-column: 3; grid-row: 2 / span 3; }
+#slot-ring2 { grid-column: 4; grid-row: 2; }
+#slot-talisman1 { grid-column: 4; grid-row: 3; }
+#slot-talisman2 { grid-column: 4; grid-row: 4; }
+#slot-food { grid-column: 1; grid-row: 5; justify-self: center; }
+
 .ability-slot,
 .available-ability {
   display: flex;


### PR DESCRIPTION
## Summary
- replace vertical equipment list with 4-column gear grid
- add responsive slot sizing and styling for small/medium/large slots
- update equipment rendering to use grid slots and inline unequip chips

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c0b27716cc83269bb3a61a09f1625e