### PR TITLE
feat: overhaul gear panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -884,18 +884,17 @@
               <button class="gear-tab-btn active" data-tab="gearEquip">Gear</button>
               <button class="gear-tab-btn" data-tab="gearAbilities">Abilities</button>
             </div>
-            <div id="gearEquipSubTab" class="gear-tab-content active">
-              <div class="equip-slots">
-                <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-head"><span class="slot-label">Head</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-body"><span class="slot-label">Body</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-foot"><span class="slot-label">Feet</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring1"><span class="slot-label">Ring 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring2"><span class="slot-label">Ring 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman1"><span class="slot-label">Talisman 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman2"><span class="slot-label">Talisman 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-food"><span class="slot-label">Food</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-              </div>
+              <div id="gearEquipSubTab" class="gear-tab-content active">
+                <div class="equip-grid">
+                  <div class="slot slot-m head-slot" id="slot-head" aria-label="Equip Head"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                  <div class="slot slot-s accessory-slot" id="slot-ring1" aria-label="Equip Accessory"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                  <div class="slot slot-m weapon-slot" id="slot-mainhand" aria-label="Equip Weapon"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                  <div class="slot slot-l body-slot" id="slot-body" aria-label="Equip Body"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                  <div class="slot slot-s talisman1-slot" id="slot-ring2" aria-label="Equip Talisman 1"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                  <div class="slot slot-s talisman2-slot" id="slot-talisman1" aria-label="Equip Talisman 2"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                  <div class="slot slot-s talisman3-slot" id="slot-talisman2" aria-label="Equip Talisman 3"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                  <div class="slot slot-s food-slot" id="slot-food" aria-label="Equip Food"><span class="slot-name">Empty</span><button class="unequip-btn btn small">Unequip</button></div>
+                </div>
               <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%">🛡 <span id="armorVal">0</span></div>
               <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>
               <div class="stat" title="Chance to avoid attacks">👣 <span id="dodgeVal">0</span></div>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -105,14 +105,13 @@ function renderStats() {
 
 function renderEquipment() {
   const slots = [
-    { key: 'mainhand', label: 'Weapon' },
     { key: 'head', label: 'Head' },
+    { key: 'ring1', label: 'Accessory' },
+    { key: 'mainhand', label: 'Weapon' },
     { key: 'body', label: 'Body' },
-    { key: 'foot', label: 'Feet' },
-    { key: 'ring1', label: 'Ring 1' },
-    { key: 'ring2', label: 'Ring 2' },
-    { key: 'talisman1', label: 'Talisman 1' },
-    { key: 'talisman2', label: 'Talisman 2' },
+    { key: 'ring2', label: 'Talisman 1' },
+    { key: 'talisman1', label: 'Talisman 2' },
+    { key: 'talisman2', label: 'Talisman 3' },
     { key: 'food', label: 'Food' }
   ];
   slots.forEach(s => {
@@ -132,8 +131,14 @@ function renderEquipment() {
     const coloredNameHtml = rarityColor ? `<span style="color:${rarityColor}">${baseNameHtml}</span>` : baseNameHtml;
     const nameHtml = stars ? `${stars} ${coloredNameHtml}` : coloredNameHtml;
     el.querySelector('.slot-name').innerHTML = nameHtml;
-    el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
-    el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
+    el.classList.toggle('equipped', !!item);
+    el.onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
+    const unequipBtn = el.querySelector('.unequip-btn');
+    if (unequipBtn) {
+      unequipBtn.onclick = ev => { ev.stopPropagation(); unequip(s.key); renderEquipmentPanel(); };
+      unequipBtn.setAttribute('aria-label', `Unequip ${s.label}`);
+    }
+    el.setAttribute('aria-label', `Equip ${s.label}`);
     const element = item?.element || item?.imbuement?.element;
     el.style.backgroundColor = element ? (ELEMENT_BG_COLORS[element] || '') : '';
   });

--- a/style.css
+++ b/style.css
@@ -2210,6 +2210,74 @@ html.reduce-motion .shield-shimmer{animation:none;}
   display: block;
 }
 
+/* Equipment grid layout */
+:root {
+  --slotS: clamp(48px, 15vw, 60px);
+  --slotM: clamp(68px, 20vw, 84px);
+  --slotL-w: calc(var(--slotM) * 1.6);
+  --slotL-h: calc(var(--slotM) * 2.0);
+}
+
+.equip-grid {
+  display: grid;
+  grid-template-columns: var(--slotS) var(--slotM) var(--slotL-w) var(--slotS);
+  gap: 8px;
+  justify-content: center;
+}
+
+.slot {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--muted);
+  border-radius: 8px;
+  padding: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.slot.equipped {
+  border-style: solid;
+  color: var(--ink);
+}
+
+.slot .slot-name {
+  font-size: 12px;
+  margin-top: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+  text-align: center;
+}
+
+.slot-s { width: var(--slotS); height: var(--slotS); }
+.slot-m { width: var(--slotM); height: var(--slotM); }
+.slot-l { width: var(--slotL-w); height: var(--slotL-h); }
+
+.head-slot { grid-column: 2 / 4; justify-self: center; }
+.accessory-slot { grid-column: 1; grid-row: 2; }
+.weapon-slot { grid-column: 2; grid-row: 2; }
+.body-slot { grid-column: 3; grid-row: 2 / span 3; }
+.talisman1-slot { grid-column: 4; grid-row: 2; }
+.talisman2-slot { grid-column: 4; grid-row: 3; }
+.talisman3-slot { grid-column: 4; grid-row: 4; }
+.food-slot { grid-column: 1; grid-row: 5; }
+
+.unequip-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: none;
+}
+
+.slot.equipped .unequip-btn {
+  display: block;
+}
+
 .ability-slot,
 .available-ability {
   display: flex;


### PR DESCRIPTION
## Summary
- replace linear gear list with PoE-style grid layout
- style slots with responsive sizes and inline unequip chip
- update equipment rendering for click-to-equip interactions

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violations)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c0b27716cc83269bb3a61a09f1625e