### PR TITLE
Add ability tooltips with long-press support

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -1,6 +1,7 @@
 /** @typedef {{
  *  key:string, displayName:string, icon:string,
  *  costQi:number, cooldownMs:number, castTimeMs:number,
+ *  description:string,
  *  tags:string[], requiresWeaponClass?:string
  * }} AbilityDef */
 
@@ -13,6 +14,7 @@ export const ABILITIES = {
     costQi: 10,
     cooldownMs: 10_000,
     castTimeMs: 0,
+    description: 'A heavy slash that deals extra damage and heals you for a small amount.',
     tags: ['weapon-skill', 'physical'],
     requiresWeaponClass: 'sword',
   },
@@ -24,6 +26,7 @@ export const ABILITIES = {
     costQi: 0,
     cooldownMs: 0,
     castTimeMs: 0,
+    description: 'A simple palm attack that deals your weapon\'s damage.',
     tags: ['weapon-skill', 'physical'],
   },
     
@@ -34,6 +37,7 @@ export const ABILITIES = {
     costQi: 0,
     cooldownMs: 5_000,
     castTimeMs: 0,
+    description: 'Strikes with stunning force, dealing weapon damage and applying a brief stun.',
     tags: ['martial', 'physical'],
     requiresWeaponClass: 'palm',
   },
@@ -44,6 +48,7 @@ export const ABILITIES = {
     costQi: 0,
     cooldownMs: 0,
     castTimeMs: 0,
+    description: 'A mysterious technique that instantly defeats your foe and restores you.',
     tags: ['special']
   },
   fireball: {
@@ -53,6 +58,7 @@ export const ABILITIES = {
     costQi: 50,
     cooldownMs: 0,
     castTimeMs: 3_000,
+    description: 'Conjures a blazing fireball that deals heavy fire damage.',
     tags: ['spell', 'fire']
   },
   lightningStep: {
@@ -62,6 +68,7 @@ export const ABILITIES = {
     costQi: 30,
     cooldownMs: 30_000,
     castTimeMs: 500,
+    description: 'Empowers you with lightning, boosting attack speed and damage for a short time.',
     tags: ['buff', 'metal']
   },
   // Leave other abilities out until you define them.

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -457,24 +457,108 @@ export function updateBattleDisplay() {
   }
 }
 
+const ABILITY_ICON_MAP = {
+  'pointy-sword': '🗡️',
+  'game-icons:mighty-force': '💥',
+  'game-icons:fireball': '🔥',
+};
+
+function renderAbilityIcon(icon) {
+  if (ABILITY_ICON_MAP[icon]) return ABILITY_ICON_MAP[icon];
+  return icon.includes(':')
+    ? `<iconify-icon icon="${icon}" aria-hidden="true"></iconify-icon>`
+    : icon;
+}
+
+let currentAbilityTooltip = null;
+
+function hideAbilityTooltip() {
+  if (currentAbilityTooltip) {
+    currentAbilityTooltip.remove();
+    currentAbilityTooltip = null;
+  }
+}
+
+function showAbilityTooltip(anchor, html) {
+  hideAbilityTooltip();
+  const tooltip = document.createElement('div');
+  tooltip.className = 'item-tooltip';
+
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'tooltip-close';
+  closeBtn.textContent = '✖';
+  closeBtn.onclick = hideAbilityTooltip;
+  tooltip.appendChild(closeBtn);
+
+  const content = document.createElement('div');
+  content.className = 'tooltip-content';
+  content.innerHTML = html;
+  tooltip.appendChild(content);
+
+  document.body.appendChild(tooltip);
+  const rect = anchor.getBoundingClientRect();
+  const tRect = tooltip.getBoundingClientRect();
+  let left = rect.right + 8;
+  let top = rect.top + rect.height / 2 - tRect.height / 2;
+  if (left + tRect.width > window.innerWidth - 8) left = rect.left - tRect.width - 8;
+  if (left < 8) left = 8;
+  if (top < 8) top = 8;
+  if (top + tRect.height > window.innerHeight - 8) top = window.innerHeight - tRect.height - 8;
+  tooltip.style.left = `${left}px`;
+  tooltip.style.top = `${top}px`;
+  currentAbilityTooltip = tooltip;
+}
+
+function abilityDetailsHTML(key) {
+  const def = ABILITIES[key];
+  if (!def) return '';
+  const weapon = getEquippedWeapon(S);
+  const mods = S.abilityMods?.[key] || {};
+  const isSpell = def.tags?.includes('spell');
+  const speedMult =
+    isSpell && weapon.classKey === 'focus'
+      ? getWeaponProficiencyBonuses(S).speedMult
+      : 1;
+  const castTimeMs = Math.round(
+    def.castTimeMs *
+      (1 + (mods.castTimePct || 0) / 100) /
+      (1 + (S.astralTreeBonuses?.castSpeedPct || 0) / 100) /
+      speedMult
+  );
+  const cooldownMs = Math.round(
+    def.cooldownMs *
+      (1 + (mods.cooldownPct || 0) / 100) *
+      (1 + (S.astralTreeBonuses?.cooldownPct || 0) / 100) /
+      speedMult
+  );
+  const dmg = getAbilityDamage(key, S);
+  const rows = [];
+  rows.push(`<div class="stat-row"><span class="label">Qi Cost</span><span class="value">${def.costQi}</span></div>`);
+  if (castTimeMs > 0)
+    rows.push(`<div class="stat-row"><span class="label">Cast</span><span class="value">${(castTimeMs / 1000).toFixed(2)}s</span></div>`);
+  rows.push(`<div class="stat-row"><span class="label">Cooldown</span><span class="value">${(cooldownMs / 1000).toFixed(2)}s</span></div>`);
+  if (dmg !== null)
+    rows.push(`<div class="stat-row"><span class="label">Damage</span><span class="value">${dmg}</span></div>`);
+  const rawIcon = renderAbilityIcon(def.icon);
+  const iconHtml = rawIcon.includes('iconify-icon')
+    ? rawIcon.replace('<iconify-icon', '<iconify-icon class="weapon-icon"')
+    : `<span class="weapon-icon">${rawIcon}</span>`;
+  const header = `<div class="tooltip-header">${iconHtml}<span class="tooltip-name">${def.displayName}</span></div>`;
+  const core = `<div class="tooltip-core">${rows.join('')}</div>`;
+  const desc = def.description ? `<div class="tooltip-implicit">${def.description}</div>` : '';
+  const footer = def.tags?.length
+    ? `<div class="tooltip-footer"><div class="tags">Tags: ${def.tags.join(', ')}</div></div>`
+    : '';
+  return header + core + desc + footer;
+}
+
 let lastAbilityHTML = '';
 export function updateAbilityBar() {
   const bar = document.getElementById('abilityBar');
   if (!bar) return;
+  hideAbilityTooltip();
   const slots = getAbilitySlots(S);
   const weapon = getEquippedWeapon(S);
-  const iconMap = {
-    'pointy-sword': '🗡️',
-    'game-icons:mighty-force': '💥',
-    'game-icons:fireball': '🔥',
-  };
-
-  const renderIcon = (icon) => {
-    if (iconMap[icon]) return iconMap[icon];
-    return icon.includes(':')
-      ? `<iconify-icon icon="${icon}" aria-hidden="true"></iconify-icon>`
-      : icon;
-  };
   let html = '';
   const slotData = [];
   slots.forEach((slot, i) => {
@@ -501,18 +585,13 @@ export function updateAbilityBar() {
           (1 + (S.astralTreeBonuses?.cooldownPct || 0) / 100) /
           speedMult
       );
-      const cdSec = cooldownMs / 1000;
-      const ctSec = castTimeMs / 1000;
-      let title = `${def.displayName} — Cost ${def.costQi} Qi`;
-      if (castTimeMs > 0) title += `, Cast ${ctSec}s`;
-      title += `, CD ${cdSec}s`;
       let content = `
         <div class="ability-title">
           <div class="ability-name">${def.displayName}</div>
           ${dmgLine}
           ${castLine}
         </div>
-        <div class="ability-icon">${renderIcon(def.icon)}</div>
+        <div class="ability-icon">${renderAbilityIcon(def.icon)}</div>
         <div class="qi-badge">${def.costQi} Qi</div>
         <div class="keybind">[${i + 1}]</div>
       `;
@@ -522,7 +601,7 @@ export function updateAbilityBar() {
       const classes = ['ability-card'];
       if (slot.cooldownRemainingMs > 0) classes.push('cooling');
       if (slot.insufficientQi) classes.push('insufficient');
-      html += `<div class="${classes.join(' ')}" data-slot="${i + 1}" title="${title}">${content}</div>`;
+      html += `<div class="${classes.join(' ')}" data-slot="${i + 1}">${content}</div>`;
       slotData.push({ abilityKey: slot.abilityKey });
     } else {
       html += `<div class="ability-card empty" data-slot="${i + 1}">
@@ -540,7 +619,33 @@ export function updateAbilityBar() {
   Array.from(bar.children).forEach((card, i) => {
     const data = slotData[i];
     if (data.abilityKey) {
+      let pressTimer;
+      let longPress = false;
+      const showTip = () => {
+        longPress = true;
+        showAbilityTooltip(card, abilityDetailsHTML(data.abilityKey));
+      };
+      card.addEventListener('mouseenter', () => {
+        showAbilityTooltip(card, abilityDetailsHTML(data.abilityKey));
+      });
+      card.addEventListener('mouseleave', hideAbilityTooltip);
+      card.addEventListener('touchstart', () => {
+        longPress = false;
+        pressTimer = setTimeout(showTip, 500);
+      });
+      card.addEventListener('touchmove', () => clearTimeout(pressTimer));
+      card.addEventListener('touchend', (e) => {
+        clearTimeout(pressTimer);
+        if (longPress) {
+          e.preventDefault();
+        }
+      });
       card.addEventListener('click', () => {
+        if (longPress) {
+          longPress = false;
+          return;
+        }
+        hideAbilityTooltip();
         if (tryCastAbility(data.abilityKey)) {
           S.qi -= ABILITIES[data.abilityKey].costQi;
           flashAbilityCard(i + 1);


### PR DESCRIPTION
## Summary
- add descriptions to ability data definitions
- show ability details tooltip on hover or long-press
- reuse gear-style tooltip for abilities with cost, cooldown, damage and tags

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b38a3acc8326863fc854188896f9