### PR TITLE
feat: add gear slot boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,15 +886,69 @@
             </div>
             <div id="gearEquipSubTab" class="gear-tab-content active">
               <div class="equip-slots">
-                <div class="equip-slot" id="slot-mainhand"><span class="slot-label">Weapon</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-head"><span class="slot-label">Head</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-body"><span class="slot-label">Body</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-foot"><span class="slot-label">Feet</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring1"><span class="slot-label">Ring 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-ring2"><span class="slot-label">Ring 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman1"><span class="slot-label">Talisman 1</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-talisman2"><span class="slot-label">Talisman 2</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
-                <div class="equip-slot" id="slot-food"><span class="slot-label">Food</span> <span class="slot-name">Empty</span> <div class="slot-actions"><button class="btn small equip-btn">Equip…</button> <button class="btn small unequip-btn">Unequip</button></div></div>
+                <div class="gear-slot slot-m" id="slot-mainhand" tabindex="0" role="button" aria-label="Weapon slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-m" id="slot-head" tabindex="0" role="button" aria-label="Head slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-l" id="slot-body" tabindex="0" role="button" aria-label="Body slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-m" id="slot-foot" tabindex="0" role="button" aria-label="Feet slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-s" id="slot-ring1" tabindex="0" role="button" aria-label="Ring 1 slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-s" id="slot-ring2" tabindex="0" role="button" aria-label="Ring 2 slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-s" id="slot-talisman1" tabindex="0" role="button" aria-label="Talisman 1 slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-s" id="slot-talisman2" tabindex="0" role="button" aria-label="Talisman 2 slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
+                <div class="gear-slot slot-s" id="slot-food" tabindex="0" role="button" aria-label="Food slot">
+                  <iconify-icon class="slot-icon"></iconify-icon>
+                  <span class="empty-label">Empty</span>
+                  <button class="unequip-chip">Unequip</button>
+                  <span class="rarity-badge"></span>
+                  <span class="count-badge"></span>
+                </div>
               </div>
               <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%">🛡 <span id="armorVal">0</span></div>
               <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -105,37 +105,63 @@ function renderStats() {
 
 function renderEquipment() {
   const slots = [
-    { key: 'mainhand', label: 'Weapon' },
-    { key: 'head', label: 'Head' },
-    { key: 'body', label: 'Body' },
-    { key: 'foot', label: 'Feet' },
-    { key: 'ring1', label: 'Ring 1' },
-    { key: 'ring2', label: 'Ring 2' },
-    { key: 'talisman1', label: 'Talisman 1' },
-    { key: 'talisman2', label: 'Talisman 2' },
-    { key: 'food', label: 'Food' }
+    { key: 'mainhand', label: 'Weapon', placeholder: WEAPON_ICONS.sword },
+    { key: 'head', label: 'Head', placeholder: GEAR_ICONS.head },
+    { key: 'body', label: 'Body', placeholder: GEAR_ICONS.body },
+    { key: 'foot', label: 'Feet', placeholder: GEAR_ICONS.foot },
+    { key: 'ring1', label: 'Ring 1', placeholder: GEAR_ICONS.ring },
+    { key: 'ring2', label: 'Ring 2', placeholder: GEAR_ICONS.ring },
+    { key: 'talisman1', label: 'Talisman 1', placeholder: GEAR_ICONS.talisman },
+    { key: 'talisman2', label: 'Talisman 2', placeholder: GEAR_ICONS.talisman },
+    { key: 'food', label: 'Food', placeholder: GEAR_ICONS.food }
   ];
   slots.forEach(s => {
     const el = document.getElementById(`slot-${s.key}`);
     if (!el) return;
     const item = S.equipment[s.key];
-    const name = item?.name || (item?.key ? (WEAPONS[item.key]?.displayName || item.key) : 'Empty');
+    const iconEl = el.querySelector('.slot-icon');
+    const unequipBtn = el.querySelector('.unequip-chip');
+    const rarityBadge = el.querySelector('.rarity-badge');
+    const countBadge = el.querySelector('.count-badge');
     const icon = item?.type === 'weapon'
       ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
       : GEAR_ICONS[item?.slot || item?.type];
-    const stars = QUALITY_STARS[item?.quality] || '';
-    const rarity = item?.rarity;
-    const rarityColor = RARITY_COLORS[rarity] || '';
-    const rarityPrefix = rarity && rarity !== 'normal' ? `${rarity[0].toUpperCase()}${rarity.slice(1)} ` : '';
-    const displayName = rarityPrefix + name;
-    const baseNameHtml = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${displayName}` : displayName;
-    const coloredNameHtml = rarityColor ? `<span style="color:${rarityColor}">${baseNameHtml}</span>` : baseNameHtml;
-    const nameHtml = stars ? `${stars} ${coloredNameHtml}` : coloredNameHtml;
-    el.querySelector('.slot-name').innerHTML = nameHtml;
-    el.querySelector('.equip-btn').onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
-    el.querySelector('.unequip-btn').onclick = () => { unequip(s.key); renderEquipmentPanel(); };
-    const element = item?.element || item?.imbuement?.element;
-    el.style.backgroundColor = element ? (ELEMENT_BG_COLORS[element] || '') : '';
+    iconEl.setAttribute('icon', icon || s.placeholder);
+    iconEl.classList.toggle('placeholder', !item);
+    el.onclick = () => { slotFilter = s.key; renderInventory({ dismissTooltip: true }); };
+    if (item) {
+      el.classList.add('equipped');
+      el.classList.remove('empty');
+      unequipBtn.style.display = '';
+      unequipBtn.onclick = e => { e.stopPropagation(); unequip(s.key); renderEquipmentPanel(); };
+      const name = item.name || (item.key ? (WEAPONS[item.key]?.displayName || item.key) : '');
+      el.setAttribute('aria-label', `${s.label}: ${name} equipped`);
+      const rarityColor = RARITY_COLORS[item.rarity];
+      if (rarityColor) {
+        rarityBadge.style.background = rarityColor;
+        rarityBadge.style.display = '';
+      } else {
+        rarityBadge.style.display = 'none';
+      }
+      const element = item.element || item.imbuement?.element;
+      el.style.backgroundColor = element ? (ELEMENT_BG_COLORS[element] || '') : '';
+      if (item.type === 'food' && item.qty > 1) {
+        countBadge.textContent = item.qty;
+        el.classList.add('has-count');
+      } else {
+        countBadge.textContent = '';
+        el.classList.remove('has-count');
+      }
+    } else {
+      el.classList.add('empty');
+      el.classList.remove('equipped', 'has-count');
+      unequipBtn.style.display = 'none';
+      unequipBtn.onclick = null;
+      rarityBadge.style.display = 'none';
+      countBadge.textContent = '';
+      el.style.backgroundColor = '';
+      el.setAttribute('aria-label', `${s.label} empty`);
+    }
   });
   const armorEl = document.getElementById('armorVal');
   if (armorEl) armorEl.textContent = S.stats?.armor || 0;

--- a/style.css
+++ b/style.css
@@ -27,7 +27,16 @@
   --card-gap: 8px;
   --dot-size: 8px;
   --row-h: 48px;
-  
+
+  /* Gear slot dimensions */
+  --slotS: clamp(48px, 15vw, 60px);
+  --slotM: clamp(68px, 20vw, 84px);
+  --slotL-w: calc(var(--slotM) * 1.6);
+  --slotL-h: calc(var(--slotM) * 2);
+  --slot-pad: 8px;
+  --slot-radius: 8px;
+  --outline-stroke: 1.5px;
+
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
   --mortal-primary: #a66c4c; /* lighter saddle brown */
   --mortal-secondary: #b6825e; /* warm tan */
@@ -2209,6 +2218,84 @@ html.reduce-motion .shield-shimmer{animation:none;}
 .gear-tab-content.active {
   display: block;
 }
+
+.equip-slots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.gear-slot {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: var(--slot-pad);
+  border: 1px solid currentColor;
+  border-radius: var(--slot-radius);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+  min-width: 44px;
+  min-height: 44px;
+  cursor: pointer;
+}
+
+.gear-slot.slot-s { width: var(--slotS); height: var(--slotS); }
+.gear-slot.slot-m { width: var(--slotM); height: var(--slotM); }
+.gear-slot.slot-l { width: var(--slotL-w); height: var(--slotL-h); }
+
+.gear-slot.empty { border-style: dashed; }
+
+.gear-slot iconify-icon {
+  color: currentColor;
+  stroke-width: var(--outline-stroke);
+  fill: none;
+}
+
+.slot-icon.placeholder { opacity: 0.3; }
+
+.gear-slot.slot-s iconify-icon { width: calc((var(--slotS) - 16px) * 0.7); height: calc((var(--slotS) - 16px) * 0.7); }
+.gear-slot.slot-m iconify-icon { width: calc((var(--slotM) - 16px) * 0.72); height: calc((var(--slotM) - 16px) * 0.72); }
+.gear-slot.slot-l iconify-icon { width: calc((var(--slotL-w) - 16px) * 0.75); height: calc((var(--slotL-w) - 16px) * 0.75); }
+
+.empty-label {
+  font-size: 11px;
+  margin-top: 4px;
+}
+
+.gear-slot.equipped .empty-label { display: none; }
+
+.unequip-chip {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 12px;
+  padding: 2px 4px;
+  display: none;
+}
+
+.rarity-badge {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  top: 2px;
+  left: 2px;
+  display: none;
+}
+
+.count-badge {
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  font-size: 10px;
+  background: var(--panel);
+  padding: 1px 3px;
+  border-radius: 8px;
+  display: none;
+}
+
+.gear-slot.has-count .count-badge { display: block; }
 
 .ability-slot,
 .available-ability {


### PR DESCRIPTION
## Summary
- replace gear list rows with interactive gear slot boxes
- style slots with size tokens, dashed empty state, and badges
- update equipment rendering to handle new slot layout and aria labels

## Testing
- `npm test`
- `npm run validate` *(fails: verification protocol violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b6edbe648326bd499e2fe06ba315