### PR TITLE
Refine status card layout and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,34 +77,34 @@
           <div class="status-metric">
             <div class="status-row">
               <div class="status-label"><iconify-icon icon="mdi:cards-heart" width="16"></iconify-icon> HP</div>
+              <div class="status-bar hp-bar">
+                <div class="fill" id="hpFill"></div>
+                <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
+                  <defs>
+                    <linearGradient id="shieldGradient">
+                      <stop offset="0%" stop-color="rgba(255,255,255,0)" />
+                      <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
+                      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+                    </linearGradient>
+                  </defs>
+                  <mask id="hpMask">
+                    <rect id="hpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
+                  </mask>
+                  <rect id="shieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#hpMask)" />
+                  <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#hpMask)" fill="url(#shieldGradient)" />
+                </svg>
+              </div>
               <div class="status-value"><span id="hpVal">100</span>/<span id="hpMax">100</span></div>
-            </div>
-            <div class="status-bar hp-bar">
-              <div class="fill" id="hpFill"></div>
-              <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
-                <defs>
-                  <linearGradient id="shieldGradient">
-                    <stop offset="0%" stop-color="rgba(255,255,255,0)" />
-                    <stop offset="50%" stop-color="rgba(255,255,255,0.8)" />
-                    <stop offset="100%" stop-color="rgba(255,255,255,0)" />
-                  </linearGradient>
-                </defs>
-                <mask id="hpMask">
-                  <rect id="hpMaskRect" x="0" y="0" width="100%" height="100%" fill="#fff" />
-                </mask>
-                <rect id="shieldFill" class="shield-fill" x="0" y="0" width="0" height="100%" mask="url(#hpMask)" />
-                <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#hpMask)" fill="url(#shieldGradient)" />
-              </svg>
             </div>
             <span id="hpA11y" class="sr-only">HP 100/100, Shield 0/0</span>
           </div>
           <div class="status-metric">
             <div class="status-row">
               <div class="status-label"><iconify-icon icon="mdi:yin-yang" width="16"></iconify-icon> Qi</div>
+              <div class="status-bar qi-bar">
+                <div class="qi-fill" id="qiFill"></div>
+              </div>
               <div class="status-value"><span id="qiVal">0</span>/<span id="qiCap">100</span></div>
-            </div>
-            <div class="status-bar qi-bar">
-              <div class="qi-fill" id="qiFill"></div>
             </div>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -1755,14 +1755,15 @@ h1{font-size:20px; margin:0; letter-spacing:.5px}
 .topbar{display:flex; gap:14px; flex-wrap:wrap}
 /* STYLE-GUIDE-UPDATE: Parchment chip style */
 .chip{background:var(--panel); border:1px solid var(--accent); padding:8px 12px; border-radius:999px; font-size:12px; box-shadow: inset 0 1px 3px rgba(139, 117, 95, 0.2);}
-.status-card{background:var(--panel);border:1px solid var(--accent);padding:var(--pad);border-radius:4px;margin-bottom:var(--gap);}
-.status-card h4{margin:0 0 var(--gap) 0;font-size:14px;}
-.status-metric{margin-bottom:var(--gap);}
+.status-card{position:relative;background:#e7dfcf;border:1px solid rgba(45,37,32,0.25);padding:12px;border-radius:8px;margin-bottom:var(--gap);overflow:hidden;}
+.status-card::before{content:"";position:absolute;inset:0;background:radial-gradient(120% 90% at 20% 10%,rgba(0,0,0,0.05) 0%,transparent 70%),radial-gradient(100% 80% at 80% 70%,rgba(255,255,255,0.04) 0%,transparent 60%);opacity:.25;pointer-events:none;}
+.status-card h4{margin:0 0 8px 0;font-size:13px;}
+.status-metric{margin-bottom:6px;}
 .status-metric:last-child{margin-bottom:0;}
-.status-row{display:flex;justify-content:space-between;align-items:center;font-size:14px;}
-.status-label{display:flex;align-items:center;gap:4px;}
-.status-value{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.status-bar{position:relative;width:100%;height:8px;background:rgba(0,0,0,0.1);border-radius:4px;margin-top:4px;}
+.status-row{display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:6px;font-size:12px;}
+.status-label{display:flex;align-items:center;gap:4px;font-weight:600;white-space:nowrap;}
+.status-value{font-weight:400;white-space:nowrap;text-align:right;width:60px;}
+.status-bar{position:relative;width:100%;height:8px;background:rgba(0,0,0,0.1);border-radius:4px;}
 .hp-bar,.qi-bar{height:8px;}
 .hp-bar{background:rgba(239,68,68,0.3);}
 .hp-bar .fill{height:100%;background:linear-gradient(90deg,#ef4444,#f87171);border-radius:4px;transition:width 0.3s ease;width:0%;}


### PR DESCRIPTION
## Summary
- Simplify Status card with a subtle parchment wash, softer border and tighter padding
- Align HP and Qi rows in a three-column layout with smaller labels and right-aligned values
- Bring HP and Qi bars closer together while preserving existing bar visuals

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: AI verification protocol violations)


------
https://chatgpt.com/codex/tasks/task_e_68c0c407c13c8326bfa8179d3ad4cca8