### PR TITLE
refactor: compact status card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,10 +75,7 @@
         <div class="status-card">
           <h4>Status</h4>
           <div class="status-metric">
-            <div class="status-row">
-              <div class="status-label"><iconify-icon icon="mdi:cards-heart" width="16"></iconify-icon> HP</div>
-              <div class="status-value"><span id="hpVal">100</span>/<span id="hpMax">100</span></div>
-            </div>
+            <div class="status-label"><iconify-icon icon="mdi:cards-heart" width="16"></iconify-icon> HP</div>
             <div class="status-bar hp-bar">
               <div class="fill" id="hpFill"></div>
               <svg class="shield-overlay" viewBox="0 0 100 8" preserveAspectRatio="none">
@@ -96,16 +93,15 @@
                 <rect class="shield-shimmer" x="0" y="0" width="100%" height="100%" mask="url(#hpMask)" fill="url(#shieldGradient)" />
               </svg>
             </div>
+            <div class="status-value"><span id="hpVal">100</span>/<span id="hpMax">100</span></div>
             <span id="hpA11y" class="sr-only">HP 100/100, Shield 0/0</span>
           </div>
           <div class="status-metric">
-            <div class="status-row">
-              <div class="status-label"><iconify-icon icon="mdi:yin-yang" width="16"></iconify-icon> Qi</div>
-              <div class="status-value"><span id="qiVal">0</span>/<span id="qiCap">100</span></div>
-            </div>
+            <div class="status-label"><iconify-icon icon="mdi:yin-yang" width="16"></iconify-icon> Qi</div>
             <div class="status-bar qi-bar">
               <div class="qi-fill" id="qiFill"></div>
             </div>
+            <div class="status-value"><span id="qiVal">0</span>/<span id="qiCap">100</span></div>
           </div>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -1755,19 +1755,20 @@ h1{font-size:20px; margin:0; letter-spacing:.5px}
 .topbar{display:flex; gap:14px; flex-wrap:wrap}
 /* STYLE-GUIDE-UPDATE: Parchment chip style */
 .chip{background:var(--panel); border:1px solid var(--accent); padding:8px 12px; border-radius:999px; font-size:12px; box-shadow: inset 0 1px 3px rgba(139, 117, 95, 0.2);}
-.status-card{background:var(--panel);border:1px solid var(--accent);padding:var(--pad);border-radius:4px;margin-bottom:var(--gap);}
-.status-card h4{margin:0 0 var(--gap) 0;font-size:14px;}
-.status-metric{margin-bottom:var(--gap);}
+.status-card{position:relative;background:var(--panel);border:1px solid rgba(45,37,32,0.25);padding:12px;border-radius:8px;margin-bottom:var(--gap);}
+.status-card::before{content:"";position:absolute;inset:0;border-radius:inherit;pointer-events:none;background:linear-gradient(rgba(0,0,0,0.03),rgba(0,0,0,0.03)),radial-gradient(circle at 30% 20%,rgba(45,37,32,0.04)0%,transparent 60%),radial-gradient(circle at 80% 70%,rgba(45,37,32,0.03)0%,transparent 55%);}
+.status-card h4{margin:0 0 8px 0;font-size:13px;}
+.status-metric{display:grid;grid-template-columns:auto 1fr auto;align-items:center;column-gap:6px;margin-bottom:4px;}
 .status-metric:last-child{margin-bottom:0;}
-.status-row{display:flex;justify-content:space-between;align-items:center;font-size:14px;}
-.status-label{display:flex;align-items:center;gap:4px;}
-.status-value{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.status-bar{position:relative;width:100%;height:8px;background:rgba(0,0,0,0.1);border-radius:4px;margin-top:4px;}
+.status-label{display:flex;align-items:center;gap:4px;font-size:12px;font-weight:600;white-space:nowrap;}
+.status-value{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:12px;font-weight:500;text-align:right;width:60px;}
+.status-bar{position:relative;width:100%;height:8px;background:rgba(0,0,0,0.1);border-radius:4px;min-width:0;overflow:hidden;}
 .hp-bar,.qi-bar{height:8px;}
 .hp-bar{background:rgba(239,68,68,0.3);}
 .hp-bar .fill{height:100%;background:linear-gradient(90deg,#ef4444,#f87171);border-radius:4px;transition:width 0.3s ease;width:0%;}
 .qi-bar{background:rgba(37,99,235,0.3);}
 .qi-bar .qi-fill{height:100%;background:linear-gradient(90deg,#3b82f6,#60a5fa);border-radius:4px;transition:width 0.3s ease;width:0%;}
+.status-metric .sr-only{grid-column:1/-1;}
 .shield-overlay{position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none; transition:width 0.2s linear;}
 .shield-fill{fill:rgba(0,255,255,0.6); height:100%; transition:width 0.2s linear;}
 .shield-shimmer{height:100%; transition:width 0.2s linear; animation:shield-shimmer 1.5s linear infinite; opacity:0.6;}


### PR DESCRIPTION
## Summary
- Rework status card markup so labels, bars, and values share a three-column baseline layout
- Tighten spacing and typography in the status card
- Add subtle parchment wash and low-contrast frame to the status card

## Testing
- ⚠️ `npm test` (no tests specified)
- ⚠️ `npm run validate` (verification failed: pre-existing issues)


------
https://chatgpt.com/codex/tasks/task_e_68c0c407c13c8326bfa8179d3ad4cca8