### PR TITLE
Remove legacy weapon adapter and refactor to new format

### DIFF
--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -5,8 +5,8 @@ import { refillShieldFromQi, ARMOR_K, ARMOR_CAP } from '../combat/logic.js';
 import { getEquippedWeapon } from '../inventory/selectors.js';
 import { getAbilitySlots, getAbilityDamage } from '../ability/selectors.js';
 import { getWeaponProficiencyBonuses } from '../proficiency/selectors.js';
-import { rollLoot, toLootTableKey } from '../loot/logic.js'; // WEAPONS-INTEGRATION
-import { WEAPONS } from '../weaponGeneration/data/weapons.js'; // WEAPONS-INTEGRATION
+import { rollLoot, toLootTableKey } from '../loot/logic.js';
+import { WEAPON_TYPES } from '../weaponGeneration/data/weaponTypes.js';
 import { rollGearDropForZone } from '../gearGeneration/selectors.js';
 import { addToInventory } from '../inventory/mutators.js';
 import { ABILITIES } from '../ability/data/abilities.js';
@@ -574,7 +574,7 @@ export function updateAdventureCombat() {
       playerAttackRate *= S.lightningStep.attackSpeedMult;
     }
     const weapon = getEquippedWeapon(S);
-    console.log('[weapon]', weapon.key); // WEAPONS-INTEGRATION
+    console.log('[weapon]', weapon.typeKey);
     const now = Date.now();
     if (S.lightningStep && S.lightningStep.expiresAt <= now) {
       delete S.lightningStep;
@@ -884,14 +884,14 @@ function defeatEnemy() {
   const area = zone?.areas?.[S.adventure.currentArea];
   const lootEntries = enemy.loot ? Object.entries(enemy.loot) : [];
   lootEntries.forEach(([item, qty]) => {
-    addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'material', qty, source: area?.name });
+    addSessionLoot({ key: item, type: WEAPON_TYPES[item] ? 'weapon' : 'material', qty, source: area?.name });
   });
 
   if (enemy.drops) {
     const dropMult = 1 + (S.gearBonuses?.dropRateMult || 0);
     Object.entries(enemy.drops).forEach(([item, chance]) => {
       if (Math.random() < Math.min(1, chance * dropMult)) {
-        addSessionLoot({ key: item, type: WEAPONS[item] ? 'weapon' : 'material', qty: 1, source: area?.name });
+        addSessionLoot({ key: item, type: WEAPON_TYPES[item] ? 'weapon' : 'material', qty: 1, source: area?.name });
         lootEntries.push([item, 1]);
       }
     });
@@ -907,11 +907,11 @@ function defeatEnemy() {
     log(msg, 'good');
   }
 
-  if (S.flags?.weaponsEnabled) { // WEAPONS-INTEGRATION
+  if (S.flags?.weaponsEnabled) {
     const tableKey = toLootTableKey(area?.id || zone?.id);
     const drop = rollLoot(tableKey);
     if (drop) {
-      addSessionLoot({ key: drop, type: WEAPONS[drop] ? 'weapon' : 'material', qty: 1, source: area?.name });
+      addSessionLoot({ key: drop, type: WEAPON_TYPES[drop] ? 'weapon' : 'material', qty: 1, source: area?.name });
       lootEntries.push([drop, 1]);
     }
 
@@ -1514,7 +1514,7 @@ export function updateActivityAdventure() {
   setText('zonesUnlocked', S.adventure.zonesUnlocked);
   {
     const equipped = getEquippedWeapon(S);
-    setText('currentWeapon', equipped?.displayName || 'Fists'); // WEAPONS-INTEGRATION
+    setText('currentWeapon', equipped?.name || 'Fists');
   }
   const atkPreview = calculatePlayerCombatAttack(S);
   const baseAttack = Math.round(

--- a/src/features/combat/logic.js
+++ b/src/features/combat/logic.js
@@ -1,5 +1,5 @@
 import { initHp } from '../../shared/utils/hp.js';
-import { WEAPONS, WEAPON_CONFIG } from '../weaponGeneration/data/weapons.js'; // WEAPONS-INTEGRATION
+import { FIST } from '../weaponGeneration/data/weapons.js';
 import { onPhysicalHit } from '../../engine/combat/stun.js';
 import { MODIFIERS } from '../gearGeneration/data/modifiers.js';
 
@@ -62,15 +62,14 @@ export function initializeFight(enemy) {
   return { enemyHP, enemyMax, atk, armor };
 }
 
-export function applyWeaponDamage(profile = {}, weapon = WEAPONS.fist, attacker = {}, typeMults = {}) {
+export function applyWeaponDamage(profile = {}, weapon = FIST, attacker = {}, typeMults = {}) {
   const result = {
     phys: Number(profile.phys) || 0,
     elems: { ...(profile.elems || {}) },
   };
 
-  const w = weapon && weapon.key ? weapon : WEAPONS[weapon] || WEAPONS.fist;
-  const config = WEAPON_CONFIG[w.key] || {};
-  const baseMult = config.damageMultiplier ?? 1;
+  const w = weapon || FIST;
+  const baseMult = (w.base?.phys.max ?? FIST.base.phys.max) / FIST.base.phys.max;
 
   result.phys *= baseMult;
   for (const k in result.elems) {
@@ -88,10 +87,10 @@ export function applyWeaponDamage(profile = {}, weapon = WEAPONS.fist, attacker 
     } else if (mod.lane === 'physFlat' && mod.range) {
       const avg = (mod.range.min + mod.range.max) / 2;
       result.phys += avg;
-    } else if (mod.element && mod.lane.endsWith('Pct') && typeof mod.value === 'number') {
+    } else if (mod.element && mod.lane?.endsWith('Pct') && typeof mod.value === 'number') {
       const elem = mod.element;
       result.elems[elem] = (result.elems[elem] || 0) * (1 + mod.value);
-    } else if (mod.element && mod.lane.endsWith('Flat') && mod.range) {
+    } else if (mod.element && mod.lane?.endsWith('Flat') && mod.range) {
       const elem = mod.element;
       const avg = (mod.range.min + mod.range.max) / 2;
       result.elems[elem] = (result.elems[elem] || 0) + avg;
@@ -132,7 +131,7 @@ export function applyResists(damage, element, target) {
   return dmg * (1 - resist);
 }
 
-export function processAttack(profile, weapon, options = {}) {
+export function processAttack(profile, weapon = FIST, options = {}) {
   const {
     target,
     onDamage,
@@ -146,7 +145,7 @@ export function processAttack(profile, weapon, options = {}) {
     tempMult = 1,
   } = options;
 
-  const w = weapon && weapon.key ? weapon : WEAPONS[weapon] || WEAPONS.fist;
+  const w = weapon || FIST;
   const scaled = applyWeaponDamage(profile, w, attacker, typeMults);
 
   const stats = w?.stats || {};

--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -3,18 +3,12 @@ import { setText } from '../../../shared/utils/dom.js';
 import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { startForging } from '../mutators.js';
-import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
 import { GEAR_BASES } from '../../gearGeneration/data/gearBases.js';
 import { startActivity as startActivityMut } from '../../activity/mutators.js';
 
 function displayName(it) {
   if (!it) return '';
-  return (
-    it.name ||
-    WEAPONS[it.key]?.displayName ||
-    GEAR_BASES[it.key]?.displayName ||
-    it.id
-  );
+  return it.name || GEAR_BASES[it.key]?.displayName || it.id;
 }
 
 function updateForgingActivity(state = S) {

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -1,5 +1,4 @@
 import { S, save } from '../../shared/state.js';
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
 export { usePill } from '../alchemy/mutators.js'; // deprecated shim
@@ -52,15 +51,15 @@ export function equipItem(item, slot = null, state = S) {
   if (!info) return false;
   const slotKey = info.slot;
   const existing = state.equipment[slotKey];
-  const existingKey = typeof existing === 'string' ? existing : existing?.key;
+  const existingKey = typeof existing === 'string' ? existing : existing?.typeKey;
   if (existingKey && existingKey !== 'fist') addToInventory(existing, state);
   const { id, ...equipData } = item;
   state.equipment[slotKey] = equipData;
   removeFromInventory(id, state);
-  console.log('[equip]', 'slot→', slotKey, 'item→', item.key);
+  console.log('[equip]', 'slot→', slotKey, 'item→', item.typeKey);
   recomputePlayerTotals(state);
   save?.();
-  const payload = { key: item.key, name: WEAPONS[item.key]?.displayName || item.name || item.key, slot: slotKey };
+  const payload = { key: item.typeKey, name: item.name, slot: slotKey };
   if (slotKey === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);
   return payload;
 }
@@ -68,7 +67,7 @@ export function equipItem(item, slot = null, state = S) {
 export function unequip(slot, state = S) {
   const item = state.equipment[slot];
   if (!item) return;
-  const key = typeof item === 'string' ? item : item.key;
+  const key = typeof item === 'string' ? item : item.typeKey;
   if (key !== 'fist') addToInventory(item, state);
   state.equipment[slot] = null;
   console.log('[equip]', 'slot→', slot, 'item→', 'none');

--- a/src/features/inventory/selectors.js
+++ b/src/features/inventory/selectors.js
@@ -1,5 +1,5 @@
 import { S } from '../../shared/state.js';
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { FIST } from '../weaponGeneration/data/weapons.js';
 
 export function getInventory(state = S) {
   return state.inventory || [];
@@ -14,12 +14,7 @@ export function getEquipped(slot, state = S) {
 }
 
 export function getEquippedWeapon(state = S) {
-  if (!state.flags?.weaponsEnabled) return WEAPONS.fist;
+  if (!state.flags?.weaponsEnabled) return FIST;
   const eq = state.equipment?.mainhand;
-  const key = typeof eq === 'string' ? eq : eq?.key;
-  if (WEAPONS[key]) return WEAPONS[key];
-  if (eq && typeof eq === 'object') {
-    return { ...eq, key, displayName: eq.displayName || eq.name || key };
-  }
-  return WEAPONS.fist;
+  return eq || FIST;
 }

--- a/src/features/inventory/state.js
+++ b/src/features/inventory/state.js
@@ -1,4 +1,6 @@
+import { FIST, PALM_WRAPS } from '../weaponGeneration/data/weapons.js';
+
 export const inventoryState = {
-  inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
-  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food: null },
+  inventory: [{ ...PALM_WRAPS, id: 'palmWraps' }],
+  equipment: { mainhand: { ...FIST }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food: null },
 };

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -1,5 +1,4 @@
 import { S, save } from '../../../shared/state.js';
-import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
 import { WEAPON_ICONS } from '../../weaponGeneration/data/weaponIcons.js';
 import { equipItem, unequip, removeFromInventory, moveToJunk } from '../mutators.js';
 import { recomputePlayerTotals } from '../logic.js';
@@ -119,9 +118,9 @@ function renderEquipment() {
     const el = document.getElementById(`slot-${s.key}`);
     if (!el) return;
     const item = S.equipment[s.key];
-    const name = item?.name || (item?.key ? (WEAPONS[item.key]?.displayName || item.key) : 'Empty');
+    const name = item?.name || 'Empty';
     const icon = item?.type === 'weapon'
-      ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
+      ? WEAPON_ICONS[item.classKey]
       : GEAR_ICONS[item?.slot || item?.type];
     const stars = QUALITY_STARS[item?.quality] || '';
     const rarity = item?.rarity;
@@ -146,13 +145,13 @@ function renderEquipment() {
 }
 
 function weaponDetailsHTML(item) {
-  const w = WEAPONS[item.key] || item;
+  const w = item;
   if (!w) return '';
-  const iconKey = WEAPONS[item.key]?.proficiencyKey;
+  const iconKey = item.classKey;
   const icon = iconKey ? WEAPON_ICONS[iconKey] : null;
   const stars = QUALITY_STARS[item.quality] || '';
   const rarityColor = RARITY_COLORS[item.rarity] || '';
-  const name = w.displayName || w.name;
+  const name = w.name;
   const header = `<div class="tooltip-header">${icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon>` : ''}<span class="tooltip-name" style="color:${rarityColor}">${stars ? stars + ' ' : ''}${name}</span></div>`;
 
   const phys = w.base?.phys || { min: 0, max: 0 };
@@ -276,7 +275,7 @@ function showDetails(item, evt) {
   } else if (['armor', 'foot', 'ring', 'talisman'].includes(item.type)) {
     html = gearDetailsHTML(item);
   } else {
-    html = item.name || item.key;
+    html = item.name || item.typeKey || '';
   }
   if (html && evt?.target) {
     evt.stopPropagation();
@@ -292,12 +291,12 @@ function createInventoryRow(item) {
     row.style.backgroundColor = ELEMENT_BG_COLORS[element] || '';
   }
   const icon = item.type === 'weapon'
-    ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
+    ? WEAPON_ICONS[item.classKey]
     : GEAR_ICONS[item.slot || item.type];
   const rarity = item.rarity;
   const rarityColor = RARITY_COLORS[rarity] || '';
   const rarityPrefix = rarity && rarity !== 'normal' ? `${rarity[0].toUpperCase()}${rarity.slice(1)} ` : '';
-  const displayName = rarityPrefix + (item.name || item.key);
+  const displayName = rarityPrefix + (item.name || item.typeKey || '');
   const stars = QUALITY_STARS[item?.quality] || '';
   const baseNameHtml = icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon> ${displayName}` : displayName;
   const coloredNameHtml = rarityColor ? `<span style="color:${rarityColor}">${baseNameHtml}</span>` : baseNameHtml;

--- a/src/features/inventory/ui/weaponChip.js
+++ b/src/features/inventory/ui/weaponChip.js
@@ -1,5 +1,5 @@
 import { on } from '../../../shared/events.js';
-import { WEAPON_FLAGS, WEAPONS } from '../../weaponGeneration/data/weapons.js';
+import { WEAPON_FLAGS } from '../../weaponGeneration/data/weapons.js';
 
 const weaponFeatureEnabled = Object.keys(WEAPON_FLAGS).some(w => w !== 'fist' && WEAPON_FLAGS[w]);
 
@@ -21,7 +21,7 @@ export function initializeWeaponChip(initial = { key: 'fist', name: 'Fists' }) {
 
 export function updateWeaponChip(payload = { key: 'fist', name: 'Fists' }) {
   if (!weaponFeatureEnabled) return;
-  const name = payload.name || WEAPONS[payload.key]?.displayName || payload.key || 'Fists';
+  const name = payload.name || payload.key || 'Fists';
   const el = document.getElementById('weaponName');
   if (el) el.textContent = name;
   const hud = document.getElementById('currentWeapon');

--- a/src/features/loot/data/lootTables.js
+++ b/src/features/loot/data/lootTables.js
@@ -1,35 +1,14 @@
-// WEAPONS-INTEGRATION: add weapons to loot tables
+// General material loot tables (weapons handled separately)
 export const LOOT_TABLES = {
   peacefulLands: [
-    { item: 'ironStraightSword', weight: 8 },
-    { item: 'crudeDagger', weight: 6 },
-    { item: 'crudeRapier', weight: 4 },
     { item: 'wood', weight: 82 },
   ],
   forestEdge: [
-    { item: 'crudeHammer', weight: 5 },
-    { item: 'crudeBludgeon', weight: 5 },
-    { item: 'crudeAxe', weight: 5 },
     { item: 'ore', weight: 85 },
   ],
   meadowPath: [
-    { item: 'bronzeSpear', weight: 5 },
-    { item: 'dimFocus', weight: 3 },
-    { item: 'starFocus', weight: 2 },
-    { item: 'crudeKnuckles', weight: 3 },
-    { item: 'crudeNunchaku', weight: 1 },
-    { item: 'tameNunchaku', weight: 1 },
     { item: 'wood', weight: 85 },
   ],
   // existing zones…
 };
 
-import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
-export const WEAPON_LOOT_TABLE = Object.fromEntries(
-  Object.values(LOOT_TABLES)
-    .flat()
-    .filter(entry => WEAPONS[entry.item])
-    .map(entry => [entry.item, (entry.weight || 0) / 100])
-);
-
-// TODO: derive weapon tables for additional zones

--- a/src/features/proficiency/logic.js
+++ b/src/features/proficiency/logic.js
@@ -1,23 +1,26 @@
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { WEAPON_TYPES } from '../weaponGeneration/data/weaponTypes.js';
 
 // Proficiency is stored on the player state as an object: { [weaponClass]: number }
-function resolveKey(key) {
-  const weapon = WEAPONS[key];
-  return weapon?.classKey || key;
+function resolveClassKey(arg) {
+  if (!arg) return 'fist';
+  if (typeof arg === 'string') {
+    return WEAPON_TYPES[arg]?.classKey || arg;
+  }
+  return arg.classKey || WEAPON_TYPES[arg.typeKey]?.classKey || arg.typeKey || 'fist';
 }
 
 export function calculateProficiencyXP(enemyMaxHP) {
   return Math.max(1, Math.ceil(enemyMaxHP / 30));
 }
 
-export function gainProficiency(key, amount, state) {
+export function gainProficiency(weaponOrKey, amount, state) {
   state.proficiency = state.proficiency || {};
-  const classKey = resolveKey(key);
+  const classKey = resolveClassKey(weaponOrKey);
   state.proficiency[classKey] = (state.proficiency[classKey] || 0) + amount;
 }
 
-export function getProficiency(key, state) {
-  const classKey = resolveKey(key);
+export function getProficiency(weaponOrKey, state) {
+  const classKey = resolveClassKey(weaponOrKey);
   const value = (state.proficiency && state.proficiency[classKey]) || 0;
   // Soft cap: returns multiplier >1 but growth slows down
   const bonus = 1 + Math.pow(value, 0.6) * 0.01;

--- a/src/features/proficiency/migrations.js
+++ b/src/features/proficiency/migrations.js
@@ -1,4 +1,4 @@
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { WEAPON_TYPES } from '../weaponGeneration/data/weaponTypes.js';
 
 export const migrations = [
   save => {
@@ -18,8 +18,8 @@ export const migrations = [
     if (save.proficiency && typeof save.proficiency === 'object') {
       const converted = {};
       for (const [key, val] of Object.entries(save.proficiency)) {
-        const weapon = WEAPONS[key];
-        const classKey = weapon?.classKey || key;
+        const type = WEAPON_TYPES[key];
+        const classKey = type?.classKey || key;
         converted[classKey] = (converted[classKey] || 0) + val;
       }
       save.proficiency = converted;

--- a/src/features/proficiency/selectors.js
+++ b/src/features/proficiency/selectors.js
@@ -1,6 +1,6 @@
 import { proficiencyState } from './state.js';
 import { getProficiency as resolveProficiency } from './logic.js';
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { FIST } from '../weaponGeneration/data/weapons.js';
 import { getTunable } from '../../shared/tunables.js';
 
 export function getProficiency(key, state = proficiencyState) {
@@ -10,9 +10,8 @@ export function getProficiency(key, state = proficiencyState) {
 }
 
 export function getWeaponProficiencyBonuses(state = proficiencyState) {
-  const equipped = state.flags?.weaponsEnabled ? state.equipment?.mainhand : 'fist';
-  const key = typeof equipped === 'string' ? equipped : equipped?.key;
-  const weapon = WEAPONS[key] || WEAPONS.fist;
+  const equipped = state.flags?.weaponsEnabled ? state.equipment?.mainhand : FIST;
+  const weapon = typeof equipped === 'object' ? equipped : FIST;
   const { value } = getProficiency(weapon.classKey, state);
   const level = Math.floor(value / 100);
   return { damageMult: 1 + level * 0.02, speedMult: 1 + level * 0.01 };

--- a/src/features/weaponGeneration/data/weapons.js
+++ b/src/features/weaponGeneration/data/weapons.js
@@ -1,6 +1,7 @@
 import { generateWeapon } from '../logic.js';
+import { WEAPON_TYPES } from './weaponTypes.js';
 
-function defaultAnimationsForType(typeKey) {
+export function defaultAnimationsForType(typeKey) {
   switch (typeKey) {
     case 'straightSword':
     case 'crudeAxe':
@@ -30,49 +31,28 @@ function defaultAnimationsForType(typeKey) {
   }
 }
 
-function toLegacy(key, item){
-  return {
-    key,
-    displayName: item.name,
-    quality: item.quality,
-    modifiers: [...(item.modifiers || [])],
-    rarity: item.rarity,
-    slot: 'mainhand',
-    typeKey: item.typeKey,
-    classKey: item.classKey,
-    base: {
-      phys: { min: item.base.phys.min, max: item.base.phys.max },
-      rate: item.base.rate,
-      elems: { ...item.base.elems }
-    },
-    tags: [...item.tags],
-    reqs: { realmMin: 1, proficiencyMin: 0 },
-    abilityKeys: [...item.abilityKeys],
-    stats: item.stats ? { ...item.stats } : undefined,
-    animations: defaultAnimationsForType(item.typeKey),
-  };
+function withAnimations(item) {
+  return { ...item, animations: defaultAnimationsForType(item.typeKey) };
 }
 
-const FIST = {
-  key: 'fist',
-  displayName: 'Fists',
+export const FIST = withAnimations({
+  name: 'Fists',
+  type: 'weapon',
+  slot: 'mainhand',
   typeKey: 'fist',
   classKey: 'fist',
   quality: 'basic',
-  modifiers: [],
   rarity: 'normal',
-  slot: 'mainhand',
+  modifiers: [],
   base: { phys: { min: 1, max: 3 }, rate: 1.0, elems: {} },
   tags: ['melee'],
   reqs: { realmMin: 0, proficiencyMin: 0 },
   abilityKeys: ['seventyFive'],
-  animations: defaultAnimationsForType('fist'),
-};
+});
 
-const PALM_WRAPS = {
+export const PALM_WRAPS = withAnimations({
   ...FIST,
-  key: 'palmWraps',
-  displayName: 'Palm Wraps',
+  name: 'Palm Wraps',
   typeKey: 'palm',
   classKey: 'palm',
   abilityKeys: ['palmStrike'],
@@ -80,37 +60,43 @@ const PALM_WRAPS = {
     stunBuildMult: 0.3,
     stunDurationMult: 0.1,
   },
-  animations: defaultAnimationsForType('palm'),
-};
+});
 
 export const WEAPONS = {
   fist: FIST,
   palmWraps: PALM_WRAPS,
-  ironStraightSword: toLegacy('ironStraightSword', generateWeapon({ typeKey: 'straightSword', materialKey: 'iron', qualityKey: 'basic' })),
-  crudeDagger: toLegacy('crudeDagger', generateWeapon({ typeKey: 'crudeDagger', materialKey: 'iron', qualityKey: 'basic' })),
-  crudeRapier: toLegacy('crudeRapier', generateWeapon({ typeKey: 'crudeRapier', materialKey: 'iron', qualityKey: 'basic' })),
-  crudeHammer: toLegacy('crudeHammer', generateWeapon({ typeKey: 'crudeHammer', materialKey: 'bronze', qualityKey: 'basic' })),
-  crudeBludgeon: toLegacy('crudeBludgeon', generateWeapon({ typeKey: 'crudeBludgeon', materialKey: 'bronze', qualityKey: 'basic' })),
-  crudeAxe: toLegacy('crudeAxe', generateWeapon({ typeKey: 'crudeAxe', materialKey: 'iron', qualityKey: 'basic' })),
-  bronzeSpear: toLegacy('bronzeSpear', generateWeapon({ typeKey: 'spear', materialKey: 'bronze', qualityKey: 'basic' })),
-  dimFocus: toLegacy('dimFocus', generateWeapon({ typeKey: 'dimFocus', materialKey: 'spiritwood', qualityKey: 'basic' })),
-  starFocus: toLegacy('starFocus', generateWeapon({ typeKey: 'starFocus', materialKey: 'spiritwood', qualityKey: 'basic' })),
-  crudeKnuckles: toLegacy('crudeKnuckles', generateWeapon({ typeKey: 'crudeKnuckles', materialKey: 'iron', qualityKey: 'basic' })),
-  crudeNunchaku: toLegacy('crudeNunchaku', generateWeapon({ typeKey: 'crudeNunchaku', materialKey: 'spiritwood', qualityKey: 'basic' })),
-  tameNunchaku: toLegacy('tameNunchaku', generateWeapon({ typeKey: 'tameNunchaku', materialKey: 'spiritwood', qualityKey: 'basic' })),
+  ironStraightSword: withAnimations(generateWeapon({ typeKey: 'straightSword', materialKey: 'iron', qualityKey: 'basic' })),
+  crudeDagger: withAnimations(generateWeapon({ typeKey: 'crudeDagger', materialKey: 'iron', qualityKey: 'basic' })),
+  crudeRapier: withAnimations(generateWeapon({ typeKey: 'crudeRapier', materialKey: 'iron', qualityKey: 'basic' })),
+  crudeHammer: withAnimations(generateWeapon({ typeKey: 'crudeHammer', materialKey: 'bronze', qualityKey: 'basic' })),
+  crudeBludgeon: withAnimations(generateWeapon({ typeKey: 'crudeBludgeon', materialKey: 'bronze', qualityKey: 'basic' })),
+  crudeAxe: withAnimations(generateWeapon({ typeKey: 'crudeAxe', materialKey: 'iron', qualityKey: 'basic' })),
+  bronzeSpear: withAnimations(generateWeapon({ typeKey: 'spear', materialKey: 'bronze', qualityKey: 'basic' })),
+  dimFocus: withAnimations(generateWeapon({ typeKey: 'dimFocus', materialKey: 'spiritwood', qualityKey: 'basic' })),
+  starFocus: withAnimations(generateWeapon({ typeKey: 'starFocus', materialKey: 'spiritwood', qualityKey: 'basic' })),
+  crudeKnuckles: withAnimations(generateWeapon({ typeKey: 'crudeKnuckles', materialKey: 'iron', qualityKey: 'basic' })),
+  crudeNunchaku: withAnimations(generateWeapon({ typeKey: 'crudeNunchaku', materialKey: 'spiritwood', qualityKey: 'basic' })),
+  tameNunchaku: withAnimations(generateWeapon({ typeKey: 'tameNunchaku', materialKey: 'spiritwood', qualityKey: 'basic' })),
 };
 
 const FIST_BASE_MAX = FIST.base.phys.max;
-export const WEAPON_FLAGS = Object.fromEntries(
-  Object.keys(WEAPONS).map(key => [key, true])
-);
+export const WEAPON_FLAGS = {
+  fist: true,
+  palmWraps: true,
+  ...Object.fromEntries(Object.keys(WEAPON_TYPES).map(key => [key, true])),
+};
 
-export const WEAPON_CONFIG = Object.fromEntries(
-  Object.entries(WEAPONS).map(([key, weapon]) => [
-    key,
-    {
-      damageMultiplier: (weapon.base?.phys.max ?? FIST_BASE_MAX) / FIST_BASE_MAX,
-      proficiencyBase: 0,
-    },
-  ])
-);
+export const WEAPON_CONFIG = {
+  fist: { damageMultiplier: 1, proficiencyBase: 0 },
+  palmWraps: { damageMultiplier: (PALM_WRAPS.base.phys.max || FIST_BASE_MAX) / FIST_BASE_MAX, proficiencyBase: 0 },
+  ...Object.fromEntries(
+    Object.entries(WEAPON_TYPES).map(([key, type]) => [
+      key,
+      {
+        damageMultiplier: (type.base?.max ?? FIST_BASE_MAX) / FIST_BASE_MAX,
+        proficiencyBase: 0,
+      },
+    ])
+  ),
+};
+

--- a/src/features/weaponGeneration/selectors.js
+++ b/src/features/weaponGeneration/selectors.js
@@ -1,6 +1,7 @@
 import { weaponGenerationState } from './state.js';
 import { WEAPON_LOOT_TABLES } from '../loot/data/lootTables.weapons.js';
 import { generateWeapon } from './logic.js';
+import { defaultAnimationsForType } from './data/weapons.js';
 import { rollQualityKey, rollRarity } from '../loot/qualityWeights.js';
 import { pickZoneElement } from '../gearGeneration/imbuement.js';
 
@@ -27,7 +28,7 @@ export function rollWeaponDropForZone(zoneKey, stage = 1){
   const rarity = rollRarity();
   const imbChance = 0.05 + Math.random() * 0.05;
   const imbuement = Math.random() < imbChance ? { element: pickZoneElement(zoneKey), tier: 1 } : undefined;
-  return generateWeapon({
+  const weapon = generateWeapon({
     typeKey: row.typeKey,
     materialKey: row.materialKey,
     qualityKey,
@@ -35,4 +36,6 @@ export function rollWeaponDropForZone(zoneKey, stage = 1){
     imbuement,
     rarity,
   });
+  weapon.animations = defaultAnimationsForType(row.typeKey);
+  return weapon;
 }

--- a/src/ui/weaponSelectOverlay.js
+++ b/src/ui/weaponSelectOverlay.js
@@ -1,16 +1,19 @@
 import { addToInventory, equipItem } from '../features/inventory/mutators.js';
-import { WEAPONS } from '../features/weaponGeneration/data/weapons.js';
+import { generateWeapon } from '../features/weaponGeneration/logic.js';
+import { WEAPON_TYPES } from '../features/weaponGeneration/data/weaponTypes.js';
 import { WEAPON_ICONS } from '../features/weaponGeneration/data/weaponIcons.js';
+import { defaultAnimationsForType } from '../features/weaponGeneration/data/weapons.js';
 
 const CHOICES = ['dimFocus', 'crudeKnuckles', 'crudeNunchaku'];
+const MATERIALS = { dimFocus: 'spiritwood', crudeKnuckles: 'iron', crudeNunchaku: 'spiritwood' };
 
 function renderOption(key) {
-  const weapon = WEAPONS[key];
-  const icon = WEAPON_ICONS[weapon.classKey];
+  const type = WEAPON_TYPES[key];
+  const icon = WEAPON_ICONS[type.classKey];
   return `
     <button class="weapon-option" data-key="${key}">
       <iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon>
-      <span>${weapon.displayName}</span>
+      <span>${type.displayName}</span>
     </button>
   `;
 }
@@ -43,7 +46,9 @@ export function showWeaponSelectOverlay(state) {
   overlay.querySelectorAll('.weapon-option').forEach(btn => {
     btn.addEventListener('click', () => {
       const key = btn.getAttribute('data-key');
-      const id = addToInventory(WEAPONS[key], state);
+      const weapon = generateWeapon({ typeKey: key, materialKey: MATERIALS[key], qualityKey: 'basic' });
+      weapon.animations = defaultAnimationsForType(key);
+      const id = addToInventory(weapon, state);
       const item = state.inventory.find(it => it.id === id);
       equipItem(item, 'mainhand', state);
       close();


### PR DESCRIPTION
## Summary
- drop `toLegacy` adapter and define weapons directly with `generateWeapon`
- store full weapon objects in inventory and update UI/logic to use `name`, `typeKey`, and `classKey`
- derive proficiency and combat stats from weapon items without the old `WEAPONS` map
- guard element lane damage modifiers against missing lane to prevent runtime errors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI verification enforcement)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a8a422c88326b7a1fbb439e9fbba