### PR TITLE
refactor equipment slots layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,9 +892,6 @@
                 <div class="gear-slot size-s empty" id="slot-talisman2" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-food" role="button" tabindex="0"></div>
               </div>
-              <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%">🛡 <span id="armorVal">0</span></div>
-              <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>
-              <div class="stat" title="Chance to avoid attacks">👣 <span id="dodgeVal">0</span></div>
             </div>
             <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">
               <div id="abilitySlots"></div>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -191,12 +191,6 @@ function renderEquipment() {
       el.setAttribute('aria-label', `${s.label} empty`);
     }
   });
-  const armorEl = document.getElementById('armorVal');
-  if (armorEl) armorEl.textContent = S.stats?.armor || 0;
-  const accEl = document.getElementById('accuracyVal');
-  if (accEl) accEl.textContent = S.stats?.accuracy || 0;
-  const dodgeEl = document.getElementById('dodgeVal');
-  if (dodgeEl) dodgeEl.textContent = S.stats?.dodge || 0;
 }
 
 function weaponDetailsHTML(item) {

--- a/style.css
+++ b/style.css
@@ -27,8 +27,8 @@
   --card-gap: 8px;
   --dot-size: 8px;
   --row-h: 48px;
-  --slotS: clamp(38px, 12vw, 48px);
-  --slotM: clamp(54px, 16vw, 67px);
+  --slotS: clamp(27px, 8.4vw, 34px);
+  --slotM: clamp(38px, 11.2vw, 47px);
   --slotL-w: calc(var(--slotM) * 1.6);
   --slotL-h: calc(var(--slotM) * 2);
   --slot-pad: 8px;
@@ -2222,12 +2222,12 @@ html.reduce-motion .shield-shimmer{animation:none;}
 .equip-slots {
   display: grid;
   gap: 8px;
-  grid-template-columns: auto auto auto auto;
+  grid-template-columns: auto auto auto auto auto;
   grid-template-areas:
-    ". head ring1 ring2"
-    "weapon body talisman1 talisman2"
-    ". foot . ."
-    ". food . .";
+    ". . head ring1 ."
+    ". weapon body ring2 ."
+    "food . foot talisman1 ."
+    ". . . talisman2 .";
   justify-content: center;
 }
 


### PR DESCRIPTION
## Summary
- shrink equipment slot sizes by 30% and reorganize grid
- remove redundant attack/defense/dodge stats under equipment slots
- stack accessory and talisman slots vertically with food slot separated on left

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c0dbcae84083269420d3f2d21b43fe