### PR TITLE
Refine equipment panel layout and sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -892,9 +892,6 @@
                 <div class="gear-slot size-s empty" id="slot-talisman2" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-food" role="button" tabindex="0"></div>
               </div>
-              <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%">🛡 <span id="armorVal">0</span></div>
-              <div class="stat" title="Chance to hit enemies">⚔ <span id="accuracyVal">0</span></div>
-              <div class="stat" title="Chance to avoid attacks">👣 <span id="dodgeVal">0</span></div>
             </div>
             <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">
               <div id="abilitySlots"></div>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -191,12 +191,6 @@ function renderEquipment() {
       el.setAttribute('aria-label', `${s.label} empty`);
     }
   });
-  const armorEl = document.getElementById('armorVal');
-  if (armorEl) armorEl.textContent = S.stats?.armor || 0;
-  const accEl = document.getElementById('accuracyVal');
-  if (accEl) accEl.textContent = S.stats?.accuracy || 0;
-  const dodgeEl = document.getElementById('dodgeVal');
-  if (dodgeEl) dodgeEl.textContent = S.stats?.dodge || 0;
 }
 
 function weaponDetailsHTML(item) {

--- a/style.css
+++ b/style.css
@@ -27,12 +27,12 @@
   --card-gap: 8px;
   --dot-size: 8px;
   --row-h: 48px;
-  --slotS: clamp(38px, 12vw, 48px);
-  --slotM: clamp(54px, 16vw, 67px);
+  --slotS: clamp(26px, 8vw, 34px);
+  --slotM: clamp(38px, 11vw, 47px);
   --slotL-w: calc(var(--slotM) * 1.6);
   --slotL-h: calc(var(--slotM) * 2);
-  --slot-pad: 8px;
-  --slot-radius: 8px;
+  --slot-pad: 6px;
+  --slot-radius: 6px;
   --outline-stroke: 1.5px;
   
   /* STYLE-GUIDE-UPDATE: Stage-specific colors for cultivation */
@@ -2222,12 +2222,13 @@ html.reduce-motion .shield-shimmer{animation:none;}
 .equip-slots {
   display: grid;
   gap: 8px;
-  grid-template-columns: auto auto auto auto;
+  grid-template-columns: auto auto auto;
   grid-template-areas:
-    ". head ring1 ring2"
-    "weapon body talisman1 talisman2"
-    ". foot . ."
-    ". food . .";
+    ". head ring1"
+    "weapon body ring2"
+    ". foot talisman1"
+    ". . talisman2"
+    "food . .";
   justify-content: center;
 }
 
@@ -2242,8 +2243,8 @@ html.reduce-motion .shield-shimmer{animation:none;}
   border-radius: var(--slot-radius);
   padding: var(--slot-pad);
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
-  min-width: 44px;
-  min-height: 44px;
+  min-width: 31px;
+  min-height: 31px;
   cursor: pointer;
   color: var(--ink);
 }
@@ -2282,7 +2283,7 @@ html.reduce-motion .shield-shimmer{animation:none;}
 #slot-food { grid-area: food; }
 
 .gear-slot .slot-empty-label {
-  font-size: 10px;
+  font-size: 7px;
   margin-top: 4px;
 }
 


### PR DESCRIPTION
## Summary
- shrink equipment slot dimensions to reduce footprint
- center main armor slots and stack accessories/talismans vertically
- remove redundant combat stats from gear tab

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI verification violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dbcae84083269420d3f2d21b43fe