### PR TITLE
Refine equipment grid with consumables row

### DIFF
--- a/index.html
+++ b/index.html
@@ -890,7 +890,25 @@
                 <div class="gear-slot size-s empty" id="slot-ring2" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-talisman1" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-talisman2" role="button" tabindex="0"></div>
+              </div>
+              <div class="consumable-slots">
                 <div class="gear-slot size-s empty" id="slot-food" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" role="button" tabindex="0">
+                  <iconify-icon icon="mdi:food-apple" class="slot-icon placeholder"></iconify-icon>
+                  <span class="slot-empty-label">Empty</span>
+                </div>
+                <div class="gear-slot size-s empty" role="button" tabindex="0">
+                  <iconify-icon icon="mdi:food-apple" class="slot-icon placeholder"></iconify-icon>
+                  <span class="slot-empty-label">Empty</span>
+                </div>
+                <div class="gear-slot size-s empty" role="button" tabindex="0">
+                  <iconify-icon icon="mdi:food-apple" class="slot-icon placeholder"></iconify-icon>
+                  <span class="slot-empty-label">Empty</span>
+                </div>
+                <div class="gear-slot size-s empty" role="button" tabindex="0">
+                  <iconify-icon icon="mdi:food-apple" class="slot-icon placeholder"></iconify-icon>
+                  <span class="slot-empty-label">Empty</span>
+                </div>
               </div>
             </div>
             <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -159,7 +159,9 @@ function renderEquipment() {
       }
       const unequipBtn = document.createElement('button');
       unequipBtn.className = 'unequip-chip';
-      unequipBtn.textContent = 'Unequip';
+      unequipBtn.textContent = '×';
+      unequipBtn.setAttribute('aria-label', 'Unequip');
+      unequipBtn.title = 'Unequip';
       unequipBtn.onclick = evt => { evt.stopPropagation(); unequip(s.key); renderEquipmentPanel(); };
       el.appendChild(unequipBtn);
       const infoBtn = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -2221,14 +2221,23 @@ html.reduce-motion .shield-shimmer{animation:none;}
 /* Gear Slots */
 .equip-slots {
   display: grid;
-  gap: 8px;
+  column-gap: 8px;
+  row-gap: 2px;
   grid-template-columns: auto auto auto;
   grid-template-areas:
     ". head ring1"
     "weapon body ring2"
     ". foot talisman1"
-    "food . talisman2";
+    ". . talisman2";
   justify-content: center;
+}
+
+.consumable-slots {
+  margin-top: 8px;
+  display: grid;
+  grid-template-columns: repeat(5, var(--slotS));
+  gap: 4px;
+  justify-content: start;
 }
 
 .gear-slot {
@@ -2279,7 +2288,11 @@ html.reduce-motion .shield-shimmer{animation:none;}
 #slot-ring2 { grid-area: ring2; }
 #slot-talisman1 { grid-area: talisman1; }
 #slot-talisman2 { grid-area: talisman2; }
-#slot-food { grid-area: food; }
+
+#slot-head,
+#slot-foot {
+  width: var(--slotL-w);
+}
 
 .gear-slot .slot-empty-label {
   font-size: 10px;
@@ -2288,10 +2301,13 @@ html.reduce-motion .shield-shimmer{animation:none;}
 
 .gear-slot .unequip-chip {
   position: absolute;
-  top: 4px;
-  right: 4px;
+  top: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  padding: 0;
   font-size: 12px;
-  padding: 2px 4px;
+  line-height: 16px;
   border: none;
   border-radius: 4px;
   background: var(--ink);


### PR DESCRIPTION
## Summary
- Replace bulky "Unequip" chip with compact × button
- Add dedicated consumable row with five slots, including existing food slot
- Widen head and foot slots and tighten accessory/talisman stacking

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: VERIFICATION FAILED - MUST fix before proceeding)


------
https://chatgpt.com/codex/tasks/task_e_68c0f7be907c832692f52da9094c0a59