### PR TITLE
Expand equipment slots and tweak layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,11 +886,21 @@
                 <div class="gear-slot size-m empty" id="slot-head" role="button" tabindex="0"></div>
                 <div class="gear-slot size-l empty" id="slot-body" role="button" tabindex="0"></div>
                 <div class="gear-slot size-m empty" id="slot-foot" role="button" tabindex="0"></div>
-                <div class="gear-slot size-s empty" id="slot-ring1" role="button" tabindex="0"></div>
-                <div class="gear-slot size-s empty" id="slot-ring2" role="button" tabindex="0"></div>
-                <div class="gear-slot size-s empty" id="slot-talisman1" role="button" tabindex="0"></div>
-                <div class="gear-slot size-s empty" id="slot-talisman2" role="button" tabindex="0"></div>
-                <div class="gear-slot size-s empty" id="slot-food" role="button" tabindex="0"></div>
+                <div class="gear-slot-stack" id="ring-slots">
+                  <div class="gear-slot size-s empty" id="slot-ring1" role="button" tabindex="0"></div>
+                  <div class="gear-slot size-s empty" id="slot-ring2" role="button" tabindex="0"></div>
+                </div>
+                <div class="gear-slot-stack" id="talisman-slots">
+                  <div class="gear-slot size-s empty" id="slot-talisman1" role="button" tabindex="0"></div>
+                  <div class="gear-slot size-s empty" id="slot-talisman2" role="button" tabindex="0"></div>
+                </div>
+              </div>
+              <div class="food-slot-row">
+                <div class="gear-slot size-s empty" id="slot-food1" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food2" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food3" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food4" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food5" role="button" tabindex="0"></div>
               </div>
             </div>
             <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -65,7 +65,12 @@ export function canEquip(item, slot = null, state = {}) {
       if (item.slot === 'head' || item.slot === 'body') return { slot: item.slot };
       break;
     case 'food':
-      return { slot: 'food' };
+      if (slot && /^food[1-5]$/.test(slot)) return { slot };
+      for (let i = 1; i <= 5; i++) {
+        const key = `food${i}`;
+        if (!state.equipment?.[key]) return { slot: key };
+      }
+      return { slot: 'food1' };
     case 'foot':
       return { slot: 'foot' };
     case 'ring':

--- a/src/features/inventory/migrations.js
+++ b/src/features/inventory/migrations.js
@@ -35,7 +35,7 @@ export const migrations = [
       }
     }
     if (!save.equipment || typeof save.equipment !== 'object') {
-      save.equipment = { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food: null };
+      save.equipment = { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food1: null, food2: null, food3: null, food4: null, food5: null };
     } else {
       if (!save.equipment.mainhand) save.equipment.mainhand = { key: 'fist', type: 'weapon' };
       if (typeof save.equipment.head === 'undefined') save.equipment.head = null;
@@ -54,7 +54,14 @@ export const migrations = [
       if (typeof save.equipment.ring2 === 'undefined') save.equipment.ring2 = null;
       if (typeof save.equipment.talisman1 === 'undefined') save.equipment.talisman1 = null;
       if (typeof save.equipment.talisman2 === 'undefined') save.equipment.talisman2 = null;
-      if (typeof save.equipment.food === 'undefined') save.equipment.food = null;
+      if (typeof save.equipment.food1 === 'undefined') {
+        save.equipment.food1 = save.equipment.food || null;
+      }
+      if (typeof save.equipment.food2 === 'undefined') save.equipment.food2 = null;
+      if (typeof save.equipment.food3 === 'undefined') save.equipment.food3 = null;
+      if (typeof save.equipment.food4 === 'undefined') save.equipment.food4 = null;
+      if (typeof save.equipment.food5 === 'undefined') save.equipment.food5 = null;
+      if (typeof save.equipment.food !== 'undefined') delete save.equipment.food;
     }
     if (!Array.isArray(save.sessionLoot)) save.sessionLoot = [];
   },

--- a/src/features/inventory/state.js
+++ b/src/features/inventory/state.js
@@ -1,4 +1,4 @@
 export const inventoryState = {
   inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
-  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food: null },
+  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food1: null, food2: null, food3: null, food4: null, food5: null },
 };

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -39,7 +39,11 @@ const SLOT_PLACEHOLDERS = {
   ring2: GEAR_ICONS.ring,
   talisman1: GEAR_ICONS.talisman,
   talisman2: GEAR_ICONS.talisman,
-  food: GEAR_ICONS.food,
+  food1: GEAR_ICONS.food,
+  food2: GEAR_ICONS.food,
+  food3: GEAR_ICONS.food,
+  food4: GEAR_ICONS.food,
+  food5: GEAR_ICONS.food,
 };
 
 const ELEMENT_ICONS = {
@@ -125,7 +129,11 @@ function renderEquipment() {
     { key: 'ring2', label: 'Ring 2' },
     { key: 'talisman1', label: 'Talisman 1' },
     { key: 'talisman2', label: 'Talisman 2' },
-    { key: 'food', label: 'Food' }
+    { key: 'food1', label: 'Food 1' },
+    { key: 'food2', label: 'Food 2' },
+    { key: 'food3', label: 'Food 3' },
+    { key: 'food4', label: 'Food 4' },
+    { key: 'food5', label: 'Food 5' }
   ];
   slots.forEach(s => {
     const el = document.getElementById(`slot-${s.key}`);
@@ -159,7 +167,7 @@ function renderEquipment() {
       }
       const unequipBtn = document.createElement('button');
       unequipBtn.className = 'unequip-chip';
-      unequipBtn.textContent = 'Unequip';
+      unequipBtn.textContent = '✕';
       unequipBtn.onclick = evt => { evt.stopPropagation(); unequip(s.key); renderEquipmentPanel(); };
       el.appendChild(unequipBtn);
       const infoBtn = document.createElement('button');
@@ -167,7 +175,7 @@ function renderEquipment() {
       infoBtn.textContent = 'i';
       infoBtn.onclick = evt => { evt.stopPropagation(); showDetails(item, evt); };
       el.appendChild(infoBtn);
-      if (s.key === 'food' && item.qty > 1) {
+      if (s.key.startsWith('food') && item.qty > 1) {
         const badge = document.createElement('span');
         badge.className = 'count-badge';
         badge.textContent = item.qty;
@@ -410,7 +418,12 @@ function canEquipToSlot(item, slot) {
     case 'ring2': return item.type === 'ring';
     case 'talisman1':
     case 'talisman2': return item.type === 'talisman';
-    case 'food': return item.type === 'food';
+    case 'food1':
+    case 'food2':
+    case 'food3':
+    case 'food4':
+    case 'food5':
+      return item.type === 'food';
   }
   return false;
 }

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -143,7 +143,7 @@ export const defaultState = () => {
   // Combat Proficiency
   proficiency: {},
 
-  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, food: null }, // EQUIP-CHAR-UI
+  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food1: null, food2: null, food3: null, food4: null, food5: null }, // EQUIP-CHAR-UI
   inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
   junk: [],
   gearBonuses: {},

--- a/style.css
+++ b/style.css
@@ -2224,11 +2224,23 @@ html.reduce-motion .shield-shimmer{animation:none;}
   gap: 8px;
   grid-template-columns: auto auto auto;
   grid-template-areas:
-    ". head ring1"
-    "weapon body ring2"
-    ". foot talisman1"
-    "food . talisman2";
+    ". head rings"
+    "weapon body rings"
+    ". foot talismans";
   justify-content: center;
+}
+
+.gear-slot-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.food-slot-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  justify-content: flex-start;
 }
 
 .gear-slot {
@@ -2275,11 +2287,12 @@ html.reduce-motion .shield-shimmer{animation:none;}
 #slot-head { grid-area: head; }
 #slot-body { grid-area: body; }
 #slot-foot { grid-area: foot; }
-#slot-ring1 { grid-area: ring1; }
-#slot-ring2 { grid-area: ring2; }
-#slot-talisman1 { grid-area: talisman1; }
-#slot-talisman2 { grid-area: talisman2; }
-#slot-food { grid-area: food; }
+#ring-slots { grid-area: rings; }
+#talisman-slots { grid-area: talismans; }
+
+#slot-head, #slot-foot {
+  width: var(--slotL-w);
+}
 
 .gear-slot .slot-empty-label {
   font-size: 10px;
@@ -2288,12 +2301,17 @@ html.reduce-motion .shield-shimmer{animation:none;}
 
 .gear-slot .unequip-chip {
   position: absolute;
-  top: 4px;
-  right: 4px;
+  top: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 12px;
-  padding: 2px 4px;
+  padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: 50%;
   background: var(--ink);
   color: var(--paper, var(--panel));
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Replace textual unequip button with compact ✕ icon
- Add five dedicated food slots along bottom of gear panel and widen head/foot slots
- Stack ring and talisman slots tightly for cleaner layout and support equipping into new food slots

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: VERIFICATION FAILED - MUST fix before proceeding)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f7be907c832692f52da9094c0a59