### PR TITLE
Revamp equipment layout with compact unequip control and extra food slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -883,14 +883,18 @@
             <div id="gearEquipSubTab" class="gear-tab-content active">
               <div class="equip-slots">
                 <div class="gear-slot size-m empty" id="slot-mainhand" role="button" tabindex="0"></div>
-                <div class="gear-slot size-m empty" id="slot-head" role="button" tabindex="0"></div>
+                <div class="gear-slot size-l empty" id="slot-head" role="button" tabindex="0"></div>
                 <div class="gear-slot size-l empty" id="slot-body" role="button" tabindex="0"></div>
-                <div class="gear-slot size-m empty" id="slot-foot" role="button" tabindex="0"></div>
+                <div class="gear-slot size-l empty" id="slot-foot" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-ring1" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-ring2" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-talisman1" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-talisman2" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-food" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food2" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food3" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food4" role="button" tabindex="0"></div>
+                <div class="gear-slot size-s empty" id="slot-food5" role="button" tabindex="0"></div>
               </div>
             </div>
             <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -40,6 +40,10 @@ const SLOT_PLACEHOLDERS = {
   talisman1: GEAR_ICONS.talisman,
   talisman2: GEAR_ICONS.talisman,
   food: GEAR_ICONS.food,
+  food2: GEAR_ICONS.food,
+  food3: GEAR_ICONS.food,
+  food4: GEAR_ICONS.food,
+  food5: GEAR_ICONS.food,
 };
 
 const ELEMENT_ICONS = {
@@ -125,7 +129,11 @@ function renderEquipment() {
     { key: 'ring2', label: 'Ring 2' },
     { key: 'talisman1', label: 'Talisman 1' },
     { key: 'talisman2', label: 'Talisman 2' },
-    { key: 'food', label: 'Food' }
+    { key: 'food', label: 'Food' },
+    { key: 'food2', label: 'Food' },
+    { key: 'food3', label: 'Food' },
+    { key: 'food4', label: 'Food' },
+    { key: 'food5', label: 'Food' }
   ];
   slots.forEach(s => {
     const el = document.getElementById(`slot-${s.key}`);
@@ -159,7 +167,7 @@ function renderEquipment() {
       }
       const unequipBtn = document.createElement('button');
       unequipBtn.className = 'unequip-chip';
-      unequipBtn.textContent = 'Unequip';
+      unequipBtn.textContent = '×';
       unequipBtn.onclick = evt => { evt.stopPropagation(); unequip(s.key); renderEquipmentPanel(); };
       el.appendChild(unequipBtn);
       const infoBtn = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -2221,13 +2221,15 @@ html.reduce-motion .shield-shimmer{animation:none;}
 /* Gear Slots */
 .equip-slots {
   display: grid;
-  gap: 8px;
-  grid-template-columns: auto auto auto;
+  column-gap: 8px;
+  row-gap: 2px;
+  grid-template-columns: repeat(5, 1fr);
   grid-template-areas:
-    ". head ring1"
-    "weapon body ring2"
-    ". foot talisman1"
-    "food . talisman2";
+    ". . head . ring1"
+    "weapon . body foot ring2"
+    ". . . . talisman1"
+    ". . . . talisman2"
+    "food food2 food3 food4 food5";
   justify-content: center;
 }
 
@@ -2280,6 +2282,10 @@ html.reduce-motion .shield-shimmer{animation:none;}
 #slot-talisman1 { grid-area: talisman1; }
 #slot-talisman2 { grid-area: talisman2; }
 #slot-food { grid-area: food; }
+#slot-food2 { grid-area: food2; }
+#slot-food3 { grid-area: food3; }
+#slot-food4 { grid-area: food4; }
+#slot-food5 { grid-area: food5; }
 
 .gear-slot .slot-empty-label {
   font-size: 10px;
@@ -2288,15 +2294,20 @@ html.reduce-motion .shield-shimmer{animation:none;}
 
 .gear-slot .unequip-chip {
   position: absolute;
-  top: 4px;
-  right: 4px;
-  font-size: 12px;
-  padding: 2px 4px;
+  top: 2px;
+  right: 2px;
+  font-size: 10px;
+  width: 16px;
+  height: 16px;
+  padding: 0;
   border: none;
   border-radius: 4px;
   background: var(--ink);
   color: var(--paper, var(--panel));
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .gear-slot .slot-info {


### PR DESCRIPTION
## Summary
- Replace text-based Unequip button with compact "×" control
- Add four additional food slots and reposition gear grid
- Resize head and foot slots to match body slot

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: VERIFICATION FAILED - MUST fix before proceeding)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f7be907c832692f52da9094c0a59