### PR TITLE
Seed inventory state with generated weapon objects

### DIFF
--- a/src/features/inventory/state.js
+++ b/src/features/inventory/state.js
@@ -1,4 +1,18 @@
+import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+
 export const inventoryState = {
-  inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
-  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food: null },
+  // Seed the player with palm wraps in their inventory and fists equipped.
+  // Store full weapon objects so downstream systems can rely on name/type metadata.
+  inventory: [{ id: 'palmWraps', ...WEAPONS.palmWraps }],
+  equipment: {
+    mainhand: { ...WEAPONS.fist },
+    head: null,
+    body: null,
+    foot: null,
+    ring1: null,
+    ring2: null,
+    talisman1: null,
+    talisman2: null,
+    food: null,
+  },
 };


### PR DESCRIPTION
## Summary
- seed starter inventory with a full palm wraps weapon object
- equip a complete fists weapon entry for initial mainhand

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI changes blocked until validation passes)*

------
https://chatgpt.com/codex/tasks/task_e_68c0fccef42483268884b9b888f2d1e5