### PR TITLE
refactor: derive weapon names and icons from items

### DIFF
--- a/src/features/forging/ui/forgingDisplay.js
+++ b/src/features/forging/ui/forgingDisplay.js
@@ -3,18 +3,11 @@ import { setText } from '../../../shared/utils/dom.js';
 import { fmt } from '../../../shared/utils/number.js';
 import { on } from '../../../shared/events.js';
 import { startForging } from '../mutators.js';
-import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
-import { GEAR_BASES } from '../../gearGeneration/data/gearBases.js';
 import { startActivity as startActivityMut } from '../../activity/mutators.js';
 
 function displayName(it) {
   if (!it) return '';
-  return (
-    it.name ||
-    WEAPONS[it.key]?.displayName ||
-    GEAR_BASES[it.key]?.displayName ||
-    it.id
-  );
+  return it.name || it.key || it.id;
 }
 
 function updateForgingActivity(state = S) {

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -1,5 +1,4 @@
 import { S, save } from '../../../shared/state.js';
-import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
 import { WEAPON_ICONS } from '../../weaponGeneration/data/weaponIcons.js';
 import { equipItem, unequip, removeFromInventory, moveToJunk } from '../mutators.js';
 import { recomputePlayerTotals } from '../logic.js';
@@ -152,7 +151,7 @@ function renderEquipment() {
       el.classList.remove('empty');
       el.classList.add('equipped');
       const icon = item.type === 'weapon'
-        ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
+        ? WEAPON_ICONS[item.classKey]
         : GEAR_ICONS[item.slot || item.type];
       const iconEl = document.createElement('iconify-icon');
       iconEl.setAttribute('icon', icon || placeholder);
@@ -202,13 +201,12 @@ function renderEquipment() {
 }
 
 function weaponDetailsHTML(item) {
-  const w = WEAPONS[item.key] || item;
+  const w = item;
   if (!w) return '';
-  const iconKey = WEAPONS[item.key]?.proficiencyKey;
-  const icon = iconKey ? WEAPON_ICONS[iconKey] : null;
+  const icon = w.classKey ? WEAPON_ICONS[w.classKey] : null;
   const stars = QUALITY_STARS[item.quality] || '';
   const rarityColor = RARITY_COLORS[item.rarity] || '';
-  const name = w.displayName || w.name;
+  const name = w.name;
   const header = `<div class="tooltip-header">${icon ? `<iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon>` : ''}<span class="tooltip-name" style="color:${rarityColor}">${stars ? stars + ' ' : ''}${name}</span></div>`;
 
   const phys = w.base?.phys || { min: 0, max: 0 };
@@ -348,7 +346,7 @@ function createInventoryRow(item) {
     row.style.backgroundColor = ELEMENT_BG_COLORS[element] || '';
   }
   const icon = item.type === 'weapon'
-    ? WEAPON_ICONS[WEAPONS[item.key]?.classKey]
+    ? WEAPON_ICONS[item.classKey]
     : GEAR_ICONS[item.slot || item.type];
   const rarity = item.rarity;
   const rarityColor = RARITY_COLORS[rarity] || '';

--- a/src/features/inventory/ui/weaponChip.js
+++ b/src/features/inventory/ui/weaponChip.js
@@ -1,5 +1,5 @@
 import { on } from '../../../shared/events.js';
-import { WEAPON_FLAGS, WEAPONS } from '../../weaponGeneration/data/weapons.js';
+import { WEAPON_FLAGS } from '../../weaponGeneration/data/weapons.js';
 
 const weaponFeatureEnabled = Object.keys(WEAPON_FLAGS).some(w => w !== 'fist' && WEAPON_FLAGS[w]);
 
@@ -21,7 +21,7 @@ export function initializeWeaponChip(initial = { key: 'fist', name: 'Fists' }) {
 
 export function updateWeaponChip(payload = { key: 'fist', name: 'Fists' }) {
   if (!weaponFeatureEnabled) return;
-  const name = payload.name || WEAPONS[payload.key]?.displayName || payload.key || 'Fists';
+  const name = payload.name || payload.key || 'Fists';
   const el = document.getElementById('weaponName');
   if (el) el.textContent = name;
   const hud = document.getElementById('currentWeapon');

--- a/src/ui/weaponSelectOverlay.js
+++ b/src/ui/weaponSelectOverlay.js
@@ -1,16 +1,15 @@
 import { addToInventory, equipItem } from '../features/inventory/mutators.js';
-import { WEAPONS } from '../features/weaponGeneration/data/weapons.js';
+import { generateWeapon } from '../features/weaponGeneration/logic.js';
+import { WEAPON_TYPES } from '../features/weaponGeneration/data/weaponTypes.js';
 import { WEAPON_ICONS } from '../features/weaponGeneration/data/weaponIcons.js';
 
-const CHOICES = ['dimFocus', 'crudeKnuckles', 'crudeNunchaku'];
-
 function renderOption(key) {
-  const weapon = WEAPONS[key];
-  const icon = WEAPON_ICONS[weapon.classKey];
+  const sample = generateWeapon({ typeKey: key });
+  const icon = WEAPON_ICONS[sample.classKey];
   return `
     <button class="weapon-option" data-key="${key}">
       <iconify-icon icon="${icon}" class="weapon-icon"></iconify-icon>
-      <span>${weapon.displayName}</span>
+      <span>${sample.name}</span>
     </button>
   `;
 }
@@ -29,7 +28,7 @@ export function showWeaponSelectOverlay(state) {
         <button class="btn small ghost close-btn">×</button>
       </div>
       <div class="weapon-options">
-        ${CHOICES.map(renderOption).join('')}
+        ${Object.keys(WEAPON_TYPES).map(renderOption).join('')}
       </div>
     </div>`;
   document.body.appendChild(overlay);
@@ -43,7 +42,8 @@ export function showWeaponSelectOverlay(state) {
   overlay.querySelectorAll('.weapon-option').forEach(btn => {
     btn.addEventListener('click', () => {
       const key = btn.getAttribute('data-key');
-      const id = addToInventory(WEAPONS[key], state);
+      const weapon = generateWeapon({ typeKey: key });
+      const id = addToInventory(weapon, state);
       const item = state.inventory.find(it => it.id === id);
       equipItem(item, 'mainhand', state);
       close();


### PR DESCRIPTION
## Summary
- generate weapon select options from weapon types and equip generated items
- use item.name and classKey when displaying weapons in UI
- simplify forging item naming

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1609011cc8326ad3b734a244b0322