### PR TITLE
feat: add rock sling dim focus ability

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -71,5 +71,16 @@ export const ABILITIES = {
     description: 'Empowers you with lightning, boosting attack speed and damage for a short time.',
     tags: ['buff', 'metal']
   },
+  rockSling: {
+    key: 'rockSling',
+    displayName: 'Rock Sling',
+    icon: 'game-icons:stone-sphere',
+    costQi: 15,
+    cooldownMs: 3_000,
+    castTimeMs: 0,
+    description: 'Hurls a rock at the enemy, dealing earth damage and building stun.',
+    tags: ['spell', 'earth'],
+    requiresWeaponClass: 'focus'
+  },
   // Leave other abilities out until you define them.
 };

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -36,6 +36,8 @@ export function resolveAbilityHit(abilityKey, state) {
       return resolveFireball(state);
     case 'lightningStep':
       return resolveLightningStep(state);
+    case 'rockSling':
+      return resolveRockSling(state);
     case 'seventyFive':
       return resolveSeventyFive();
     default:
@@ -88,6 +90,16 @@ function resolveLightningStep(state) {
     expiresAt: Date.now() + durationMs,
   };
   return {};
+}
+
+function resolveRockSling(state) {
+  const dmg = Math.floor(Math.random() * 11) + 10; // 10-20 damage
+  return {
+    attacks: [
+      { amount: dmg, type: 'earth', target: state.adventure.currentEnemy },
+    ],
+    stun: { mult: 1.2 },
+  };
 }
 
 function resolveSeventyFive() {

--- a/src/features/weaponGeneration/data/weaponTypes.js
+++ b/src/features/weaponGeneration/data/weaponTypes.js
@@ -81,7 +81,7 @@ export const WEAPON_TYPES = {
     slot: 'mainhand',
       base: { min: 1, max: 3, rate: 1.1 },
     tags: [],
-    signatureAbilityKey: 'mindSpike',
+    signatureAbilityKey: 'rockSling',
     implicitStats: { qiCostPct: -0.05 },
   },
   starFocus: {


### PR DESCRIPTION
## Summary
- add Rock Sling spell for Dim Focus weapons
- allow Dim Focus weapons to use Rock Sling as signature ability

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI verification enforcement report)*

------
https://chatgpt.com/codex/tasks/task_e_68c18225a4c08326bcb0a5f031285477