### PR TITLE
Add rock sling focus ability

### DIFF
--- a/src/features/ability/data/abilities.js
+++ b/src/features/ability/data/abilities.js
@@ -71,5 +71,16 @@ export const ABILITIES = {
     description: 'Empowers you with lightning, boosting attack speed and damage for a short time.',
     tags: ['buff', 'metal']
   },
+  rockSling: {
+    key: 'rockSling',
+    displayName: 'Rock Sling',
+    icon: 'game-icons:stone-sphere',
+    costQi: 15,
+    cooldownMs: 3_000,
+    castTimeMs: 0,
+    description: 'Hurls a jagged stone that deals earth damage and a minor stun.',
+    tags: ['spell', 'earth'],
+    requiresWeaponClass: 'focus',
+  },
   // Leave other abilities out until you define them.
 };

--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -34,6 +34,8 @@ export function resolveAbilityHit(abilityKey, state) {
       return resolveFlowingPalm(state);
     case 'fireball':
       return resolveFireball(state);
+    case 'rockSling':
+      return resolveRockSling(state);
     case 'lightningStep':
       return resolveLightningStep(state);
     case 'seventyFive':
@@ -68,6 +70,16 @@ function resolveFireball(state) {
     attacks: [{ amount: damage, type: 'fire', target: state.adventure.currentEnemy }],
 
    };
+}
+
+function resolveRockSling(state) {
+  const damage = Math.floor(Math.random() * 11) + 10;
+  return {
+    attacks: [
+      { amount: damage, type: 'earth', target: state.adventure.currentEnemy },
+    ],
+    stun: { mult: 0.2 },
+  };
 }
 
 function resolvePalmStrike(state) {

--- a/src/features/weaponGeneration/data/weaponTypes.js
+++ b/src/features/weaponGeneration/data/weaponTypes.js
@@ -81,7 +81,7 @@ export const WEAPON_TYPES = {
     slot: 'mainhand',
       base: { min: 1, max: 3, rate: 1.1 },
     tags: [],
-    signatureAbilityKey: 'mindSpike',
+    signatureAbilityKey: 'rockSling',
     implicitStats: { qiCostPct: -0.05 },
   },
   starFocus: {


### PR DESCRIPTION
## Summary
- add Rock Sling ability for focus weapons that hurls an earth-infused stone and lightly stuns
- hook Rock Sling into ability logic and make it the Dim Focus signature

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: AI changes blocked until validation passes)
- `npm run enforce-ai`


------
https://chatgpt.com/codex/tasks/task_e_68c18225a4c08326bcb0a5f031285477