### PR TITLE
feat: use item metadata for inventory operations

### DIFF
--- a/src/features/inventory/migrations.js
+++ b/src/features/inventory/migrations.js
@@ -1,5 +1,4 @@
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
-import { GEAR_BASES } from '../gearGeneration/data/gearBases.js';
+// removed reliance on weapon/gear maps for migration
 
 export const migrations = [
   save => {
@@ -24,20 +23,56 @@ export const migrations = [
       if (Array.isArray(legacy.weapons)) {
         legacy.weapons.forEach(w => {
           const key = w.key || w;
-          save.inventory.push({ id: Date.now() + Math.random(), key, type: 'weapon' });
+          save.inventory.push({
+            id: Date.now() + Math.random(),
+            key,
+            type: 'weapon',
+            name: w.name || key,
+            typeKey: w.typeKey || key,
+            classKey: w.classKey || w.typeKey || key,
+          });
         });
       }
       if (Array.isArray(legacy.armor)) {
         legacy.armor.forEach(a => {
           const key = a.key || a;
-          save.inventory.push({ id: Date.now() + Math.random(), key, type: 'armor', slot: a.slot });
+          save.inventory.push({
+            id: Date.now() + Math.random(),
+            key,
+            type: 'armor',
+            slot: a.slot,
+            name: a.name || key,
+            typeKey: a.typeKey || key,
+            classKey: a.classKey || a.typeKey || key,
+          });
         });
       }
     }
     if (!save.equipment || typeof save.equipment !== 'object') {
-      save.equipment = { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food1: null, food2: null, food3: null, food4: null, food5: null };
+      save.equipment = {
+        mainhand: { key: 'fist', type: 'weapon', name: 'Fists', typeKey: 'fist', classKey: 'fist' },
+        head: null,
+        body: null,
+        foot: null,
+        ring1: null,
+        ring2: null,
+        talisman1: null,
+        talisman2: null,
+        food1: null,
+        food2: null,
+        food3: null,
+        food4: null,
+        food5: null,
+      };
     } else {
-      if (!save.equipment.mainhand) save.equipment.mainhand = { key: 'fist', type: 'weapon' };
+      if (!save.equipment.mainhand)
+        save.equipment.mainhand = {
+          key: 'fist',
+          type: 'weapon',
+          name: 'Fists',
+          typeKey: 'fist',
+          classKey: 'fist',
+        };
       if (typeof save.equipment.head === 'undefined') save.equipment.head = null;
       if (typeof save.equipment.body === 'undefined') {
         if (typeof save.equipment.torso !== 'undefined') {
@@ -75,7 +110,14 @@ export const migrations = [
     const hasPalmWraps = save.inventory.some(it => (typeof it === 'string' ? it === 'palmWraps' : it.key === 'palmWraps'));
     const equippedPalm = typeof save.equipment?.mainhand === 'object' && save.equipment.mainhand?.key === 'palmWraps';
     if (!hasPalmWraps && !equippedPalm) {
-      save.inventory.push({ id: Date.now() + Math.random(), key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' });
+      save.inventory.push({
+        id: Date.now() + Math.random(),
+        key: 'palmWraps',
+        name: 'Palm Wraps',
+        type: 'weapon',
+        typeKey: 'palm',
+        classKey: 'palm',
+      });
     }
   },
   save => {
@@ -85,20 +127,18 @@ export const migrations = [
   save => {
     if (!Array.isArray(save.inventory)) save.inventory = [];
     save.inventory.forEach(it => {
-      if (it && typeof it === 'object' && !it.name && it.key) {
-        it.name =
-          WEAPONS[it.key]?.displayName ||
-          GEAR_BASES[it.key]?.displayName ||
-          it.key;
+      if (it && typeof it === 'object') {
+        if (!it.name && it.key) it.name = it.key;
+        if (!it.typeKey) it.typeKey = it.type || it.key;
+        if (!it.classKey) it.classKey = it.class || it.typeKey || it.key;
       }
     });
     if (save.equipment && typeof save.equipment === 'object') {
       Object.values(save.equipment).forEach(it => {
-        if (it && typeof it === 'object' && !it.name && it.key) {
-          it.name =
-            WEAPONS[it.key]?.displayName ||
-            GEAR_BASES[it.key]?.displayName ||
-            it.key;
+        if (it && typeof it === 'object') {
+          if (!it.name && it.key) it.name = it.key;
+          if (!it.typeKey) it.typeKey = it.type || it.key;
+          if (!it.classKey) it.classKey = it.class || it.typeKey || it.key;
         }
       });
     }
@@ -113,7 +153,9 @@ export const migrations = [
         id: Date.now() + Math.random(),
         key: 'palmWraps',
         name: 'Palm Wraps',
-        type: 'weapon'
+        type: 'weapon',
+        typeKey: 'palm',
+        classKey: 'palm',
       });
     }
   }

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -1,5 +1,4 @@
 import { S, save } from '../../shared/state.js';
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
 export { usePill } from '../alchemy/mutators.js'; // deprecated shim
@@ -57,10 +56,16 @@ export function equipItem(item, slot = null, state = S) {
   const { id, ...equipData } = item;
   state.equipment[slotKey] = equipData;
   removeFromInventory(id, state);
-  console.log('[equip]', 'slot→', slotKey, 'item→', item.key);
+  console.log('[equip]', 'slot→', slotKey, 'item→', item.name || item.key);
   recomputePlayerTotals(state);
   save?.();
-  const payload = { key: item.key, name: WEAPONS[item.key]?.displayName || item.name || item.key, slot: slotKey };
+  const payload = {
+    key: item.key,
+    name: item.name || item.key,
+    typeKey: item.typeKey,
+    classKey: item.classKey,
+    slot: slotKey,
+  };
   if (slotKey === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);
   return payload;
 }
@@ -74,7 +79,13 @@ export function unequip(slot, state = S) {
   console.log('[equip]', 'slot→', slot, 'item→', 'none');
   recomputePlayerTotals(state);
   save?.();
-  const payload = { key: 'fist', name: 'Fists', slot };
+  const payload = {
+    key: 'fist',
+    name: 'Fists',
+    typeKey: 'fist',
+    classKey: 'fist',
+    slot,
+  };
   if (slot === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);
   return payload;
 }

--- a/src/features/inventory/selectors.js
+++ b/src/features/inventory/selectors.js
@@ -1,5 +1,4 @@
 import { S } from '../../shared/state.js';
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 
 export function getInventory(state = S) {
   return state.inventory || [];
@@ -14,12 +13,12 @@ export function getEquipped(slot, state = S) {
 }
 
 export function getEquippedWeapon(state = S) {
-  if (!state.flags?.weaponsEnabled) return WEAPONS.fist;
+  const fists = { key: 'fist', name: 'Fists', typeKey: 'fist', classKey: 'fist', slot: 'mainhand' };
+  if (!state.flags?.weaponsEnabled) return fists;
   const eq = state.equipment?.mainhand;
-  const key = typeof eq === 'string' ? eq : eq?.key;
-  if (WEAPONS[key]) return WEAPONS[key];
-  if (eq && typeof eq === 'object') {
-    return { ...eq, key, displayName: eq.displayName || eq.name || key };
+  if (!eq) return fists;
+  if (typeof eq === 'string') {
+    return { ...fists, key: eq, name: eq, typeKey: eq, classKey: eq };
   }
-  return WEAPONS.fist;
+  return { slot: 'mainhand', ...eq, name: eq.name || eq.key };
 }


### PR DESCRIPTION
## Summary
- use item metadata for equip/unequip events
- drop WEAPONS map lookups from inventory selectors
- migrate legacy saves to name/typeKey/classKey fields

## Testing
- `npm test`
- `npm run validate`

------
https://chatgpt.com/codex/tasks/task_e_68c1a0a1af708326aa72d25df3986aaf