### PR TITLE
feat: apply stun strength multiplier

### DIFF
--- a/docs/game-state-and-mechanics.md
+++ b/docs/game-state-and-mechanics.md
@@ -17,7 +17,10 @@ again【F:src/game/GameController.js†L13-L53】.
 Temporary conditions such as **Bruise**, **Fracture** or **Qi Disruption** are
 modeled as status entries with duration, stack limits and rule modifiers. Some
 statuses scale with attributes like Physique or Mind, and special flags handle
-stun immunity and weakened states【F:src/data/status.ts†L1-L55】.
+stun immunity and weakened states【F:src/data/status.ts†L1-L55】. Stun build from
+physical hits is further modified by the attacker’s **Stun Strength**
+(`stunBuildMult`) and the defender’s **Stun Build Reduction**
+(`stunBuildTakenReduction`) before the per-hit cap is applied【F:src/engine/combat/stun.js†L52-L59】.
 
 The Physique attribute grants permanent bonuses. Each Physique level awards one
 Physique point. For every point the player gains +3 maximum HP and +1

--- a/src/engine/combat/stun.js
+++ b/src/engine/combat/stun.js
@@ -50,7 +50,11 @@ export function tickStunDecay(target, dtSec, nowMs) {
 
 /** Add stun progress; triggers stun when threshold reached. */
 export function addStunPercent(stun, rawPercent, opts = {}) {
-  const gain = Math.min(rawPercent, MAX_STUN_PER_HIT);
+  const { attackerStats = {}, targetStats = {} } = opts;
+  let gain = rawPercent;
+  gain *= 1 + (attackerStats.stunBuildMult || 0);
+  gain *= 1 - (targetStats.stunBuildTakenReduction || 0);
+  gain = Math.min(gain, MAX_STUN_PER_HIT);
   stun.value += gain;
   if (stun.value >= STUN_THRESHOLD) {
     const overshoot = stun.value - STUN_THRESHOLD;


### PR DESCRIPTION
## Summary
- factor attacker stun strength and target stun reduction into stun build
- document stun build modifiers in mechanics guide

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violation warnings)

------
https://chatgpt.com/codex/tasks/task_e_68c1f7ec21708326a6b12e8d2a52a432