### PR TITLE
Use stun build for Rock Sling

### DIFF
--- a/src/features/ability/logic.js
+++ b/src/features/ability/logic.js
@@ -78,7 +78,7 @@ function resolveRockSling(state) {
     attacks: [
       { amount: damage, type: 'earth', target: state.adventure.currentEnemy },
     ],
-    stun: { mult: 0.2 },
+    stunBuildPct: 20,
   };
 }
 


### PR DESCRIPTION
## Summary
- Build stun bar with Rock Sling instead of instant stun
- Handle `stunBuildPct` in ability processing via `addStunPercent`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c208ff94708326b9db05c0da582866