### PR TITLE
Refactor weapon loot tables to use type keys

### DIFF
--- a/src/features/loot/data/lootTables.js
+++ b/src/features/loot/data/lootTables.js
@@ -24,12 +24,34 @@ export const LOOT_TABLES = {
   // existing zones…
 };
 
-import { WEAPONS } from '../../weaponGeneration/data/weapons.js';
+import { WEAPON_TYPES } from '../../weaponGeneration/data/weaponTypes.js';
+import { generateWeapon } from '../../weaponGeneration/logic.js';
+
+function parseWeaponKey(item) {
+  const typeKey = Object.keys(WEAPON_TYPES).find(k => item.endsWith(k));
+  if (!typeKey) return null;
+  const materialKey = item.slice(0, item.length - typeKey.length) || undefined;
+  return { typeKey, materialKey };
+}
+
 export const WEAPON_LOOT_TABLE = Object.fromEntries(
   Object.values(LOOT_TABLES)
     .flat()
-    .filter(entry => WEAPONS[entry.item])
-    .map(entry => [entry.item, (entry.weight || 0) / 100])
+    .map(entry => {
+      const info = parseWeaponKey(entry.item);
+      if (!info) return null;
+      const { typeKey, materialKey } = info;
+      return [
+        entry.item,
+        {
+          weight: (entry.weight || 0) / 100,
+          typeKey,
+          materialKey,
+          create: () => generateWeapon({ typeKey, materialKey }),
+        },
+      ];
+    })
+    .filter(Boolean)
 );
 
 // TODO: derive weapon tables for additional zones

--- a/src/ui/weaponSelectOverlay.js
+++ b/src/ui/weaponSelectOverlay.js
@@ -3,8 +3,12 @@ import { generateWeapon } from '../features/weaponGeneration/logic.js';
 import { WEAPON_TYPES } from '../features/weaponGeneration/data/weaponTypes.js';
 import { WEAPON_ICONS } from '../features/weaponGeneration/data/weaponIcons.js';
 
+function createWeapon(typeKey) {
+  return generateWeapon({ typeKey });
+}
+
 function renderOption(key) {
-  const sample = generateWeapon({ typeKey: key });
+  const sample = createWeapon(key);
   const icon = WEAPON_ICONS[sample.classKey];
   return `
     <button class="weapon-option" data-key="${key}">
@@ -42,7 +46,7 @@ export function showWeaponSelectOverlay(state) {
   overlay.querySelectorAll('.weapon-option').forEach(btn => {
     btn.addEventListener('click', () => {
       const key = btn.getAttribute('data-key');
-      const weapon = generateWeapon({ typeKey: key });
+      const weapon = createWeapon(key);
       const id = addToInventory(weapon, state);
       const item = state.inventory.find(it => it.id === id);
       equipItem(item, 'mainhand', state);


### PR DESCRIPTION
## Summary
- Parse loot table entries against `WEAPON_TYPES` and generate weapons at drop time
- Provide generator function per weapon entry and retain material information
- Consolidate weapon selection overlay to construct final items with `generateWeapon`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c2091d976c8326ac0fd5bcf5199d4e