### PR TITLE
Remove combat HUD stat icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,11 +687,6 @@
                     </div>
                     <div class="status-ailments" id="playerAilments"></div>
                   </div>
-                  <div class="stat-icons">
-                    <span class="icon" id="playerAttack" title="ATK">⚔️</span>
-                    <span class="icon" id="playerAttackRate" title="Rate">⏱️</span>
-                    <span class="icon" id="playerMitigation" title="Mit">🛡️</span>
-                  </div>
                 </div>
 
                 <div class="hud enemy">
@@ -710,11 +705,6 @@
                     </div>
                     <div class="enemy-affixes" id="enemyAffixes"></div>
                     <div class="status-ailments" id="enemyAilments"></div>
-                  </div>
-                  <div class="stat-icons">
-                    <span class="icon" id="enemyAttack" title="ATK">⚔️</span>
-                    <span class="icon" id="enemyAttackRate" title="Rate">⏱️</span>
-                    <span class="icon" id="enemyMitigation" title="Mit">🛡️</span>
                   </div>
                 </div>
               </div>

--- a/style.css
+++ b/style.css
@@ -4457,8 +4457,6 @@ tr:last-child td {
 .combat-hud .health-bar{height:12px;margin:0}
 .combat-hud .qi-bar{height:8px;margin:0}
 .combat-hud .health-text,.combat-hud .qi-text{font-size:.65rem}
-.combat-hud .stat-icons{display:flex;gap:4px;font-size:12px}
-.combat-hud .stat-icons .icon{cursor:help}
 .combat-hud .enemy-name{font-size:.75rem;font-weight:600}
 .combat-hud .player-name{font-size:.75rem;font-weight:600}
 .status-ailments{display:flex;gap:4px;margin-top:2px}


### PR DESCRIPTION
## Summary
- Remove sword, timer, and shield icons under adventure HUD life bars for player and enemy
- Clean up unused CSS styling for removed stat icons

## Testing
- ⚠️ `npm test` (no test specified)
- ⚠️ `npm run validate` (AI verification enforcement failure)
- ✅ `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c24b0d51a88326ae624d3fe181243a