### PR TITLE
Allow proficiency API to accept weapon objects

### DIFF
--- a/src/features/proficiency/logic.js
+++ b/src/features/proficiency/logic.js
@@ -1,23 +1,29 @@
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { WEAPON_TYPES } from '../weaponGeneration/data/weaponTypes.js';
 
 // Proficiency is stored on the player state as an object: { [weaponClass]: number }
-function resolveKey(key) {
-  const weapon = WEAPONS[key];
-  return weapon?.classKey || key;
+function resolveClassKey(target) {
+  if (typeof target === 'string') {
+    return WEAPON_TYPES[target]?.classKey || target;
+  }
+  if (target && typeof target === 'object') {
+    return target.classKey || WEAPON_TYPES[target.typeKey]?.classKey || target.typeKey;
+  }
+  return target;
 }
 
 export function calculateProficiencyXP(enemyMaxHP) {
   return Math.max(1, Math.ceil(enemyMaxHP / 30));
 }
 
-export function gainProficiency(key, amount, state) {
+export function gainProficiency(weapon, amount, state) {
   state.proficiency = state.proficiency || {};
-  const classKey = resolveKey(key);
+  const classKey = resolveClassKey(weapon);
+  if (!classKey) return;
   state.proficiency[classKey] = (state.proficiency[classKey] || 0) + amount;
 }
 
-export function getProficiency(key, state) {
-  const classKey = resolveKey(key);
+export function getProficiency(weapon, state) {
+  const classKey = resolveClassKey(weapon);
   const value = (state.proficiency && state.proficiency[classKey]) || 0;
   // Soft cap: returns multiplier >1 but growth slows down
   const bonus = 1 + Math.pow(value, 0.6) * 0.01;

--- a/src/features/proficiency/migrations.js
+++ b/src/features/proficiency/migrations.js
@@ -1,4 +1,4 @@
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
+import { WEAPON_TYPES } from '../weaponGeneration/data/weaponTypes.js';
 
 export const migrations = [
   save => {
@@ -18,8 +18,7 @@ export const migrations = [
     if (save.proficiency && typeof save.proficiency === 'object') {
       const converted = {};
       for (const [key, val] of Object.entries(save.proficiency)) {
-        const weapon = WEAPONS[key];
-        const classKey = weapon?.classKey || key;
+        const classKey = WEAPON_TYPES[key]?.classKey || key;
         converted[classKey] = (converted[classKey] || 0) + val;
       }
       save.proficiency = converted;

--- a/src/features/proficiency/selectors.js
+++ b/src/features/proficiency/selectors.js
@@ -1,19 +1,17 @@
 import { proficiencyState } from './state.js';
 import { getProficiency as resolveProficiency } from './logic.js';
-import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { getTunable } from '../../shared/tunables.js';
 
-export function getProficiency(key, state = proficiencyState) {
-  const res = resolveProficiency(key, state);
+export function getProficiency(weapon, state = proficiencyState) {
+  const res = resolveProficiency(weapon, state);
   const xpMult = getTunable('proficiency.xpGainMult', 1);
   return { ...res, xpMult };
 }
 
 export function getWeaponProficiencyBonuses(state = proficiencyState) {
   const equipped = state.flags?.weaponsEnabled ? state.equipment?.mainhand : 'fist';
-  const key = typeof equipped === 'string' ? equipped : equipped?.key;
-  const weapon = WEAPONS[key] || WEAPONS.fist;
-  const { value } = getProficiency(weapon.classKey, state);
+  const weapon = equipped || 'fist';
+  const { value } = getProficiency(weapon, state);
   const level = Math.floor(value / 100);
   return { damageMult: 1 + level * 0.02, speedMult: 1 + level * 0.01 };
 }


### PR DESCRIPTION
## Summary
- Resolve proficiency using weapon objects or explicit class/type keys instead of static weapon list
- Remove `WEAPONS` dependencies from selectors and translate legacy keys to class keys in migrations

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: AI verification violations)


------
https://chatgpt.com/codex/tasks/task_e_68c24b5ceae483269e1c6c2bf2d4733f