### PR TITLE
chore: remove dexterity stat

### DIFF
--- a/docs/To-dos/combat-stats-analysis.md
+++ b/docs/To-dos/combat-stats-analysis.md
@@ -3,9 +3,9 @@
 ## Current Implementation Status (v1.2.0)
 
 ### ✅ Core Combat Stats (Implemented)
-- **Critical Chance** - `S.stats.criticalChance` (base 0.05, scales with dexterity)
-- **Attack Speed** - `S.stats.attackSpeed` (base 1.0, scales with dexterity)
-- **Cooldown Reduction** - `S.stats.cooldownReduction` (scales with dexterity)
+- **Critical Chance** - `S.stats.criticalChance` (base 0.05)
+- **Attack Speed** - `S.stats.attackSpeed` (base 1.0)
+- **Cooldown Reduction** - `S.stats.cooldownReduction`
 - **Defense** - `calcDef()` function with realm bonuses
 - **Adventure Speed** - `S.stats.adventureSpeed` for exploration
 
@@ -47,12 +47,6 @@ const damageMultiplier = isCritical ? 1.5 : 1.0; // Base 1.5x crit damage
 ```
 
 ## Attribute Integration
-
-### Dexterity
-- **Attack Speed**: +4% per point
-- **Critical Chance**: +0.5% per point
-- **Dodge**: +0.3% per point
-- **Accuracy**: +0.4% per point
 
 ### Mind
 - **Spell Power**: +6% per point

--- a/docs/To-dos/combat-stats.md
+++ b/docs/To-dos/combat-stats.md
@@ -2,9 +2,9 @@
 
 ## ✅ Implemented Stats
 
-* **Critical Chance** - `S.stats.criticalChance` (base 0.05, scales with dexterity)
-* **Attack Speed** - `S.stats.attackSpeed` (base 1.0, scales with dexterity)
-* **Cooldown Reduction** - `S.stats.cooldownReduction` (scales with dexterity)
+* **Critical Chance** - `S.stats.criticalChance` (base 0.05)
+* **Attack Speed** - `S.stats.attackSpeed` (base 1.0)
+* **Cooldown Reduction** - `S.stats.cooldownReduction`
 * **Defense** - `calcDef()` function with realm bonuses
 * **Adventure Speed** - `S.stats.adventureSpeed` for exploration speed
 
@@ -36,6 +36,6 @@
 - **Status Effects**: Chance to apply based on attacker's stats vs target's resistances
 
 ## 📊 Scaling Factors
-- Primary attributes (Strength, Dexterity, etc.) affect different stats
+- Primary attributes (Physique, Mind, Agility, etc.) affect different stats
 - Equipment and manuals provide flat or percentage bonuses
 - Some stats have diminishing returns at higher values

--- a/docs/parameters-and-formulas.md
+++ b/docs/parameters-and-formulas.md
@@ -12,7 +12,6 @@
 | Physique | 10 |
 | Mind | 10 |
 | Agility | 10 |
-| Dexterity | 10 |
 | Comprehension | 10 |
 | Critical Chance | 5% |
 | Attack Speed | 1.0× |

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -444,7 +444,7 @@ S = {
   
   // Stats system
   stats: {
-    physique: 10, mind: 10, dexterity: 10, comprehension: 10,
+    physique: 10, mind: 10, agility: 10, comprehension: 10,
     criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0
   },
   

--- a/index.html
+++ b/index.html
@@ -789,7 +789,6 @@
                 <div class="stat"><span>Hit Chance</span><span id="hitChance">--</span></div>
                 <div class="stat"><span>Evade Chance</span><span id="evadeChance">--</span></div>
                 <div class="stat"><span>Qi Shield</span><span id="qiShield">0/0</span></div>
-                <div class="muted" style="margin-top:8px">Higher dexterity increases attack rate.</div>
               </div>
             </div>
             
@@ -889,7 +888,6 @@
                 <div class="stat"><span>Physique</span><span id="stat-physique">10</span></div>
                 <div class="stat"><span>Mind</span><span id="stat-mind">10</span></div>
                 <div class="stat"><span>Agility</span><span id="stat-agility">10</span></div>
-                <div class="stat"><span>Dexterity</span><span id="stat-dexterity">10</span></div>
                 <div class="stat"><span>Comprehension</span><span id="stat-comprehension">10</span></div>
                 <div class="stat"><span>Crit Chance</span><span id="stat-criticalChance">5%</span></div>
                 <div class="stat"><span>Attack Speed</span><span id="stat-attackSpeed">1.00</span></div>

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -100,7 +100,6 @@ function renderStats() {
     { id: 'physique', stat: 'physique' },
     { id: 'mind', stat: 'mind' },
     { id: 'agility', stat: 'agility' },
-    { id: 'dexterity', stat: 'dexterity' },
     { id: 'comprehension', stat: 'comprehension' },
     { id: 'accuracy', stat: 'accuracy' },
     { id: 'dodge', stat: 'dodge' },

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -138,7 +138,6 @@ export function calcArmor(state = progressionState){
 export function getStatEffects(state = progressionState) {
   const stats = state.stats || {};
   const mind = Number(stats.mind) || 10;
-  const dex = Number(stats.dexterity) || 10;
   const comp = Number(stats.comprehension) || 10;
   const crit = Number(stats.criticalChance) || 0;
   const atkSpd = Number(stats.attackSpeed) || 0;
@@ -148,16 +147,16 @@ export function getStatEffects(state = progressionState) {
     spellPowerMult: 1 + (mind - 10) * 0.06,
     alchemySuccessMult: 1 + (mind - 10) * 0.04,
     learningSpeedMult: 1 + (mind - 10) * 0.05,
-    attackSpeedMult: 1 + (dex - 10) * 0.04,
-    cooldownReductionBonus: (dex - 10) * 0.02,
-    craftingSpeedMult: 1 + (dex - 10) * 0.03,
-    adventureSpeedMult: 1 + (dex - 10) * 0.03,
+    attackSpeedMult: 1,
+    cooldownReductionBonus: 0,
+    craftingSpeedMult: 1,
+    adventureSpeedMult: 1,
     foundationGainMult: 1 + (comp - 10) * 0.05,
     learningSpeedMult2: 1 + (comp - 10) * 0.04,
-    totalCritChance: crit + (dex - 10) * 0.005,
-    totalAttackSpeed: atkSpd * (1 + (dex - 10) * 0.04),
-    totalCooldownReduction: cdRed + (dex - 10) * 0.02,
-    totalAdventureSpeed: advSpd * (1 + (dex - 10) * 0.03)
+    totalCritChance: crit,
+    totalAttackSpeed: atkSpd,
+    totalCooldownReduction: cdRed,
+    totalAdventureSpeed: advSpd
   };
 }
 
@@ -191,11 +190,9 @@ export function calculatePlayerCombatAttack(state = progressionState) {
 
 export function calculatePlayerAttackRate(state = progressionState) {
   const baseRate = 1.0;
-  const dex = Number(state.stats?.dexterity) || 10;
   const attackSpeedBonus = Number(state.stats?.attackSpeed) || 0;
   const speedMult = Number(getWeaponProficiencyBonuses(state).speedMult) || 1;
-  const dexterityBonus = (dex - 10) * 0.05;
-  return (baseRate + dexterityBonus + attackSpeedBonus / 100) * speedMult;
+  return (baseRate + attackSpeedBonus / 100) * speedMult;
 }
 
 export function breakthroughChance(state = progressionState){

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -33,7 +33,7 @@ export function advanceRealm(state = progressionState) {
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.stats = state.stats || {
-      physique: 10, mind: 10, dexterity: 10, comprehension: 10,
+      physique: 10, mind: 10, agility: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0,
       armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE
     };
@@ -45,7 +45,7 @@ export function advanceRealm(state = progressionState) {
     const realmStatPoints = 3 + state.realm.tier;
     state.stats.physique += Math.ceil(realmStatPoints * 0.3);
     state.stats.mind += Math.ceil(realmStatPoints * 0.25);
-    state.stats.dexterity += Math.ceil(realmStatPoints * 0.25);
+    state.stats.agility += Math.ceil(realmStatPoints * 0.25);
     state.stats.comprehension += Math.ceil(realmStatPoints * 0.2);
     state.stats.criticalChance += 0.01;
 
@@ -62,7 +62,7 @@ export function advanceRealm(state = progressionState) {
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.stats = state.stats || {
-      physique: 10, mind: 10, dexterity: 10, comprehension: 10,
+      physique: 10, mind: 10, agility: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0,
       armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE
     };
@@ -79,7 +79,7 @@ export function advanceRealm(state = progressionState) {
     } else if (statDistribution < 0.85) {
       state.stats.mind += stageStatPoints;
     } else {
-      state.stats.dexterity += stageStatPoints;
+      state.stats.agility += stageStatPoints;
     }
 
     log?.(`Stage breakthrough! ATK +${stageBonus}, Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`, 'good');

--- a/src/features/progression/state.js
+++ b/src/features/progression/state.js
@@ -34,7 +34,6 @@ export const progressionState = {
     physique: 10,
     mind: 10,
     agility: 10,
-    dexterity: 10,
     comprehension: 10,
     criticalChance: 0.05,
     attackSpeed: 1.0,

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -30,7 +30,6 @@ export const defaultState = () => {
     physique: 10,        // Physical power
     mind: 10,            // Spell power, alchemy, learning speed
     agility: 10,         // Weapon handling, dodge
-    dexterity: 10,       // Attack speed, cooldowns, crafting, adventure speed
     comprehension: 10,   // Foundation gain, learning speed
     criticalChance: 0.05, // Base critical hit chance
     attackSpeed: 1.0,    // Base attack speed multiplier


### PR DESCRIPTION
## Summary
- drop dexterity stat from player state and progression logic
- shift realm and stage stat gains from dexterity to agility
- clean up UI and docs to omit dexterity references

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: VERIFICATION FAILED - MUST fix before proceeding)

------
https://chatgpt.com/codex/tasks/task_e_68c3307f59208326a515c40df2bb07ff