### PR TITLE
Split stats into base and derived

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -87,7 +87,7 @@ function applyAbilityResult(abilityKey, res, state) {
   const logs = state.adventure?.combatLog;
   const mods = state.abilityMods?.[abilityKey];
   const weapon = getEquippedWeapon(state);
-  const attackerStats = mergeStats(state.stats, weapon?.stats);
+  const attackerStats = mergeStats({ ...state.attributes, ...state.derivedStats }, weapon?.stats);
   const attacks = res.attacks || (res.attack ? [res.attack] : []);
   if (attacks.length) {
     const { target } = attacks[0];
@@ -98,7 +98,7 @@ function applyAbilityResult(abilityKey, res, state) {
 
     if (!isSpell) {
       const enemyDodge = (target?.stats?.dodge ?? target?.dodge ?? 0) + DODGE_BASE;
-      const hitP = chanceToHit(state.stats?.accuracy || 0, enemyDodge);
+      const hitP = chanceToHit(state.derivedStats?.accuracy || 0, enemyDodge);
       if (Math.random() >= hitP) {
         logs?.push(`Your ${ability.displayName} missed!`);
         return;
@@ -121,7 +121,7 @@ function applyAbilityResult(abilityKey, res, state) {
           mult *= getWeaponProficiencyBonuses(state).damageMult;
         }
         const { spellPowerMult } = getStatEffects(state);
-        const spellDamage = state.stats?.spellDamage || 0;
+        const spellDamage = state.derivedStats?.spellDamage || 0;
         const spellTreeMult = 1 + (state.astralTreeBonuses?.spellDamagePct || 0) / 100;
         mult *= spellPowerMult * (1 + spellDamage / 100) * spellTreeMult;
       } else {

--- a/src/features/ability/selectors.js
+++ b/src/features/ability/selectors.js
@@ -54,7 +54,7 @@ export function getAbilityDamage(abilityKey, state = S) {
       amount = Math.round(amount * getWeaponProficiencyBonuses(state).damageMult);
     }
     const { spellPowerMult } = getStatEffects(state);
-    const spellDamage = state.stats?.spellDamage || 0;
+    const spellDamage = state.derivedStats?.spellDamage || 0;
     const treeMult = 1 + (state.astralTreeBonuses?.spellDamagePct || 0) / 100;
     amount = Math.round(amount * spellPowerMult * (1 + spellDamage / 100) * treeMult);
   }

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -325,7 +325,7 @@ export function updateBattleDisplay() {
 
   // Calculate physical mitigation against the strongest enemy in the current zone
   let mitPct = 0;
-  const armor = S.stats?.armor || 0;
+  const armor = S.derivedStats?.armor || 0;
   const zone = ZONES[S.adventure.currentZone];
   if (armor > 0 && zone?.areas?.length) {
     let maxEnemyAtk = 0;
@@ -761,9 +761,9 @@ export function updateAdventureCombat() {
     if (!S.currentCast && now - S.adventure.lastPlayerAttack >= (1000 / playerAttackRate)) {
       S.adventure.lastPlayerAttack = now;
       const enemyDodge = (S.adventure.currentEnemy?.stats?.dodge ?? S.adventure.currentEnemy?.dodge ?? 0) + DODGE_BASE;
-      const hitP = chanceToHit(S.stats?.accuracy || 0, enemyDodge);
+      const hitP = chanceToHit(S.derivedStats?.accuracy || 0, enemyDodge);
       if (Math.random() < hitP) {
-        const critChance = S.stats?.criticalChance || 0;
+        const critChance = S.attributes?.criticalChance || 0;
         const isCrit = Math.random() < critChance;
         const critMult = isCrit ? 2 : 1;
         const profile = {
@@ -888,7 +888,7 @@ export function updateAdventureCombat() {
       if (now - S.adventure.lastEnemyAttack >= (1000 / enemyAttackRate)) {
         S.adventure.lastEnemyAttack = now;
         const enemyAcc = S.adventure.currentEnemy?.stats?.accuracy ?? S.adventure.currentEnemy?.accuracy ?? 0;
-        const playerDodge = S.stats?.dodge || 0;
+        const playerDodge = S.derivedStats?.dodge || 0;
         const hitP = chanceToHit(enemyAcc, playerDodge);
         if (Math.random() < hitP) {
           const critChance = S.adventure.currentEnemy?.stats?.criticalChance ?? S.adventure.currentEnemy?.criticalChance ?? 0;
@@ -1689,10 +1689,10 @@ export function updateActivityAdventure() {
   const enemyData = currentArea ? ENEMY_DATA[currentArea.enemy] : null;
   if (enemyData) {
     const enemyDodge = (enemyData.stats?.dodge ?? enemyData.dodge ?? 0) + DODGE_BASE;
-    const hitP = chanceToHit(S.stats?.accuracy || 0, enemyDodge);
+    const hitP = chanceToHit(S.derivedStats?.accuracy || 0, enemyDodge);
     setText('hitChance', `${Math.round(hitP * 100)}%`);
     const enemyAcc = enemyData.stats?.accuracy ?? enemyData.accuracy ?? 0;
-    const evadeP = 1 - chanceToHit(enemyAcc, S.stats?.dodge || 0);
+    const evadeP = 1 - chanceToHit(enemyAcc, S.derivedStats?.dodge || 0);
     setText('evadeChance', `${Math.round(evadeP * 100)}%`);
   } else {
     setText('hitChance', '--');

--- a/src/features/agility/logic.js
+++ b/src/features/agility/logic.js
@@ -5,8 +5,8 @@ function slice(state){
 }
 
 export function getAgilityEffects(state){
-  const root = state.stats ? state : { stats: { agility: 10 } };
-  const current = root.stats.agility || 10;
+  const root = state.attributes ? state : { attributes: { agility: 10 } };
+  const current = root.attributes.agility || 10;
   const accuracyBonus = Math.floor(current * 2);
   const dodgeBonus = Math.floor(current * 0.5);
   const forgeSpeed = 1 + current * 0.02;

--- a/src/features/agility/mutators.js
+++ b/src/features/agility/mutators.js
@@ -14,11 +14,12 @@ export function addAgilityExp(amount, state = agilityState){
     p.exp -= p.expMax;
     p.level++;
     p.expMax = Math.floor(p.expMax * 1.4);
-    if(state.stats){
-      state.stats.agility = (state.stats.agility || 10) + 1;
+    if(state.attributes){
+      state.attributes.agility = (state.attributes.agility || 10) + 1;
       const { accuracyBonus, dodgeBonus } = getAgilityEffects(state);
-      state.stats.accuracy = ACCURACY_BASE + accuracyBonus;
-      state.stats.dodge = DODGE_BASE + dodgeBonus;
+      state.derivedStats = state.derivedStats || {};
+      state.derivedStats.accuracy = ACCURACY_BASE + accuracyBonus;
+      state.derivedStats.dodge = DODGE_BASE + dodgeBonus;
     }
   }
   return p.exp;
@@ -110,7 +111,7 @@ export function tickAgilityTraining(state = agilityState){
       return endTrainingSession(state);
     }
   }else{
-    regenAgilityStamina(0.03 * (1 + (state.stats?.agility || 10) * 0.1), state);
+    regenAgilityStamina(0.03 * (1 + (state.attributes?.agility || 10) * 0.1), state);
   }
   return null;
 }

--- a/src/features/agility/ui/agilityDisplay.js
+++ b/src/features/agility/ui/agilityDisplay.js
@@ -5,7 +5,7 @@ import { buildObstacleCourse } from '../mutators.js';
 
 function render(state){
   const bonuses = getAgilityBonuses(state);
-  setText('currentAgilityStat', state.stats?.agility || 10);
+  setText('currentAgilityStat', state.attributes?.agility || 10);
   setText('agilityAccuracyStat', `+${bonuses.accuracyBonus}`);
   setText('agilityDodgeStat', `+${bonuses.dodgeBonus}`);
   setText('agilityForgeSpeedStat', `+${Math.floor((bonuses.forgeSpeed - 1) * 100)}%`);

--- a/src/features/alchemy/mutators.js
+++ b/src/features/alchemy/mutators.js
@@ -1,4 +1,5 @@
 import { S, save } from '../../shared/state.js';
+import { isAttributeStat } from '../../shared/utils/stats.js';
 import { alchemyState } from './state.js';
 import { getSuccessBonus } from './selectors.js';
 import { qCap, clamp } from '../progression/selectors.js';
@@ -103,12 +104,17 @@ export function usePill(root, type, tier = 1) {
     const res = alch.resistance?.[type] || { rp: 0, rpCap: resDef.rpCap };
     let { rp } = res;
     if (rp < resDef.rpCap) {
-      const stats = recipe.effects?.stats || {};
-      root.stats = root.stats || {};
-      for (const [stat, val] of Object.entries(stats)) {
+    const stats = recipe.effects?.stats || {};
+    root.attributes = root.attributes || {};
+    root.derivedStats = root.derivedStats || {};
+    for (const [stat, val] of Object.entries(stats)) {
         const gain = val / (1 + rp);
-        root.stats[stat] = (root.stats[stat] || 0) + gain;
-      }
+        if (isAttributeStat(stat)) {
+          root.attributes[stat] = (root.attributes[stat] || 0) + gain;
+        } else {
+          root.derivedStats[stat] = (root.derivedStats[stat] || 0) + gain;
+        }
+    }
     }
     const rpGain = resDef.baseRp * (resDef.tierWeight ?? 1);
     rp = Math.min(rp + rpGain, resDef.rpCap);

--- a/src/features/alchemy/selectors.js
+++ b/src/features/alchemy/selectors.js
@@ -50,7 +50,7 @@ export function inspectPillResistance(lineKey, tier = 1, state = S) {
 export function getSuccessBonus(state = S) {
   const building = getBuildingBonuses(state).alchemySuccess || 0;
   const level = getAlchemyLevel(state) * LEVEL_SUCCESS_BONUS;
-  const mind = (state.stats?.mind || 10) - 10;
+  const mind = (state.attributes?.mind || 10) - 10;
   return building + level + mind * 0.04;
 }
 

--- a/src/features/catching/mutators.js
+++ b/src/features/catching/mutators.js
@@ -15,7 +15,7 @@ export function startCatch(state, zi, ai){
   const stage = ai + 1;
   const chance = Math.pow(0.5, stage);
   const baseMinutes = 10 + 5 * stage;
-  const agility = state.stats?.agility || 0;
+  const agility = state.attributes?.agility || 0;
   const duration = baseMinutes * 60_000 * Math.max(0, 1 - 0.04 * agility);
   const icon = getCatchingIcon(area.enemy);
   root.nets -= 1;

--- a/src/features/combat/ui/combatStats.js
+++ b/src/features/combat/ui/combatStats.js
@@ -5,13 +5,13 @@ import { fmt } from '../../../shared/utils/number.js';
 
 export function updateCombatStats(state = S) {
   setText('atkVal', calcAtk(state));
-  setText('armorVal', state.stats?.armor || 0);
-  setText('accuracyVal', state.stats?.accuracy || 0);
-  setText('dodgeVal', state.stats?.dodge || 0);
+  setText('armorVal', state.derivedStats?.armor || 0);
+  setText('accuracyVal', state.derivedStats?.accuracy || 0);
+  setText('dodgeVal', state.derivedStats?.dodge || 0);
   setText('atkVal2', calcAtk(state));
-  setText('armorVal2', state.stats?.armor || 0);
-  setText('accuracyVal2', state.stats?.accuracy || 0);
-  setText('dodgeVal2', state.stats?.dodge || 0);
+  setText('armorVal2', state.derivedStats?.armor || 0);
+  setText('accuracyVal2', state.derivedStats?.accuracy || 0);
+  setText('dodgeVal2', state.derivedStats?.dodge || 0);
 
   // HP & Shield HUD (moved here to avoid duplicate updates in ui/index.js)
   setText('hpVal', fmt(state.hp));

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -31,13 +31,14 @@ export function recomputePlayerTotals(player) {
       dropRateMult += item.bonuses.dropRateMult || 0;
     }
   }
-  player.stats = player.stats || {};
+  player.derivedStats = player.derivedStats || {};
   const baseArmor = calcBaseArmor(player);
-  player.stats.armor = armor + baseArmor;
-  player.stats.accuracy = ACCURACY_BASE + accuracy;
-  player.stats.dodge = DODGE_BASE + dodge;
+  player.derivedStats.armor = armor + baseArmor;
+  player.derivedStats.accuracy = ACCURACY_BASE + accuracy;
+  player.derivedStats.dodge = DODGE_BASE + dodge;
   player.shield = player.shield || { current: 0, max: 0 };
-  const mind = player.stats.mind || 0;
+  player.attributes = player.attributes || {};
+  const mind = player.attributes.mind || 0;
   const shieldMult = 1 + mind * 0.06;
   player.shield.max = Math.round(shieldMax * shieldMult);
   // Fully refresh the player's Qi shield whenever equipment changes so that

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -93,7 +93,8 @@ export function renderEquipmentPanel() {
 }
 
 function renderStats() {
-  if (!S.stats) return;
+  const stats = { ...S.attributes, ...S.derivedStats };
+  if (!stats) return;
   const defs = [
     { id: 'hp', value: () => `${S.hp}/${S.hpMax}` },
     { id: 'shield', value: () => `${S.shield?.current || 0}/${S.shield?.max || 0}` },
@@ -115,7 +116,7 @@ function renderStats() {
   defs.forEach(d => {
     const el = document.getElementById(`stat-${d.id}`);
     if (!el) return;
-    const val = d.value ? d.value() : (S.stats[d.stat] ?? 0);
+    const val = d.value ? d.value() : (stats[d.stat] ?? 0);
     el.textContent = d.format ? d.format(val) : val;
   });
 }

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -83,7 +83,7 @@ export function onTick(S, dt) {
     stopReading(S);
     return;
   }
-  const add = calcFromManual(manual, dt, S.stats);
+  const add = calcFromManual(manual, dt, S.attributes);
   const applied = applyPuzzleMultiplier(add, S.mind.multiplier);
   S.mind.fromReading += add;
   S.mind.xp += applied;

--- a/src/features/mind/ui/mindMainTab.js
+++ b/src/features/mind/ui/mindMainTab.js
@@ -52,7 +52,7 @@ export function renderMindMainTab(rootEl, state) {
   rootEl.appendChild(card);
 
   // Mind attribute breakdown
-  const mindAttr = state.stats?.mind ?? 0;
+  const mindAttr = state.attributes?.mind ?? 0;
   const mindPoints = state.mind.level; // each level grants one point
   const attrCard = document.createElement('div');
   attrCard.className = 'card';

--- a/src/features/mind/ui/mindReadingTab.js
+++ b/src/features/mind/ui/mindReadingTab.js
@@ -81,7 +81,7 @@ function showManualPopup(manual, S) {
         <button class="btn small ghost close-btn">×</button>
       </div>
       <div class="manual-meta">${manual.category} • Req Level ${manual.reqLevel}</div>
-      ${renderSpeedInfo(manual, S.stats)}
+      ${renderSpeedInfo(manual, S.attributes)}
       ${renderEffects(manual)}
       <div class="manual-actions">
         <button class="btn small add-btn">Add to Queue</button>
@@ -132,7 +132,7 @@ function buildQueueItems(S) {
     const m = getManual(id);
     if (m) {
       const rec = S.mind.manualProgress[id] || { xp: 0, level: 0 };
-      const speed = calcManualSpeedDetails(m, S.stats).mult;
+      const speed = calcManualSpeedDetails(m, S.attributes).mult;
       const needed = m.baseTimeSec * m.levelTimeMult[rec.level] * m.xpRate;
       const xpRate = m.xpRate * speed;
       const eta = (needed - rec.xp) / xpRate;

--- a/src/features/physique/logic.js
+++ b/src/features/physique/logic.js
@@ -9,8 +9,8 @@ function slice(state){
  * Returns HP bonus and additional carry capacity.
  */
 export function getPhysiqueEffects(state){
-  const root = state.stats ? state : { stats: { physique: 10 } };
-  const current = root.stats.physique || 10;
+  const root = state.attributes ? state : { attributes: { physique: 10 } };
+  const current = root.attributes.physique || 10;
   const hpBonus = Math.floor(current * 3);
   const carryCapacity = current;
   const maxStamina = current * 10;

--- a/src/features/physique/mutators.js
+++ b/src/features/physique/mutators.js
@@ -12,9 +12,9 @@ export function addPhysiqueExp(amount, state = physiqueState){
     p.exp -= p.expMax;
     p.level++;
     p.expMax = Math.floor(p.expMax * 1.4);
-    if(state.stats){
-      state.stats.physique = (state.stats.physique || 10) + 1;
-      p.maxStamina = (state.stats.physique || 10) * 10;
+    if(state.attributes){
+      state.attributes.physique = (state.attributes.physique || 10) + 1;
+      p.maxStamina = (state.attributes.physique || 10) * 10;
       p.stamina = Math.min(p.stamina || 0, p.maxStamina);
       state.hpMax = (state.hpMax || 0) + 3;
       state.hp = Math.min(state.hpMax, (state.hp || 0) + 3);
@@ -47,7 +47,7 @@ export function trainPhysique(state = physiqueState){
     return { message: 'You must be training physique to use the training dummy!', type: 'bad' };
   }
   const baseExp = 5 + Math.floor(Math.random() * 10);
-  const expGain = Math.floor(baseExp * (1 + ((root.stats?.physique || 10) - 10) * 0.1));
+  const expGain = Math.floor(baseExp * (1 + ((root.attributes?.physique || 10) - 10) * 0.1));
   addPhysiqueExp(expGain, state);
   return { message: `Training session complete! +${expGain} physique exp`, type: 'good' };
 }

--- a/src/features/physique/ui/physiqueDisplay.js
+++ b/src/features/physique/ui/physiqueDisplay.js
@@ -11,7 +11,7 @@ function render(state){
   setText('physiqueLevel', `Level ${getPhysiqueLevel(state)}`);
   setFill('physiqueProgressFill', getPhysiqueExp(state) / getPhysiqueExpMax(state));
   const bonuses = getPhysiqueBonuses(state);
-  setText('currentPhysiqueStat', state.stats?.physique || 10);
+  setText('currentPhysiqueStat', state.attributes?.physique || 10);
   setText('physiqueHpStat', `+${bonuses.hpBonus}`);
   setText('physiqueCarryStat', `+${bonuses.carryCapacity}`);
   setText('physiqueMaxStaminaStat', `${bonuses.maxStamina}`);

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -82,7 +82,7 @@ export function foundationGainPerSec(state = progressionState){
       buildingMult: 1.0
     };
   }
-  const comprehensionMult = 1 + (state.stats.comprehension - 10) * 0.05;
+  const comprehensionMult = 1 + (state.attributes.comprehension - 10) * 0.05;
   const cultivationMult = state.cultivation.talent * comprehensionMult * state.cultivation.foundationMult;
   const lawBonuses = getLawBonuses(state);
   const lawMult = lawBonuses.foundationMult || 1;
@@ -136,7 +136,7 @@ export function calcArmor(state = progressionState){
 }
 
 export function getStatEffects(state = progressionState) {
-  const stats = state.stats || {};
+  const stats = state.attributes || {};
   const mind = Number(stats.mind) || 10;
   const comp = Number(stats.comprehension) || 10;
   const crit = Number(stats.criticalChance) || 0;
@@ -190,7 +190,7 @@ export function calculatePlayerCombatAttack(state = progressionState) {
 
 export function calculatePlayerAttackRate(state = progressionState) {
   const baseRate = 1.0;
-  const attackSpeedBonus = Number(state.stats?.attackSpeed) || 0;
+  const attackSpeedBonus = Number(state.attributes?.attackSpeed) || 0;
   const speedMult = Number(getWeaponProficiencyBonuses(state).speedMult) || 1;
   return (baseRate + attackSpeedBonus / 100) * speedMult;
 }

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -32,10 +32,12 @@ export function advanceRealm(state = progressionState) {
     result.statMsg = `ATK +${realmBonus * 2}, Armor +${realmBonus}, HP +25%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
-    state.stats = state.stats || {
+    state.attributes = state.attributes || {
       physique: 10, mind: 10, agility: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0,
-      armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE
+    };
+    state.derivedStats = state.derivedStats || {
+      armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE,
     };
 
     state.cultivation.talent += 0.15;
@@ -43,11 +45,11 @@ export function advanceRealm(state = progressionState) {
     result.extraMsg = `Talent +15%, Comprehension +10%, Foundation Mult +8%`;
 
     const realmStatPoints = 3 + state.realm.tier;
-    state.stats.physique += Math.ceil(realmStatPoints * 0.3);
-    state.stats.mind += Math.ceil(realmStatPoints * 0.25);
-    state.stats.agility += Math.ceil(realmStatPoints * 0.25);
-    state.stats.comprehension += Math.ceil(realmStatPoints * 0.2);
-    state.stats.criticalChance += 0.01;
+    state.attributes.physique += Math.ceil(realmStatPoints * 0.3);
+    state.attributes.mind += Math.ceil(realmStatPoints * 0.25);
+    state.attributes.agility += Math.ceil(realmStatPoints * 0.25);
+    state.attributes.comprehension += Math.ceil(realmStatPoints * 0.2);
+    state.attributes.criticalChance += 0.01;
 
     const powerGain = currentRealm.power / REALMS[oldRealm].power;
     log?.(`Realm breakthrough! Power increased by ${powerGain.toFixed(1)}x! ATK +${realmBonus * 2}, Armor +${realmBonus}, HP +25%`, 'good');
@@ -61,10 +63,12 @@ export function advanceRealm(state = progressionState) {
     result.statMsg = `ATK +${stageBonus}, Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
-    state.stats = state.stats || {
+    state.attributes = state.attributes || {
       physique: 10, mind: 10, agility: 10, comprehension: 10,
       criticalChance: 0.05, attackSpeed: 1.0, cooldownReduction: 0, adventureSpeed: 1.0,
-      armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE
+    };
+    state.derivedStats = state.derivedStats || {
+      armor: 0, accuracy: ACCURACY_BASE, dodge: DODGE_BASE,
     };
 
     state.cultivation.talent += 0.03;
@@ -73,13 +77,13 @@ export function advanceRealm(state = progressionState) {
     const stageStatPoints = 1 + Math.floor(state.realm.tier * 0.5);
     const statDistribution = Math.random();
     if (statDistribution < 0.4) {
-      state.stats.physique += stageStatPoints;
+      state.attributes.physique += stageStatPoints;
     } else if (statDistribution < 0.7) {
-      state.stats.comprehension += stageStatPoints;
+      state.attributes.comprehension += stageStatPoints;
     } else if (statDistribution < 0.85) {
-      state.stats.mind += stageStatPoints;
+      state.attributes.mind += stageStatPoints;
     } else {
-      state.stats.agility += stageStatPoints;
+      state.attributes.agility += stageStatPoints;
     }
 
     log?.(`Stage breakthrough! ATK +${stageBonus}, Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`, 'good');

--- a/src/features/progression/state.js
+++ b/src/features/progression/state.js
@@ -30,7 +30,7 @@ export const progressionState = {
   pills: { ward: 0, meridian_opening_dan: 0 },
   breakthroughBonus: 0,
   breakthroughChanceMult: 1,
-  stats: {
+  attributes: {
     physique: 10,
     mind: 10,
     agility: 10,
@@ -39,6 +39,8 @@ export const progressionState = {
     attackSpeed: 1.0,
     cooldownReduction: 0,
     adventureSpeed: 1.0,
+  },
+  derivedStats: {
     armor: 0,
     accuracy: ACCURACY_BASE,
     dodge: DODGE_BASE,

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -456,7 +456,7 @@ export function tryBreakthrough(){
 
   const minTime = 3;
   const maxTimeBase = 10 + (S.realm.tier * 10);
-  const mindReduction = (S.stats.mind - 10) * 0.02;
+  const mindReduction = (S.attributes.mind - 10) * 0.02;
   const maxTime = Math.max(minTime + 1, maxTimeBase * (1 - mindReduction));
 
   const duration = minTime + Math.random() * (maxTime - minTime);

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -26,7 +26,7 @@ export function loadSave(){
 
 export const defaultState = () => {
   const { hp: enemyHP, hpMax: enemyMaxHP } = initHp(0);
-  const stats = {
+  const attributes = {
     physique: 10,        // Physical power
     mind: 10,            // Spell power, alchemy, learning speed
     agility: 10,         // Weapon handling, dodge
@@ -35,6 +35,8 @@ export const defaultState = () => {
     attackSpeed: 1.0,    // Base attack speed multiplier
     cooldownReduction: 0, // Cooldown reduction percentage
     adventureSpeed: 1.0, // Adventure/exploration speed multiplier
+  };
+  const derivedStats = {
     armor: 0,           // Total armor from gear and bonuses
     accuracy: ACCURACY_BASE,        // Chance to hit with attacks
     dodge: DODGE_BASE,          // Chance to avoid attacks
@@ -44,7 +46,7 @@ export const defaultState = () => {
     ccResist: 0,                // Resistance to crowd control duration
     stunBuildTakenReduction: 0  // Reduction to stun build taken
   };
-  const baseHP = 100 + stats.physique * 3;
+  const baseHP = 100 + attributes.physique * 3;
   return {
   ver: SAVE_VERSION,
   time:0,
@@ -64,7 +66,8 @@ export const defaultState = () => {
   atkBase:5, armorBase:2, tempAtk:0, tempArmor:0, breakthroughBonus:0,
   breakthroughChanceMult:1,
   // Expanded Stat System
-  stats,
+  attributes,
+  derivedStats,
   disciples:1,
   gather:{herbs:0, ore:0, wood:0},
   yieldMult:{herbs:0, ore:0, wood:0},

--- a/src/shared/utils/stats.js
+++ b/src/shared/utils/stats.js
@@ -9,3 +9,18 @@ export function mergeStats(base = {}, ...mods) {
   }
   return out;
 }
+
+export const ATTRIBUTE_KEYS = new Set([
+  'physique',
+  'mind',
+  'agility',
+  'comprehension',
+  'criticalChance',
+  'attackSpeed',
+  'cooldownReduction',
+  'adventureSpeed',
+]);
+
+export function isAttributeStat(stat) {
+  return ATTRIBUTE_KEYS.has(stat);
+}


### PR DESCRIPTION
## Summary
- separate core attributes from derived combat stats in player state
- update progression, inventory, and UI modules to consume new `attributes` and `derivedStats`
- add helpers for identifying attribute keys

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c337eb6428832697eb3005d6a8d8da