### PR TITLE
fix: guard comprehension property

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -82,7 +82,8 @@ export function foundationGainPerSec(state = progressionState){
       buildingMult: 1.0
     };
   }
-  const comprehensionMult = 1 + (state.attributes.comprehension - 10) * 0.05;
+  const comp = Number(state.attributes?.comprehension ?? 10);
+  const comprehensionMult = 1 + (comp - 10) * 0.05;
   const cultivationMult = state.cultivation.talent * comprehensionMult * state.cultivation.foundationMult;
   const lawBonuses = getLawBonuses(state);
   const lawMult = lawBonuses.foundationMult || 1;


### PR DESCRIPTION
## Summary
- avoid reading undefined comprehension in `foundationGainPerSec`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: AI verification enforcement report)*

------
https://chatgpt.com/codex/tasks/task_e_68c46b4c82e88326b56332c6a233ba27