### PR TITLE
Refactor combat damage pipeline

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -133,11 +133,23 @@ function applyAbilityResult(abilityKey, res, state) {
         type === 'physical'
           ? { phys: amount, elems: {} }
           : { phys: 0, elems: { [type]: amount } };
-      const typeMults = { [type === 'physical' ? 'physical' : type]: treeMult };
+      const astralPct = { [type === 'physical' ? 'physical' : type]: treeMult - 1 };
+      const manualPct = {};
+      if (mult !== 1) manualPct.all = mult - 1;
       const { total: dealt, components } = processAttack(
         profile,
         weapon,
-        { target: atkTarget, attacker: state, nowMs: now, typeMults, globalMult: mult },
+        {
+          target: atkTarget,
+          attacker: state,
+          nowMs: now,
+          astralPct,
+          manualPct,
+          critChance: 0,
+          critMult: 1,
+          attackSpeed: 1,
+          hitChance: 1,
+        },
         state
       );
       totalDealt += dealt;

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -782,15 +782,17 @@ export function updateAdventureCombat() {
           profile.elems.metal = (profile.elems.metal || 0) + profile.phys;
           profile.phys = 0;
         }
-        const typeMults = {};
+        const astralPct = {};
         if (profile.phys > 0) {
-          typeMults.physical =
-            1 + (S.astralTreeBonuses?.physicalDamagePct || 0) / 100;
+          astralPct.physical =
+            (S.astralTreeBonuses?.physicalDamagePct || 0) / 100;
         }
         for (const elem of Object.keys(profile.elems)) {
           const key = `${elem}DamagePct`;
-          typeMults[elem] = 1 + (S.astralTreeBonuses?.[key] || 0) / 100;
+          astralPct[elem] = (S.astralTreeBonuses?.[key] || 0) / 100;
         }
+        const manualPct = {};
+        if (externalMult !== 1) manualPct.all = externalMult - 1;
         const { total: dealt, components } = processAttack(
           profile,
           weapon,
@@ -798,8 +800,12 @@ export function updateAdventureCombat() {
             attacker: S,
             target: S.adventure.currentEnemy,
             nowMs: now,
-            typeMults,
-            globalMult: externalMult * critMult,
+            astralPct,
+            manualPct,
+            critChance: isCrit ? 1 : 0,
+            critMult,
+            attackSpeed: 1,
+            hitChance: 1,
           },
           S
         );
@@ -902,7 +908,15 @@ export function updateAdventureCombat() {
           const { total: taken, components } = processAttack(
             profile,
             undefined,
-            { attacker: S.adventure.currentEnemy, target: S, nowMs: now },
+            {
+              attacker: S.adventure.currentEnemy,
+              target: S,
+              nowMs: now,
+              critChance: isCrit ? 1 : 0,
+              critMult: 2,
+              attackSpeed: 1,
+              hitChance: 1,
+            },
             S
           );
           const parts = [];


### PR DESCRIPTION
## Summary
- Revamp `processAttack` to bucket weapon/gear/astral/manual bonuses, apply crit before defenses, and scale damage by attack speed and hit chance
- Update adventure and ability combat flows for new `processAttack` signature and explicit crit multiplier

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c4846898b08326bf4b75522fe328aa