### PR TITLE
Refactor player attack calculations to use base weapon flats

### DIFF
--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -116,9 +116,11 @@ function applyAbilityResult(abilityKey, res, state) {
       }
 
       let treeMult = 1;
+      const gearPct = {};
       if (isSpell) {
         if (weapon.classKey === 'focus') {
-          mult *= getWeaponProficiencyBonuses(state).damageMult;
+          const profBonus = getWeaponProficiencyBonuses(state).damageMult - 1;
+          if (profBonus) gearPct.all = profBonus;
         }
         const { spellPowerMult } = getStatEffects(state);
         const spellDamage = state.derivedStats?.spellDamage || 0;
@@ -145,6 +147,7 @@ function applyAbilityResult(abilityKey, res, state) {
           nowMs: now,
           astralPct,
           manualPct,
+          gearPct,
           critChance: 0,
           critMult: 1,
           attackSpeed: 1,
@@ -212,7 +215,11 @@ function applyAbilityResult(abilityKey, res, state) {
       state.qi = state.qiMax || state.qi || 0;
     }
   }
-  if (abilityKey === 'lightningStep' || abilityKey === 'fireball') {
+  if (
+    abilityKey === 'lightningStep' ||
+    abilityKey === 'fireball' ||
+    abilityKey === 'palmStrike'
+  ) {
     emit('ABILITY:FX', { abilityKey });
   }
 }

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -139,6 +139,13 @@ on('ABILITY:FX', ({ abilityKey }) => {
         playFireball(pos.svg, pos.from, to);
       }
     }
+  } else if (abilityKey === 'palmStrike') {
+    const pos = getCombatPositions();
+    if (pos) {
+      const weapon = getEquippedWeapon(S);
+      setFxTint(pos.svg, weapon?.animations?.tint || 'auto');
+      playPalmHit(pos.svg, pos.to);
+    }
   }
 });
 
@@ -793,6 +800,9 @@ export function updateAdventureCombat() {
         }
         const manualPct = {};
         if (externalMult !== 1) manualPct.all = externalMult - 1;
+        const gearPct = {};
+        const profBonus = getWeaponProficiencyBonuses(S).damageMult - 1;
+        if (profBonus) gearPct.all = profBonus;
         const { total: dealt, components } = processAttack(
           profile,
           weapon,
@@ -802,6 +812,7 @@ export function updateAdventureCombat() {
             nowMs: now,
             astralPct,
             manualPct,
+            gearPct,
             critChance: isCrit ? 1 : 0,
             critMult,
             attackSpeed: 1,

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -171,29 +171,18 @@ export function calculatePlayerCombatAttack(state = progressionState) {
     elems[elem] = (range.min + range.max) / 2;
   }
 
-  const profMult = Number(getWeaponProficiencyBonuses(state).damageMult) || 1;
-  const lawMult = getLawBonuses(state).atk || 1;
-  const realm = REALMS[state.realm.tier] || { atk: 1 };
-  const stageMult = 1 + (state.realm.stage - 1) * 0.08;
-  const realmMult = (realm.atk || 1) * stageMult;
-  const karmaMult = 1 + (Number(karmaAtkBonus(state)) || 0) / 100;
-
-  const totalMult = profMult * lawMult * realmMult * karmaMult;
-
-  const phys = basePhys * totalMult;
-  const scaledElems = {};
-  for (const [elem, val] of Object.entries(elems)) {
-    scaledElems[elem] = val * totalMult;
-  }
-
-  return { phys, elems: scaledElems };
+  return { phys: basePhys, elems };
 }
 
 export function calculatePlayerAttackRate(state = progressionState) {
-  const baseRate = 1.0;
-  const attackSpeedBonus = Number(state.attributes?.attackSpeed) || 0;
-  const speedMult = Number(getWeaponProficiencyBonuses(state).speedMult) || 1;
-  return (baseRate + attackSpeedBonus / 100) * speedMult;
+  const weapon = getEquippedWeapon(state);
+  const baseRate = weapon?.base?.rate || 1;
+  const attr = Number(state.attributes?.attackSpeed) || 0;
+  const gear = Number(state.gearBonuses?.attackRatePct || state.gearBonuses?.attackSpeedPct || 0);
+  const astral = Number(state.astralTreeBonuses?.attackSpeedPct || 0);
+  const profMult = Number(getWeaponProficiencyBonuses(state).speedMult) || 1;
+  const totalPct = attr + gear + astral + (profMult - 1) * 100;
+  return baseRate * (1 + totalPct / 100);
 }
 
 export function breakthroughChance(state = progressionState){


### PR DESCRIPTION
## Summary
- Return only average weapon base damage in `calculatePlayerCombatAttack`
- Compute attack rate from weapon's base rate and aggregated speed bonuses
- Pass proficiency bonuses as percent buckets in combat calculations
- Restore palm strike ability FX emission

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c49140cee4832693b047b3648984ee