### PR TITLE
feat: add settings statistics tab

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -403,6 +403,7 @@ way-of-ascension/
 ├── src/features/alchemy/consumableEffects.js
 ├── src/features/alchemy/data/pills.js
 ├── src/features/alchemy/test.js
+├── src/features/settings/ui/settingsDisplay.js
 ├── src/features/tutorial/steps.js
 └── style.css
 ```
@@ -1259,6 +1260,9 @@ Paths added:
  - `src/features/mind/index.js` – Mind feature descriptor.
 - `src/features/astralTree/index.js` – Astral Tree feature descriptor.
 - `src/features/law/index.js` – Law feature descriptor.
+
+### Settings Feature (`src/features/settings/`)
+- `src/features/settings/ui/settingsDisplay.js` – Handles Settings tab navigation and displays session statistics.
 
 ## Tutorial Feature
 

--- a/index.html
+++ b/index.html
@@ -1180,17 +1180,30 @@
 
       <section id="activity-settings" class="activity-content tab-content" style="display:none;">
         <h2>⚙️ Settings</h2>
-        <div class="cards">
-          <div class="card">
-            <div class="settings-buttons">
-              <button class="btn small ghost" id="saveBtn">💾 Save</button>
-              <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
-              <button class="btn small ghost" id="importBtn">⬆️ Import</button>
-              <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
+        <div class="settings-tabs tab-bar">
+          <button class="settings-tab-btn active" data-tab="general">General</button>
+          <button class="settings-tab-btn" data-tab="stats">Statistics</button>
+        </div>
+        <div id="generalSettingsTab" class="settings-tab-content tab-content active">
+          <div class="cards">
+            <div class="card">
+              <div class="settings-buttons">
+                <button class="btn small ghost" id="saveBtn">💾 Save</button>
+                <button class="btn small ghost" id="exportBtn">⬇️ Export</button>
+                <button class="btn small ghost" id="importBtn">⬆️ Import</button>
+                <button class="btn small warn" id="resetBtn" title="Hard reset">♻️ Reset</button>
+              </div>
+            </div>
+            <div class="card">
+              <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
             </div>
           </div>
-          <div class="card">
-            <div class="chip" id="reduceMotionChip">Reduce Motion: <input type="checkbox" id="reduceMotionToggle"></div>
+        </div>
+        <div id="statsSettingsTab" class="settings-tab-content tab-content" style="display:none;">
+          <div class="cards">
+            <div class="card">
+              <div class="stat"><span>Time since game start</span><span id="timeSinceStart">0s</span></div>
+            </div>
           </div>
         </div>
       </section>

--- a/src/features/settings/ui/settingsDisplay.js
+++ b/src/features/settings/ui/settingsDisplay.js
@@ -1,0 +1,28 @@
+import { setText } from '../../../shared/utils/dom.js';
+
+let startTime = performance.now();
+
+export function setupSettingsTabs() {
+  const buttons = document.querySelectorAll('.settings-tab-btn');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.tab;
+      buttons.forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.settings-tab-content').forEach(el => {
+        el.classList.remove('active');
+        el.style.display = 'none';
+      });
+      btn.classList.add('active');
+      const content = document.getElementById(`${tab}SettingsTab`);
+      if (content) {
+        content.classList.add('active');
+        content.style.display = 'block';
+      }
+    });
+  });
+}
+
+export function updateSettingsStats() {
+  const elapsed = Math.floor((performance.now() - startTime) / 1000);
+  setText('timeSinceStart', `${elapsed}s`);
+}

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -35,6 +35,7 @@ import { renderMindMainTab, setupMindTabs } from '../features/mind/ui/mindMainTa
 import { renderMindReadingTab } from '../features/mind/ui/mindReadingTab.js';
 import { renderMindPuzzlesTab } from '../features/mind/ui/mindPuzzlesTab.js';
 import { renderMindStatsTab } from '../features/mind/ui/mindStatsTab.js';
+import { setupSettingsTabs, updateSettingsStats } from '../features/settings/ui/settingsDisplay.js';
 import { updateQiAndFoundation } from '../features/progression/ui/qiDisplay.js';
 import { updateCombatStats } from '../features/combat/ui/combatStats.js';
 import { updateAdventureProgress, mountAdventureControls } from '../features/adventure/ui/adventureDisplay.js';
@@ -224,6 +225,8 @@ function updateAll(){
   renderMindStatsTab(document.getElementById('mindStatsTab'), S);
   renderMindPuzzlesTab(document.getElementById('mindPuzzlesTab'), S);
 
+  updateSettingsStats();
+
   emit('RENDER');
 }
 
@@ -388,6 +391,7 @@ function enableLayoutDebug() {
     setupAdventureTabs();
     setupMindTabs();
     setupEquipmentTab(); // EQUIP-CHAR-UI
+    setupSettingsTabs();
     // Ensure derived stats like Qi shield are initialized based on equipped gear
     recomputePlayerTotals(S);
     mountDiagnostics(S);

--- a/style.css
+++ b/style.css
@@ -2218,6 +2218,50 @@ html.reduce-motion .shield-shimmer{animation:none;}
   display: block;
 }
 
+/* Settings Tabs */
+.settings-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid var(--accent);
+}
+
+.settings-tab-btn {
+  padding: 10px 16px;
+  border: none;
+  border-bottom: 2px solid var(--accent);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-radius: 0;
+  font-family: 'Trajan Pro', 'Palatino Linotype', 'Book Antiqua', Palatino, serif;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+}
+
+.settings-tab-btn:hover {
+  background: rgba(139, 69, 19, 0.05);
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+}
+
+.settings-tab-btn.active {
+  background: transparent;
+  color: var(--ink);
+  border-bottom: 2px solid var(--ink);
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.settings-tab-content {
+  display: none;
+}
+
+.settings-tab-content.active {
+  display: block;
+}
+
 /* Gear Slots */
 .equip-slots {
   display: grid;


### PR DESCRIPTION
## Summary
- add Settings UI tabs and Statistics panel
- track session start time and show elapsed seconds
- document new Settings UI module

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run validate` (fails: UI state violation and DOM usage warnings)


------
https://chatgpt.com/codex/tasks/task_e_68c4c31957dc83269f2c713c0825b284