### PR TITLE
Refactor combat snapshot and multipliers

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -367,6 +367,7 @@ way-of-ascension/
 ├── src/features/automation/selectors.js
 ├── src/features/automation/state.js
 ├── src/features/combat/index.js
+├── src/features/combat/snapshot.js
 ├── src/features/karma/index.js
 ├── src/features/law/index.js
 ├── src/features/mining/index.js
@@ -948,6 +949,7 @@ Paths added:
 - `src/features/automation/selectors.js` – automation selectors
 - `src/features/automation/state.js` – automation state slice
 - `src/features/combat/ui/floatingText.js` – floating combat text renderer
+- `src/features/combat/snapshot.js` – builds player attack snapshots
 
 #### `src/game/GameController.js` - Game Orchestrator
 **Purpose**: Boots the game, runs the fixed-step loop, emits events and handles simple routing.
@@ -1042,6 +1044,7 @@ Paths added:
 ### Combat Feature (`src/features/combat/`)
 - `src/features/combat/logic.js` – Core combat calculations such as armor mitigation and shield handling.
 - `src/features/combat/mutators.js` – Stateful combat helpers (`initializeFight`, `processAttack`, `applyStatus`).
+- `src/features/combat/snapshot.js` – Builds player attack snapshots (weapon flats, % buckets, crit).
 - `src/features/combat/state.js` – Shape of combat-related state values (enemy HP, stun bars).
 - `src/features/combat/selectors.js` – Accessors for combat state like enemy HP and stun bars.
 - `src/features/combat/attack.js` – Applies status effects and stun bar changes when attacks land.
@@ -1054,6 +1057,8 @@ Paths added:
 
 #### `src/features/combat/data/ailments.js` - Ailment Definitions
 **Purpose**: Enumerates poison, burn, chill and other ailments with durations, stack limits and effect callbacks.
+#### `src/features/combat/snapshot.js` - Player Attack Snapshot Builder
+**Purpose**: Aggregates weapon flats, crit data and damage percentage buckets from player stats for reuse in combat.
 **When to modify**: Add new ailments or adjust existing damage-over-time and debuff behaviour.
 
 ### Karma Feature (`src/features/karma/`)

--- a/src/features/combat/snapshot.js
+++ b/src/features/combat/snapshot.js
@@ -1,0 +1,38 @@
+import { calculatePlayerCombatAttack } from '../progression/selectors.js';
+import { getEquippedWeapon } from '../inventory/selectors.js';
+import { getWeaponProficiencyBonuses } from '../proficiency/selectors.js';
+
+/**
+ * Build a snapshot of the player's offensive stats used for combat.
+ * Includes the base weapon profile, per-category percentage buckets,
+ * critical values, global multiplier and equipped weapon reference.
+ */
+export function buildPlayerSnapshot(state) {
+  const weapon = getEquippedWeapon(state);
+  const profile = calculatePlayerCombatAttack(state);
+
+  const pct = {};
+  if (profile.phys > 0) {
+    const physTree = (state.astralTreeBonuses?.physicalDamagePct || 0) / 100;
+    if (physTree) pct.physical = physTree;
+  }
+  for (const elem of Object.keys(profile.elems)) {
+    const key = `${elem}DamagePct`;
+    const val = (state.astralTreeBonuses?.[key] || 0) / 100;
+    if (val) pct[elem] = (pct[elem] || 0) + val;
+  }
+
+  const profBonus = getWeaponProficiencyBonuses(state).damageMult - 1;
+  if (profBonus) pct.all = (pct.all || 0) + profBonus;
+
+  const critChance = state.attributes?.criticalChance || 0;
+
+  return {
+    weapon,
+    profile,
+    pct,
+    critChance,
+    critMult: 2,
+    globalPct: 0,
+  };
+}


### PR DESCRIPTION
## Summary
- add `buildPlayerSnapshot` to aggregate weapon damage, crit, and percentage buckets
- simplify `processAttack` to accept pct buckets and a single global multiplier
- update adventure and ability attacks to use snapshots and new API

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: multiple pre-existing architecture violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c4bd76f48326ab4d59bbcbb5f9d0