### PR TITLE
feat: add attack snapshot

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -174,6 +174,27 @@ export function calculatePlayerCombatAttack(state = progressionState) {
   return { phys: basePhys, elems };
 }
 
+export function calculatePlayerAttackSnapshot(state = progressionState) {
+  const profile = calculatePlayerCombatAttack(state);
+
+  const astralPct = {};
+  for (const [key, val] of Object.entries(state.astralTreeBonuses || {})) {
+    if (key.endsWith('DamagePct')) {
+      const elem = key === 'physicalDamagePct' ? 'physical' : key.replace('DamagePct', '');
+      astralPct[elem] = (val || 0) / 100;
+    }
+  }
+
+  const gearPct = {};
+  const profBonus = getWeaponProficiencyBonuses(state).damageMult - 1;
+  if (profBonus) gearPct.all = profBonus;
+
+  const critChance = Number(state.attributes?.criticalChance) || 0;
+  const critMult = 2;
+
+  return { profile, astralPct, gearPct, critChance, critMult, globalPct: 0 };
+}
+
 export function calculatePlayerAttackRate(state = progressionState) {
   const weapon = getEquippedWeapon(state);
   const baseRate = weapon?.base?.rate || 1;

--- a/src/features/progression/selectors.js
+++ b/src/features/progression/selectors.js
@@ -13,6 +13,7 @@ import {
   calcArmor as calcCalcArmor,
   getStatEffects as calcStatEffects,
   calculatePlayerCombatAttack as calcPlayerCombatAttack,
+  calculatePlayerAttackSnapshot as calcPlayerAttackSnapshot,
   calculatePlayerAttackRate as calcPlayerAttackRate,
   breakthroughChance as calcBreakthroughChance,
 } from './logic.js';
@@ -57,6 +58,20 @@ export function calcArmor(state = progressionState) {
 
 export function getStatEffects(state = progressionState) {
   return calcStatEffects(state);
+}
+
+export function calculatePlayerAttackSnapshot(state = progressionState) {
+  const snap = calcPlayerAttackSnapshot(state);
+  const mult = getTunable('combat.damageMult', 1);
+  return {
+    ...snap,
+    profile: {
+      phys: snap.profile.phys * mult,
+      elems: Object.fromEntries(
+        Object.entries(snap.profile.elems).map(([k, v]) => [k, v * mult])
+      ),
+    },
+  };
 }
 
 export function calculatePlayerCombatAttack(state = progressionState) {


### PR DESCRIPTION
## Summary
- build reusable combat snapshot with weapon damage, multipliers, crit, and global pct
- use snapshot in adventure and abilities when calling `processAttack`
- update ability damage preview to rely on snapshot multipliers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c4c4bd76f48326ab4d59bbcbb5f9d0