### PR TITLE
Collect gear stats for combat and EHP

### DIFF
--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -185,12 +185,14 @@ export function calculatePlayerAttackSnapshot(state = progressionState) {
     }
   }
 
-  const gearPct = {};
+  const gearPct = { ...(state.gearDamagePct || {}) };
   const profBonus = getWeaponProficiencyBonuses(state).damageMult - 1;
-  if (profBonus) gearPct.all = profBonus;
+  if (profBonus) gearPct.all = (gearPct.all || 0) + profBonus;
 
-  const critChance = Number(state.attributes?.criticalChance) || 0;
-  const critMult = 2;
+  const baseCrit = Number(state.attributes?.criticalChance) || 0;
+  const gearCrit = Number(state.gearStats?.critChance) || 0;
+  const critChance = baseCrit + gearCrit;
+  const critMult = 2 * (1 + (state.gearStats?.critMult || 0));
 
   return { profile, astralPct, gearPct, critChance, critMult, globalPct: 0 };
 }


### PR DESCRIPTION
## Summary
- aggregate gear attack speed, crit, accuracy and elemental damage into `player.gearStats` and `player.gearDamagePct`
- expose defensive stats and resists from equipment
- include gear-derived crit and damage bonuses when building attack snapshot

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c4c8bb0e10832692fccae38e5f4b97