### PR TITLE
Add preview snapshots and per-slot PP summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -872,6 +872,7 @@
                 <div class="gear-slot size-s empty" id="slot-food4" role="button" tabindex="0"></div>
                 <div class="gear-slot size-s empty" id="slot-food5" role="button" tabindex="0"></div>
               </div>
+              <div id="ppSlotSummary" class="pp-slot-summary"></div>
             </div>
               <div id="gearAbilitiesSubTab" class="gear-tab-content" style="display:none;">
                 <div id="abilitySlots"></div>

--- a/style.css
+++ b/style.css
@@ -5338,3 +5338,9 @@ html.reduce-motion .log-sheet{transition:none;}
 #journalEntries li.current .checkmark {
   color: var(--core-primary);
 }
+
+.pp-slot-summary {
+  margin-top: 8px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}


### PR DESCRIPTION
## Summary
- compute preview attack snapshot when showing weapon and gear details
- display per-slot PP contribution summary on equipment panel

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: requires docs for src/engine/pp.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e95fee148326ae9cdc906bd0025b