### PR TITLE
feat: add power point utilities

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,1 @@
+export * from './power/index.js';

--- a/src/lib/power/index.js
+++ b/src/lib/power/index.js
@@ -1,0 +1,1 @@
+export * from './pp.js';

--- a/src/lib/power/pp.js
+++ b/src/lib/power/pp.js
@@ -1,0 +1,42 @@
+export const DamageElements = ["phys", "fire", "cold", "lightning", "poison", "arcane"];
+
+export function Snapshot(opts = {}) {
+  const {
+    weapon = {},
+    nonWeaponFlat = {},
+    critChance = 0,
+    critMult = 1,
+    globalPct = 0,
+    armor = 0,
+    aps = 1,
+    hp = 0,
+  } = opts;
+  return { weapon, nonWeaponFlat, critChance, critMult, globalPct, armor, aps, hp };
+}
+
+export function armorDR(damage, armor) {
+  return Math.max(damage - armor, 0);
+}
+
+export function idleDPS(snap) {
+  const crit = 1 + snap.critChance * (snap.critMult - 1);
+  let total = 0;
+  for (const el of DamageElements) {
+    const base = snap.weapon[el] || 0;
+    const afterCrit = base * crit;
+    const afterDefense = armorDR(afterCrit, snap.armor);
+    total += afterDefense;
+  }
+  return total * (1 + snap.globalPct) * snap.aps;
+}
+
+export function ehp(snap) {
+  return snap.hp + snap.armor;
+}
+
+export const dpsDelta = (base, mod) => (mod - base) / base;
+export const ehpDelta = (base, mod) => (mod - base) / base;
+
+export function ppFromDeltas({ dps, ehp }) {
+  return (1 + dps) * (1 + ehp) - 1;
+}

--- a/src/lib/power/pp.test.js
+++ b/src/lib/power/pp.test.js
@@ -1,0 +1,36 @@
+import assert from 'assert';
+import { Snapshot, idleDPS } from './pp.js';
+
+// Crit is applied before defenses
+{
+  const snap = Snapshot({
+    weapon: { phys: 100 },
+    critChance: 1,
+    critMult: 2,
+    armor: 50,
+  });
+  assert.equal(idleDPS(snap), 150);
+  assert.notEqual(idleDPS(snap), (100 - 50) * 2);
+}
+
+// Global% bucket applied once after summed damage
+{
+  const snap = Snapshot({
+    weapon: { phys: 100, fire: 100 },
+    armor: 50,
+    globalPct: 0.5,
+  });
+  assert.equal(idleDPS(snap), 150);
+}
+
+// Only weapon flats change DPS; non-weapon flats ignored
+{
+  const base = Snapshot({ weapon: { phys: 100 } });
+  const withNonWeapon = Snapshot({ weapon: { phys: 100 }, nonWeaponFlat: { phys: 50 } });
+  const withWeapon = Snapshot({ weapon: { phys: 150 } });
+  assert.equal(idleDPS(base), 100);
+  assert.equal(idleDPS(withNonWeapon), 100);
+  assert.equal(idleDPS(withWeapon), 150);
+}
+
+console.log('pp tests passed');


### PR DESCRIPTION
## Summary
- add power-point calculation utilities (DamageElements, Snapshot, armorDR, idleDPS, ehp and helpers)
- expose utilities via lib index
- cover critical hit, global multiplier, and flat damage behavior with tests

## Testing
- `node src/lib/power/pp.test.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ec2640f48326b19bb3698bab489e