### PR TITLE
Remove base attack and use weapon damage

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,7 +886,7 @@
               <div id="gearStatsSubTab" class="gear-tab-content" style="display:none;">
                 <div class="stat"><span>HP</span><span id="stat-hp">100/100</span></div>
                 <div class="stat"><span>Shield</span><span id="stat-shield">0/0</span></div>
-                <div class="stat"><span>Attack</span><span id="stat-atkBase">5</span></div>
+                <div class="stat"><span>Attack</span><span id="stat-atkBase">2</span></div>
                 <div class="stat"><span>Base Armor</span><span id="stat-armorBase">2</span></div>
                 <div class="stat"><span>Armor</span><span id="stat-armor">0</span></div>
                 <div class="stat"><span>Accuracy</span><span id="stat-accuracy">0</span></div>
@@ -1218,7 +1218,7 @@
         <div class="cards">
           <div class="card">
             <h4>Combat Stats</h4>
-            <div class="stat"><span>Your ATK</span><span id="atkVal2">5</span></div>
+            <div class="stat"><span>Your ATK</span><span id="atkVal2">2</span></div>
             <div class="stat" title="Reduces Physical damage. Mitigation = armor / (armor + K × hit), capped at 90%"><span>🛡 Armor</span><span id="armorVal2">0</span></div>
             <div class="stat"><span>Accuracy</span><span id="accuracyVal2">0</span></div>
             <div class="stat"><span>Dodge</span><span id="dodgeVal2">0</span></div>

--- a/src/engine/pp.js
+++ b/src/engine/pp.js
@@ -53,13 +53,11 @@ export function breakthroughPPSnapshot(state) {
     sim.realm.tier++;
     sim.realm.stage = 1;
     const realmBonus = Math.max(1, Math.floor(sim.realm.tier * 1.5));
-    sim.atkBase += realmBonus * 2;
     sim.armorBase += realmBonus;
   } else {
     // Stage advancement
     sim.realm.stage++;
     const stageBonus = Math.max(1, Math.floor((sim.realm.tier + 1) * 0.5));
-    sim.atkBase += stageBonus;
     sim.armorBase += Math.floor(stageBonus * 0.7);
   }
 

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -9,7 +9,7 @@ import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
 import { computePP } from '../../../engine/pp.js';
-import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
+import { calculatePlayerAttackSnapshot, calcAtk } from '../../progression/selectors.js';
 
 // Consolidated equipment/inventory panel
 let currentFilter = 'all';
@@ -151,7 +151,7 @@ function renderStats() {
   const defs = [
     { id: 'hp', value: () => `${S.hp}/${S.hpMax}` },
     { id: 'shield', value: () => `${S.shield?.current || 0}/${S.shield?.max || 0}` },
-    { id: 'atkBase', value: () => S.atkBase },
+    { id: 'atkBase', value: () => Math.round(calcAtk(S)) },
     { id: 'armorBase', value: () => S.armorBase },
     { id: 'armor', stat: 'armor' },
     { id: 'physique', stat: 'physique' },

--- a/src/features/progression/data/realms.js
+++ b/src/features/progression/data/realms.js
@@ -1,7 +1,6 @@
 //cap = max QI
 //fcap = max foundation
 //baseRegen = qi regen per second
-//atk = base attack
 //armor = base armor
 //bt = base breakthrough chance
 //power = base power
@@ -12,7 +11,6 @@ export const REALMS = [
     cap: 100,
     fcap: 60,
     baseRegen: 1,
-    atk: 1,
     armor: 1,
     bt: 0.60,
     power: 1,
@@ -27,7 +25,6 @@ export const REALMS = [
     cap: 300,
     fcap: 150,
     baseRegen: 2,
-    atk: 3,
     armor: 2,
     bt: 0.55,
     power: 3,
@@ -42,7 +39,6 @@ export const REALMS = [
     cap: 800,
     fcap: 400,
     baseRegen: 3,
-    atk: 6,
     armor: 4,
     bt: 0.50,
     power: 8,
@@ -57,7 +53,6 @@ export const REALMS = [
     cap: 2000,
     fcap: 1100,
     baseRegen: 5,
-    atk: 12,
     armor: 8,
     bt: 0.45,
     power: 20,
@@ -72,7 +67,6 @@ export const REALMS = [
     cap: 7000,
     fcap: 3000,
     baseRegen: 8,
-    atk: 24,
     armor: 16,
     bt: 0.40,
     power: 50,
@@ -87,7 +81,6 @@ export const REALMS = [
     cap: 20000,
     fcap: 8000,
     baseRegen: 12,
-    atk: 40,
     armor: 28,
     bt: 0.35,
     power: 120,
@@ -102,7 +95,6 @@ export const REALMS = [
     cap: 60000,
     fcap: 25000,
     baseRegen: 18,
-    atk: 70,
     armor: 50,
     bt: 0.30,
     power: 300,
@@ -117,7 +109,6 @@ export const REALMS = [
     cap: 180000,
     fcap: 80000,
     baseRegen: 25,
-    atk: 120,
     armor: 85,
     bt: 0.25,
     power: 750,
@@ -132,7 +123,6 @@ export const REALMS = [
     cap: 500000,
     fcap: 250000,
     baseRegen: 35,
-    atk: 200,
     armor: 140,
     bt: 0.20,
     power: 1800,
@@ -147,7 +137,6 @@ export const REALMS = [
     cap: 1500000,
     fcap: 800000,
     baseRegen: 50,
-    atk: 350,
     armor: 250,
     bt: 0.15,
     power: 4500,

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -124,10 +124,9 @@ export function getCultivationPower(state = progressionState) {
 export function calcAtk(state = progressionState){
   const lawBonuses = getLawBonuses(state);
   const profMult = Number(getWeaponProficiencyBonuses(state).damageMult) || 1;
-  const base = Number(state.atkBase) || 0;
-  const temp = Number(state.tempAtk) || 0;
-  const karma = Number(karmaAtkBonus(state)) || 0;
-  return Math.floor((base + temp + karma) * profMult * (lawBonuses.atk || 1));
+  const profile = calculatePlayerCombatAttack(state);
+  const base = profile.phys + Object.values(profile.elems || {}).reduce((a, b) => a + b, 0);
+  return Math.floor(base * profMult * (lawBonuses.atk || 1));
 }
 
 export function calcArmor(state = progressionState){
@@ -167,7 +166,9 @@ export function getStatEffects(state = progressionState) {
 export function calculatePlayerCombatAttack(state = progressionState) {
   const weapon = getEquippedWeapon(state);
   const physBase = weapon?.base?.phys || { min: 0, max: 0 };
-  const basePhys = (physBase.min + physBase.max) / 2;
+  const temp = Number(state.tempAtk) || 0;
+  const karma = Number(karmaAtkBonus(state)) || 0;
+  const basePhys = (physBase.min + physBase.max) / 2 + temp + karma;
 
   const elems = {};
   for (const [elem, range] of Object.entries(weapon?.base?.elems || {})) {

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -25,11 +25,10 @@ export function advanceRealm(state = progressionState) {
 
   if (wasRealmAdvancement) {
     const realmBonus = Math.max(1, Math.floor(state.realm.tier * 1.5));
-    state.atkBase += realmBonus * 2;
     state.armorBase += realmBonus;
     state.hpMax += Math.floor(state.hpMax * 0.25);
     state.hp = state.hpMax;
-    result.statMsg = `ATK +${realmBonus * 2}, Armor +${realmBonus}, HP +25%`;
+    result.statMsg = `Armor +${realmBonus}, HP +25%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.attributes = state.attributes || {
@@ -52,15 +51,14 @@ export function advanceRealm(state = progressionState) {
     state.attributes.criticalChance += 0.01;
 
     const powerGain = currentRealm.power / REALMS[oldRealm].power;
-    log?.(`Realm breakthrough! Power increased by ${powerGain.toFixed(1)}x! ATK +${realmBonus * 2}, Armor +${realmBonus}, HP +25%`, 'good');
+    log?.(`Realm breakthrough! Power increased by ${powerGain.toFixed(1)}x! Armor +${realmBonus}, HP +25%`, 'good');
     log?.(`Cultivation enhanced! Talent +15%, Comprehension +10%, Foundation Mult +8%`, 'good');
   } else {
     const stageBonus = Math.max(1, Math.floor((state.realm.tier + 1) * 0.5));
-    state.atkBase += stageBonus;
     state.armorBase += Math.floor(stageBonus * 0.7);
     state.hpMax += Math.floor(state.hpMax * 0.08);
     state.hp = Math.min(state.hpMax, state.hp + Math.floor(state.hpMax * 0.5));
-    result.statMsg = `ATK +${stageBonus}, Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`;
+    result.statMsg = `Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.attributes = state.attributes || {
@@ -86,7 +84,7 @@ export function advanceRealm(state = progressionState) {
       state.attributes.agility += stageStatPoints;
     }
 
-    log?.(`Stage breakthrough! ATK +${stageBonus}, Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`, 'good');
+    log?.(`Stage breakthrough! Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`, 'good');
     log?.(`Cultivation improved! Talent +3%, Comprehension +2%`, 'good');
   }
 

--- a/src/features/progression/state.js
+++ b/src/features/progression/state.js
@@ -21,7 +21,6 @@ export const progressionState = {
       alchemy: {},
     },
   },
-  atkBase: 5,
   armorBase: 2,
   tempAtk: 0,
   tempArmor: 0,

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -63,7 +63,7 @@ export const defaultState = () => {
   realm: { tier: 0, stage: 1 },
   wood:0, spiritWood:0, cores:0, iron:0, oreDust:0, herbs:0, aromaticHerb:0, meat:0, cookedMeat:0,
   pills:{qi:0, body:0, ward:0, meridian_opening_dan:0, insight:0},
-  atkBase:5, armorBase:2, tempAtk:0, tempArmor:0, breakthroughBonus:0,
+  armorBase:2, tempAtk:0, tempArmor:0, breakthroughBonus:0,
   breakthroughChanceMult:1,
   // Expanded Stat System
   attributes,


### PR DESCRIPTION
## Summary
- Derive attack strength from the equipped weapon, including fists when unarmed
- Remove attack bonuses from realm progression and power point calculations
- Update UI and state to display weapon-based attack values

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c57f48ed9c832692672347362e0ae6