### PR TITLE
Remove base armor and compute armor from gear

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -70,6 +70,7 @@ way-of-ascension/
 │   ├── data/
 │   │   └── status.ts
 │   ├── engine/
+│   │   ├── pp.js
 │   │   └── combat/
 │   │       └── stun.js
 │   ├── features/
@@ -405,6 +406,12 @@ way-of-ascension/
 ├── src/features/alchemy/test.js
 ├── src/features/settings/ui/settingsDisplay.js
 ├── src/features/tutorial/steps.js
+├── src/lib/
+│   ├── index.js
+│   └── power/
+│       ├── index.js
+│       ├── pp.js
+│       └── pp.test.js
 └── style.css
 ```
 
@@ -1039,6 +1046,12 @@ Paths added:
 ### Engine (`src/engine/`)
 - `src/engine/combat/stun.js` – Handles stun accumulation, decay, and status application.
 - `src/engine/pp.js` – Computes offensive, defensive, and total power points for the player.
+
+### Library (`src/lib/`)
+- `src/lib/index.js` – Entry point for shared libraries.
+- `src/lib/power/index.js` – Exports power calculation utilities.
+- `src/lib/power/pp.js` – Power point calculation helpers.
+- `src/lib/power/pp.test.js` – Tests for power point calculations.
 
 ### Combat Feature (`src/features/combat/`)
 - `src/features/combat/logic.js` – Core combat calculations such as armor mitigation and shield handling.

--- a/index.html
+++ b/index.html
@@ -887,7 +887,7 @@
                 <div class="stat"><span>HP</span><span id="stat-hp">100/100</span></div>
                 <div class="stat"><span>Shield</span><span id="stat-shield">0/0</span></div>
                 <div class="stat"><span>Attack</span><span id="stat-atkBase">5</span></div>
-                <div class="stat"><span>Base Armor</span><span id="stat-armorBase">2</span></div>
+                <div class="stat"><span>Equipment Armor</span><span id="stat-armorGear">0</span></div>
                 <div class="stat"><span>Armor</span><span id="stat-armor">0</span></div>
                 <div class="stat"><span>Accuracy</span><span id="stat-accuracy">0</span></div>
                 <div class="stat"><span>Dodge</span><span id="stat-dodge">0</span></div>

--- a/src/engine/pp.js
+++ b/src/engine/pp.js
@@ -25,7 +25,7 @@ export function computePP(state) {
 
   opp *= 1 + (snap.power?.opFromCult || 0);
 
-  const baseArmor = state.derivedStats?.armor ?? calcArmor(state);
+  const baseArmor = state.derivedStats?.armor ?? calcArmor(state, state.gearStats?.armor || 0);
   const baseHP = state.hpMax || state.hp || 0;
   const dpp = (baseHP + baseArmor) * (1 + (snap.power?.dpFromCult || 0));
   const pp = opp + dpp;
@@ -54,13 +54,11 @@ export function breakthroughPPSnapshot(state) {
     sim.realm.stage = 1;
     const realmBonus = Math.max(1, Math.floor(sim.realm.tier * 1.5));
     sim.atkBase += realmBonus * 2;
-    sim.armorBase += realmBonus;
   } else {
     // Stage advancement
     sim.realm.stage++;
     const stageBonus = Math.max(1, Math.floor((sim.realm.tier + 1) * 0.5));
     sim.atkBase += stageBonus;
-    sim.armorBase += Math.floor(stageBonus * 0.7);
   }
 
   const after = computePP(sim);

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -2,7 +2,7 @@
 
 // Recalculate derived player stats based on equipped items
 import { ACCURACY_BASE, DODGE_BASE } from '../combat/hit.js';
-import { calcArmor as calcBaseArmor } from '../progression/selectors.js';
+import { calcArmor } from '../progression/selectors.js';
 export function recomputePlayerTotals(player) {
   let armor = 0;
   let accuracy = 0;
@@ -94,8 +94,7 @@ export function recomputePlayerTotals(player) {
   player.gearDamagePct = damagePct;
 
   player.derivedStats = player.derivedStats || {};
-  const baseArmor = calcBaseArmor(player);
-  player.derivedStats.armor = armor + baseArmor;
+  player.derivedStats.armor = calcArmor(player, armor);
   player.derivedStats.accuracy = ACCURACY_BASE + accuracy;
   player.derivedStats.dodge = DODGE_BASE + dodge;
   player.resists = resists;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -152,7 +152,7 @@ function renderStats() {
     { id: 'hp', value: () => `${S.hp}/${S.hpMax}` },
     { id: 'shield', value: () => `${S.shield?.current || 0}/${S.shield?.max || 0}` },
     { id: 'atkBase', value: () => S.atkBase },
-    { id: 'armorBase', value: () => S.armorBase },
+    { id: 'armorGear', value: () => S.gearStats?.armor || 0 },
     { id: 'armor', stat: 'armor' },
     { id: 'physique', stat: 'physique' },
     { id: 'mind', stat: 'mind' },

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -130,13 +130,12 @@ export function calcAtk(state = progressionState){
   return Math.floor((base + temp + karma) * profMult * (lawBonuses.atk || 1));
 }
 
-export function calcArmor(state = progressionState){
+export function calcArmor(state = progressionState, gearArmor = 0){
   const lawBonuses = getLawBonuses(state);
-  const base = Number(state.armorBase) || 0;
   const temp = Number(state.tempArmor) || 0;
   const karma = Number(karmaArmorBonus(state)) || 0;
   const astral = 1 + (state.astralTreeBonuses?.armorPct || 0) / 100;
-  return Math.floor((base + temp + karma) * (lawBonuses.armor || 1) * astral);
+  return Math.floor((gearArmor + temp + karma) * (lawBonuses.armor || 1) * astral);
 }
 
 export function getStatEffects(state = progressionState) {

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -26,10 +26,9 @@ export function advanceRealm(state = progressionState) {
   if (wasRealmAdvancement) {
     const realmBonus = Math.max(1, Math.floor(state.realm.tier * 1.5));
     state.atkBase += realmBonus * 2;
-    state.armorBase += realmBonus;
     state.hpMax += Math.floor(state.hpMax * 0.25);
     state.hp = state.hpMax;
-    result.statMsg = `ATK +${realmBonus * 2}, Armor +${realmBonus}, HP +25%`;
+    result.statMsg = `ATK +${realmBonus * 2}, HP +25%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.attributes = state.attributes || {
@@ -52,15 +51,14 @@ export function advanceRealm(state = progressionState) {
     state.attributes.criticalChance += 0.01;
 
     const powerGain = currentRealm.power / REALMS[oldRealm].power;
-    log?.(`Realm breakthrough! Power increased by ${powerGain.toFixed(1)}x! ATK +${realmBonus * 2}, Armor +${realmBonus}, HP +25%`, 'good');
+    log?.(`Realm breakthrough! Power increased by ${powerGain.toFixed(1)}x! ATK +${realmBonus * 2}, HP +25%`, 'good');
     log?.(`Cultivation enhanced! Talent +15%, Comprehension +10%, Foundation Mult +8%`, 'good');
   } else {
     const stageBonus = Math.max(1, Math.floor((state.realm.tier + 1) * 0.5));
     state.atkBase += stageBonus;
-    state.armorBase += Math.floor(stageBonus * 0.7);
     state.hpMax += Math.floor(state.hpMax * 0.08);
     state.hp = Math.min(state.hpMax, state.hp + Math.floor(state.hpMax * 0.5));
-    result.statMsg = `ATK +${stageBonus}, Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`;
+    result.statMsg = `ATK +${stageBonus}, HP +8%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.attributes = state.attributes || {
@@ -86,7 +84,7 @@ export function advanceRealm(state = progressionState) {
       state.attributes.agility += stageStatPoints;
     }
 
-    log?.(`Stage breakthrough! ATK +${stageBonus}, Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`, 'good');
+    log?.(`Stage breakthrough! ATK +${stageBonus}, HP +8%`, 'good');
     log?.(`Cultivation improved! Talent +3%, Comprehension +2%`, 'good');
   }
 

--- a/src/features/progression/selectors.js
+++ b/src/features/progression/selectors.js
@@ -53,8 +53,8 @@ export function calcAtk(state = progressionState) {
   return calcCalcAtk(state);
 }
 
-export function calcArmor(state = progressionState) {
-  return calcCalcArmor(state);
+export function calcArmor(state = progressionState, gearArmor = 0) {
+  return calcCalcArmor(state, gearArmor);
 }
 
 export function getCultivationPower(state = progressionState) {

--- a/src/features/progression/state.js
+++ b/src/features/progression/state.js
@@ -22,7 +22,6 @@ export const progressionState = {
     },
   },
   atkBase: 5,
-  armorBase: 2,
   tempAtk: 0,
   tempArmor: 0,
     alchemy: { successBonus: 0 },

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -63,7 +63,7 @@ export const defaultState = () => {
   realm: { tier: 0, stage: 1 },
   wood:0, spiritWood:0, cores:0, iron:0, oreDust:0, herbs:0, aromaticHerb:0, meat:0, cookedMeat:0,
   pills:{qi:0, body:0, ward:0, meridian_opening_dan:0, insight:0},
-  atkBase:5, armorBase:2, tempAtk:0, tempArmor:0, breakthroughBonus:0,
+  atkBase:5, tempAtk:0, tempArmor:0, breakthroughBonus:0,
   breakthroughChanceMult:1,
   // Expanded Stat System
   attributes,


### PR DESCRIPTION
## Summary
- remove `armorBase` and apply bonuses to gear armor in `calcArmor`
- show equipment armor and final armor in the UI
- stop realm and stage advancement from granting armor

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: app.js imports feature internals and other pre-existing violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c57f79c594832680c040c588e94712