### PR TITLE
Remove base armor and derive defense from equipment

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,7 +887,7 @@
                 <div class="stat"><span>HP</span><span id="stat-hp">100/100</span></div>
                 <div class="stat"><span>Shield</span><span id="stat-shield">0/0</span></div>
                 <div class="stat"><span>Attack</span><span id="stat-attack">2</span></div>
-                <div class="stat"><span>Base Armor</span><span id="stat-armorBase">2</span></div>
+                <div class="stat"><span>Equipment Armor</span><span id="stat-armorEquip">0</span></div>
                 <div class="stat"><span>Armor</span><span id="stat-armor">0</span></div>
                 <div class="stat"><span>Accuracy</span><span id="stat-accuracy">0</span></div>
                 <div class="stat"><span>Dodge</span><span id="stat-dodge">0</span></div>

--- a/src/engine/pp.js
+++ b/src/engine/pp.js
@@ -52,13 +52,9 @@ export function breakthroughPPSnapshot(state) {
     // Realm advancement
     sim.realm.tier++;
     sim.realm.stage = 1;
-    const realmBonus = Math.max(1, Math.floor(sim.realm.tier * 1.5));
-    sim.armorBase += realmBonus;
   } else {
     // Stage advancement
     sim.realm.stage++;
-    const stageBonus = Math.max(1, Math.floor((sim.realm.tier + 1) * 0.5));
-    sim.armorBase += Math.floor(stageBonus * 0.7);
   }
 
   const after = computePP(sim);

--- a/src/features/inventory/logic.js
+++ b/src/features/inventory/logic.js
@@ -2,7 +2,7 @@
 
 // Recalculate derived player stats based on equipped items
 import { ACCURACY_BASE, DODGE_BASE } from '../combat/hit.js';
-import { calcArmor as calcBaseArmor } from '../progression/selectors.js';
+import { calcArmor } from '../progression/selectors.js';
 export function recomputePlayerTotals(player) {
   let armor = 0;
   let accuracy = 0;
@@ -94,8 +94,7 @@ export function recomputePlayerTotals(player) {
   player.gearDamagePct = damagePct;
 
   player.derivedStats = player.derivedStats || {};
-  const baseArmor = calcBaseArmor(player);
-  player.derivedStats.armor = armor + baseArmor;
+  player.derivedStats.armor = calcArmor(player);
   player.derivedStats.accuracy = ACCURACY_BASE + accuracy;
   player.derivedStats.dodge = DODGE_BASE + dodge;
   player.resists = resists;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -158,7 +158,7 @@ function renderStats() {
         return Math.round(p.phys + Object.values(p.elems).reduce((a, b) => a + b, 0));
       },
     },
-    { id: 'armorBase', value: () => S.armorBase },
+    { id: 'armorEquip', value: () => S.gearStats?.armor || 0 },
     { id: 'armor', stat: 'armor' },
     { id: 'physique', stat: 'physique' },
     { id: 'mind', stat: 'mind' },

--- a/src/features/progression/data/realms.js
+++ b/src/features/progression/data/realms.js
@@ -1,7 +1,6 @@
 //cap = max QI
 //fcap = max foundation
 //baseRegen = qi regen per second
-//armor = base armor
 //bt = base breakthrough chance
 //power = base power
 export const REALMS = [
@@ -11,7 +10,6 @@ export const REALMS = [
     cap: 100,
     fcap: 60,
     baseRegen: 1,
-    armor: 1,
     bt: 0.60,
     power: 1,
     opPerStagePct: 0.01,
@@ -25,7 +23,6 @@ export const REALMS = [
     cap: 300,
     fcap: 150,
     baseRegen: 2,
-    armor: 2,
     bt: 0.55,
     power: 3,
     opPerStagePct: 0.012,
@@ -39,7 +36,6 @@ export const REALMS = [
     cap: 800,
     fcap: 400,
     baseRegen: 3,
-    armor: 4,
     bt: 0.50,
     power: 8,
     opPerStagePct: 0.015,
@@ -53,7 +49,6 @@ export const REALMS = [
     cap: 2000,
     fcap: 1100,
     baseRegen: 5,
-    armor: 8,
     bt: 0.45,
     power: 20,
     opPerStagePct: 0.018,
@@ -67,7 +62,6 @@ export const REALMS = [
     cap: 7000,
     fcap: 3000,
     baseRegen: 8,
-    armor: 16,
     bt: 0.40,
     power: 50,
     opPerStagePct: 0.02,
@@ -81,7 +75,6 @@ export const REALMS = [
     cap: 20000,
     fcap: 8000,
     baseRegen: 12,
-    armor: 28,
     bt: 0.35,
     power: 120,
     opPerStagePct: 0.022,
@@ -95,7 +88,6 @@ export const REALMS = [
     cap: 60000,
     fcap: 25000,
     baseRegen: 18,
-    armor: 50,
     bt: 0.30,
     power: 300,
     opPerStagePct: 0.025,
@@ -109,7 +101,6 @@ export const REALMS = [
     cap: 180000,
     fcap: 80000,
     baseRegen: 25,
-    armor: 85,
     bt: 0.25,
     power: 750,
     opPerStagePct: 0.028,
@@ -123,7 +114,6 @@ export const REALMS = [
     cap: 500000,
     fcap: 250000,
     baseRegen: 35,
-    armor: 140,
     bt: 0.20,
     power: 1800,
     opPerStagePct: 0.03,
@@ -137,7 +127,6 @@ export const REALMS = [
     cap: 1500000,
     fcap: 800000,
     baseRegen: 50,
-    armor: 250,
     bt: 0.15,
     power: 4500,
     opPerStagePct: 0.035,

--- a/src/features/progression/logic.js
+++ b/src/features/progression/logic.js
@@ -123,11 +123,12 @@ export function getCultivationPower(state = progressionState) {
 
 export function calcArmor(state = progressionState){
   const lawBonuses = getLawBonuses(state);
-  const base = Number(state.armorBase) || 0;
+  const gear = Number(state.gearStats?.armor) || 0;
   const temp = Number(state.tempArmor) || 0;
   const karma = Number(karmaArmorBonus(state)) || 0;
+  const base = gear + temp + karma;
   const astral = 1 + (state.astralTreeBonuses?.armorPct || 0) / 100;
-  return Math.floor((base + temp + karma) * (lawBonuses.armor || 1) * astral);
+  return Math.floor(base * (lawBonuses.armor || 1) * astral);
 }
 
 export function getStatEffects(state = progressionState) {

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -24,11 +24,9 @@ export function advanceRealm(state = progressionState) {
   result.stage = state.realm.stage;
 
   if (wasRealmAdvancement) {
-    const realmBonus = Math.max(1, Math.floor(state.realm.tier * 1.5));
-    state.armorBase += realmBonus;
     state.hpMax += Math.floor(state.hpMax * 0.25);
     state.hp = state.hpMax;
-    result.statMsg = `Armor +${realmBonus}, HP +25%`;
+    result.statMsg = `HP +25%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.attributes = state.attributes || {
@@ -51,14 +49,12 @@ export function advanceRealm(state = progressionState) {
     state.attributes.criticalChance += 0.01;
 
     const powerGain = currentRealm.power / REALMS[oldRealm].power;
-    log?.(`Realm breakthrough! Power increased by ${powerGain.toFixed(1)}x! Armor +${realmBonus}, HP +25%`, 'good');
+    log?.(`Realm breakthrough! Power increased by ${powerGain.toFixed(1)}x! HP +25%`, 'good');
     log?.(`Cultivation enhanced! Talent +15%, Comprehension +10%, Foundation Mult +8%`, 'good');
   } else {
-    const stageBonus = Math.max(1, Math.floor((state.realm.tier + 1) * 0.5));
-    state.armorBase += Math.floor(stageBonus * 0.7);
     state.hpMax += Math.floor(state.hpMax * 0.08);
     state.hp = Math.min(state.hpMax, state.hp + Math.floor(state.hpMax * 0.5));
-    result.statMsg = `Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`;
+    result.statMsg = `HP +8%`;
 
     state.cultivation = state.cultivation || { talent: 1.0, foundationMult: 1.0, pillMult: 1.0, buildingMult: 1.0 };
     state.attributes = state.attributes || {
@@ -84,7 +80,7 @@ export function advanceRealm(state = progressionState) {
       state.attributes.agility += stageStatPoints;
     }
 
-    log?.(`Stage breakthrough! Armor +${Math.floor(stageBonus * 0.7)}, HP +8%`, 'good');
+    log?.(`Stage breakthrough! HP +8%`, 'good');
     log?.(`Cultivation improved! Talent +3%, Comprehension +2%`, 'good');
   }
 

--- a/src/features/progression/state.js
+++ b/src/features/progression/state.js
@@ -21,7 +21,6 @@ export const progressionState = {
       alchemy: {},
     },
   },
-  armorBase: 2,
   tempAtk: 0,
   tempArmor: 0,
     alchemy: { successBonus: 0 },

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -63,7 +63,7 @@ export const defaultState = () => {
   realm: { tier: 0, stage: 1 },
   wood:0, spiritWood:0, cores:0, iron:0, oreDust:0, herbs:0, aromaticHerb:0, meat:0, cookedMeat:0,
   pills:{qi:0, body:0, ward:0, meridian_opening_dan:0, insight:0},
-  armorBase:2, tempAtk:0, tempArmor:0, breakthroughBonus:0,
+  tempAtk:0, tempArmor:0, breakthroughBonus:0,
   breakthroughChanceMult:1,
   // Expanded Stat System
   attributes,


### PR DESCRIPTION
## Summary
- Drop base armor stat and compute armor from gear, temporary boosts, and bonuses
- Expose gear armor separately in UI while showing final armor with bonuses
- Realm and stage breakthroughs no longer grant flat armor, focusing on HP growth

## Testing
- `npm test` *(fails: no test specified)*
- `npm run validate` *(fails: AI verification enforcement violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c585a5250083268cc4c36d35d40d15