### PR TITLE
Fix fist and palm wrap detail display

### DIFF
--- a/src/features/inventory/migrations.js
+++ b/src/features/inventory/migrations.js
@@ -116,5 +116,22 @@ export const migrations = [
         type: 'weapon'
       });
     }
+  },
+  save => {
+    const fillWeapon = it => {
+      if (it && typeof it === 'object' && it.type === 'weapon') {
+        const def = WEAPONS[it.key];
+        if (def && !it.base) {
+          const { id, qty } = it;
+          Object.assign(it, { ...def, id, qty });
+        }
+      }
+    };
+    if (Array.isArray(save.inventory)) save.inventory.forEach(fillWeapon);
+    if (save.equipment && typeof save.equipment === 'object') {
+      Object.keys(save.equipment).forEach(slot => {
+        fillWeapon(save.equipment[slot]);
+      });
+    }
   }
 ];

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -13,6 +13,7 @@ import { catchingState } from '../features/catching/state.js';
 import { sideLocationState } from '../features/sideLocations/state.js';
 import { tutorialState } from '../features/tutorial/state.js';
 import { alchemyState } from '../features/alchemy/state.js';
+import { WEAPONS } from '../features/weaponGeneration/data/weapons.js';
 
 export function loadSave(){
   try{
@@ -145,8 +146,22 @@ export const defaultState = () => {
   // Combat Proficiency
   proficiency: {},
 
-  equipment: { mainhand: { key: 'fist', type: 'weapon' }, head: null, body: null, foot: null, ring1: null, ring2: null, talisman1: null, talisman2: null, food1: null, food2: null, food3: null, food4: null, food5: null }, // EQUIP-CHAR-UI
-  inventory: [{ id: 'palmWraps', key: 'palmWraps', name: 'Palm Wraps', type: 'weapon' }],
+  equipment: {
+    mainhand: { ...WEAPONS.fist },
+    head: null,
+    body: null,
+    foot: null,
+    ring1: null,
+    ring2: null,
+    talisman1: null,
+    talisman2: null,
+    food1: null,
+    food2: null,
+    food3: null,
+    food4: null,
+    food5: null,
+  }, // EQUIP-CHAR-UI
+  inventory: [{ id: 'palmWraps', ...WEAPONS.palmWraps }],
   junk: [],
   gearBonuses: {},
   sessionLoot: [], // EQUIP-CHAR-UI


### PR DESCRIPTION
## Summary
- Initialize shared state with complete weapon objects for fists and palm wraps so details show name and damage
- Add migration to backfill weapon stats for existing fist and palm wrap items

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: undocumented files and UI state violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c5982e436c832680350038710d3cde