### PR TITLE
Add additional combat and utility stats to stats tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -899,6 +899,15 @@
                 <div class="stat"><span>Attack Speed</span><span id="stat-attackSpeed">1.00</span></div>
                 <div class="stat"><span>Cooldown Reduction</span><span id="stat-cooldownReduction">0%</span></div>
                 <div class="stat"><span>Adventure Speed</span><span id="stat-adventureSpeed">1.00</span></div>
+                <div class="stat"><span>Qi Shield Efficiency</span><span id="stat-qiShieldEfficiency">100%</span></div>
+                <div class="stat"><span>Qi Cost Reduction</span><span id="stat-qiCostReduction">0%</span></div>
+                <div class="stat"><span>Forge Speed</span><span id="stat-forgeSpeed">0%</span></div>
+                <div class="stat"><span>Spell Damage</span><span id="stat-spellDamage">0%</span></div>
+                <div class="stat"><span>Stun Strength</span><span id="stat-stunBuildMult">0%</span></div>
+                <div class="stat"><span>Stun Duration</span><span id="stat-stunDurationMult">0%</span></div>
+                <div class="stat"><span>Stun Resist</span><span id="stat-stunResist">0%</span></div>
+                <div class="stat"><span>CC Resist</span><span id="stat-ccResist">0%</span></div>
+                <div class="stat"><span>Stun Build Reduction</span><span id="stat-stunBuildTakenReduction">0%</span></div>
                 <div class="stat"><span>Coin</span><span id="stat-coin">0</span></div>
               </div>
           </div>


### PR DESCRIPTION
## Summary
- show Qi shield efficiency, Qi cost reduction, forge speed, spell damage, and stun-related stats in the gear stats tab
- compute new metrics from existing state, agility bonuses, laws, and mind attribute

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: required doc updates)*
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c59e3f33108326a14c213ca86e6040