### PR TITLE
Refactor PP calculation to use weighted offense/defense

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -8,7 +8,7 @@ import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
-import { computePP } from '../../../engine/pp.js';
+import { computePP, W_O, W_D } from '../../../engine/pp.js';
 import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
 
 // Consolidated equipment/inventory panel
@@ -189,14 +189,16 @@ function computeItemPPDelta(item, state = S) {
   const temp = JSON.parse(JSON.stringify(state));
   recomputePlayerTotals(temp);
   const prev = computePP(temp);
+  const prevTotal = W_O * prev.OPP + W_D * prev.DPP;
   temp.equipment = temp.equipment || {};
   temp.equipment[slot] = { ...item };
   recomputePlayerTotals(temp);
   const next = computePP(temp);
+  const nextTotal = W_O * next.OPP + W_D * next.DPP;
   return {
-    opp: next.opp - prev.opp,
-    dpp: next.dpp - prev.dpp,
-    pp: next.pp - prev.pp,
+    opp: next.OPP - prev.OPP,
+    dpp: next.DPP - prev.DPP,
+    pp: nextTotal - prevTotal,
   };
 }
 

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -12,7 +12,7 @@ import {
   updateActivitySelectors,
   renderActiveActivity,
 } from '../../activity/ui/activityUI.js';
-import { computePP } from '../../../engine/pp.js';
+import { computePP, W_O, W_D } from '../../../engine/pp.js';
 import { configReport, featureFlags, devShowPP } from '../../../config.js';
 
 const STORAGE_KEY = 'astralTreeAllocated';
@@ -437,9 +437,11 @@ async function buildTree() {
       }
       const after = computePP(sim);
       const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
+      const beforePP = W_O * before.OPP + W_D * before.DPP;
+      const afterPP = W_O * after.OPP + W_D * after.DPP;
       lines.push(
-        `DEV:PP ${fmt(after.opp - before.opp)}/${fmt(after.dpp - before.dpp)}/${fmt(
-          after.pp - before.pp
+        `DEV:PP ${fmt(after.OPP - before.OPP)}/${fmt(after.DPP - before.DPP)}/${fmt(
+          afterPP - beforePP
         )}`
       );
     }
@@ -471,9 +473,11 @@ async function buildTree() {
         if (devShowPP && beforePP) {
           const afterPP = computePP(S);
           const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
+          const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+          const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
           console.log(
-            `DEV:PP ${fmt(afterPP.opp - beforePP.opp)}/${fmt(afterPP.dpp - beforePP.dpp)}/${fmt(
-              afterPP.pp - beforePP.pp
+            `DEV:PP ${fmt(afterPP.OPP - beforePP.OPP)}/${fmt(afterPP.DPP - beforePP.DPP)}/${fmt(
+              nextTotal - prevTotal
             )}`
           );
         }

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -18,7 +18,7 @@ import { isProd, devShowPP } from '../../../config.js';
 import { mountAllFeatureUIs } from '../../index.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import { renderPillIcons } from '../../alchemy/ui/pillIcons.js';
-import { computePP, breakthroughPPSnapshot } from '../../../engine/pp.js';
+import { computePP, breakthroughPPSnapshot, W_O, W_D } from '../../../engine/pp.js';
 
 let pendingAstralUnlock = false;
 
@@ -85,9 +85,9 @@ export function updateActivityCultivation() {
 
   if (devShowPP) {
     const snap = breakthroughPPSnapshot(S);
-    const fmt = v => `${v.pp.toFixed(1)} (O${v.opp.toFixed(1)} / D${v.dpp.toFixed(1)})`;
+    const fmt = v => `${v.PP.toFixed(1)} (O${v.OPP.toFixed(1)} / D${v.DPP.toFixed(1)})`;
     const fmtDiff = v =>
-      `${v.pp >= 0 ? '+' : ''}${v.pp.toFixed(1)} (O${v.opp >= 0 ? '+' : ''}${v.opp.toFixed(1)} / D${v.dpp >= 0 ? '+' : ''}${v.dpp.toFixed(1)})`;
+      `${v.PP >= 0 ? '+' : ''}${v.PP.toFixed(1)} (O${v.OPP >= 0 ? '+' : ''}${v.OPP.toFixed(1)} / D${v.DPP >= 0 ? '+' : ''}${v.DPP.toFixed(1)})`;
     setText('ppCurrentActivity', fmt(snap.before));
     setText('ppPostActivity', fmt(snap.after));
     setText('ppDiffActivity', fmtDiff(snap.diff));
@@ -512,9 +512,11 @@ export function updateBreakthrough() {
       if (devShowPP && beforePP) {
         const afterPP = computePP(S);
         const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
-        const opp = afterPP.opp - beforePP.opp;
-        const dpp = afterPP.dpp - beforePP.dpp;
-        const pp = afterPP.pp - beforePP.pp;
+        const opp = afterPP.OPP - beforePP.OPP;
+        const dpp = afterPP.DPP - beforePP.DPP;
+        const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+        const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
+        const pp = nextTotal - prevTotal;
         console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Breakthrough`);
       }
       log('Breakthrough succeeded! Realm advanced.', 'good');


### PR DESCRIPTION
## Summary
- expose weight constants W_O and W_D for offense/defense power
- computePP now returns {OPP, DPP} and breakthrough snapshots include PP via weights
- update inventory and progression UIs to compute total PP using weights

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: AI verification enforcement unmet)

------
https://chatgpt.com/codex/tasks/task_e_68c59e70656483268add6916900a2b58