### PR TITLE
Display current power on equipment panel

### DIFF
--- a/src/engine/pp.js
+++ b/src/engine/pp.js
@@ -35,6 +35,21 @@ export function computePP(state) {
 }
 
 /**
+ * Convenience selector for current total power points.
+ *
+ * @param {object} state Player or global state object
+ * @returns {{ PP:number, OPP:number, DPP:number }}
+ */
+export function getCurrentPP(state) {
+  const { OPP, DPP } = computePP(state);
+  return {
+    OPP,
+    DPP,
+    PP: W_O * OPP + W_D * DPP,
+  };
+}
+
+/**
  * Create a snapshot of current and post-breakthrough power points.
  * Simulates the next realm/stage advancement and compares the resulting
  * Offensive/Defensive/total Power Points.

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -8,7 +8,7 @@ import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
-import { computePP, W_O, W_D } from '../../../engine/pp.js';
+import { computePP, getCurrentPP, W_O, W_D } from '../../../engine/pp.js';
 import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
 import { qiCostPerShield, QI_PER_SHIELD_BASE } from '../../combat/logic.js';
 import { getAgilityBonuses } from '../../agility/selectors.js';
@@ -276,6 +276,18 @@ function statTooltipHTML(info) {
 
 export function renderEquipmentPanel() {
   recomputePlayerTotals(S);
+  const { PP, OPP, DPP } = getCurrentPP(S);
+  const header = document.querySelector('#activity-character .card h4');
+  let ppEl = document.getElementById('currentPP');
+  if (!ppEl && header) {
+    ppEl = document.createElement('div');
+    ppEl.id = 'currentPP';
+    header.insertAdjacentElement('afterend', ppEl);
+  }
+  if (ppEl) {
+    const fmt = n => n.toFixed(2);
+    ppEl.textContent = `Power: ${fmt(PP)} (O ${fmt(OPP)} / D ${fmt(DPP)})`;
+  }
   renderEquipment();
   renderSlotPPSummary();
   renderInventory();


### PR DESCRIPTION
## Summary
- add `getCurrentPP` helper to compute current power points
- show "Power: X (O Y / D Z)" beneath the equipment header using new selector

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint:balance`
- `npm run validate` *(fails: AI verification enforcement report)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a4e4c2988326bf0f919dcd5c55e2