### PR TITLE
Integrate EHP utilities into power calculations

### DIFF
--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -8,11 +8,18 @@ import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
-import { computePP, W_O, W_D } from '../../../engine/pp.js';
+import { computePP, W_O } from '../../../engine/pp.js';
 import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
 import { qiCostPerShield, QI_PER_SHIELD_BASE } from '../../combat/logic.js';
 import { getAgilityBonuses } from '../../agility/selectors.js';
 import { getLawBonuses } from '../../progression/logic.js';
+
+const getPPInputs = s => ({
+  dodge: s.derivedStats?.dodge || 0,
+  qiRegenPct: (s.qiRegenMult || 0) + (s.gearBonuses?.qiRegenMult || 0),
+  maxQiPct: ((s.astralTreeBonuses?.maxQiPct || 0) / 100) + (s.qiCapMult || 0),
+  resists: s.resists || {},
+});
 
 // Consolidated equipment/inventory panel
 let currentFilter = 'all';
@@ -236,13 +243,13 @@ function computeItemPPDelta(item, state = S) {
   if (!slot) return null;
   const temp = JSON.parse(JSON.stringify(state));
   recomputePlayerTotals(temp);
-  const prev = computePP(temp);
-  const prevTotal = W_O * prev.OPP + W_D * prev.DPP;
+  const prev = computePP(temp, getPPInputs(temp));
+  const prevTotal = W_O * prev.OPP + prev.DPP;
   temp.equipment = temp.equipment || {};
   temp.equipment[slot] = { ...item };
   recomputePlayerTotals(temp);
-  const next = computePP(temp);
-  const nextTotal = W_O * next.OPP + W_D * next.DPP;
+  const next = computePP(temp, getPPInputs(temp));
+  const nextTotal = W_O * next.OPP + next.DPP;
   return {
     opp: next.OPP - prev.OPP,
     dpp: next.DPP - prev.DPP,

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -12,8 +12,15 @@ import {
   updateActivitySelectors,
   renderActiveActivity,
 } from '../../activity/ui/activityUI.js';
-import { computePP, W_O, W_D } from '../../../engine/pp.js';
+import { computePP, W_O } from '../../../engine/pp.js';
 import { configReport, featureFlags, devShowPP } from '../../../config.js';
+
+const getPPInputs = s => ({
+  dodge: s.derivedStats?.dodge || 0,
+  qiRegenPct: (s.qiRegenMult || 0) + (s.gearBonuses?.qiRegenMult || 0),
+  maxQiPct: ((s.astralTreeBonuses?.maxQiPct || 0) / 100) + (s.qiCapMult || 0),
+  resists: s.resists || {},
+});
 
 const STORAGE_KEY = 'astralTreeAllocated';
 // Starting nodes must match the roots in the astral_tree.json dataset
@@ -424,7 +431,7 @@ async function buildTree() {
     lines.push(`Cost: ${info.cost ?? '-'}`);
 
     if (devShowPP) {
-      const before = computePP(S);
+      const before = computePP(S, getPPInputs(S));
       const sim = { ...S, astralTreeBonuses: { ...(S.astralTreeBonuses || {}) } };
       if (info.bonus) {
         for (const [k, v] of Object.entries(info.bonus)) {
@@ -435,10 +442,10 @@ async function buildTree() {
           }
         }
       }
-      const after = computePP(sim);
+      const after = computePP(sim, getPPInputs(sim));
       const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-      const beforePP = W_O * before.OPP + W_D * before.DPP;
-      const afterPP = W_O * after.OPP + W_D * after.DPP;
+      const beforePP = W_O * before.OPP + before.DPP;
+      const afterPP = W_O * after.OPP + after.DPP;
       lines.push(
         `DEV:PP ${fmt(after.OPP - before.OPP)}/${fmt(after.DPP - before.DPP)}/${fmt(
           afterPP - beforePP
@@ -458,7 +465,7 @@ async function buildTree() {
         if ((S.astralPoints || 0) < (info2?.cost || 0)) return;
         const parentId = (adj[n.id] || []).find(id => allocated.has(id));
         let beforePP;
-        if (devShowPP) beforePP = computePP(S);
+        if (devShowPP) beforePP = computePP(S, getPPInputs(S));
         S.astralPoints -= info2.cost;
         allocated.add(n.id);
         applyEffects(n.id, manifest);
@@ -471,10 +478,10 @@ async function buildTree() {
           unlockStartingActivities(n.id);
         }
         if (devShowPP && beforePP) {
-          const afterPP = computePP(S);
+          const afterPP = computePP(S, getPPInputs(S));
           const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-          const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
-          const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
+          const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
+          const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
           console.log(
             `DEV:PP ${fmt(afterPP.OPP - beforePP.OPP)}/${fmt(afterPP.DPP - beforePP.DPP)}/${fmt(
               nextTotal - prevTotal

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -18,7 +18,14 @@ import { isProd, devShowPP } from '../../../config.js';
 import { mountAllFeatureUIs } from '../../index.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import { renderPillIcons } from '../../alchemy/ui/pillIcons.js';
-import { computePP, breakthroughPPSnapshot, W_O, W_D } from '../../../engine/pp.js';
+import { computePP, breakthroughPPSnapshot, W_O } from '../../../engine/pp.js';
+
+const getPPInputs = s => ({
+  dodge: s.derivedStats?.dodge || 0,
+  qiRegenPct: (s.qiRegenMult || 0) + (s.gearBonuses?.qiRegenMult || 0),
+  maxQiPct: ((s.astralTreeBonuses?.maxQiPct || 0) / 100) + (s.qiCapMult || 0),
+  resists: s.resists || {},
+});
 
 let pendingAstralUnlock = false;
 
@@ -507,15 +514,15 @@ export function updateBreakthrough() {
       S.qi = 0;
       S.foundation = 0;
       let beforePP;
-      if (devShowPP) beforePP = computePP(S);
+      if (devShowPP) beforePP = computePP(S, getPPInputs(S));
       const info = advanceRealm(S);
       if (devShowPP && beforePP) {
-        const afterPP = computePP(S);
+        const afterPP = computePP(S, getPPInputs(S));
         const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
         const opp = afterPP.OPP - beforePP.OPP;
         const dpp = afterPP.DPP - beforePP.DPP;
-        const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
-        const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
+        const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
+        const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
         const pp = nextTotal - prevTotal;
         console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Breakthrough`);
       }

--- a/src/lib/power/ehp.js
+++ b/src/lib/power/ehp.js
@@ -1,0 +1,24 @@
+export function drFromArmor(armor = 0, k = 100) {
+  const a = Number(armor) || 0;
+  if (a <= 0) return 0;
+  return a / (a + k);
+}
+
+export function dEhpFromHP(hp = 0, base = 100) {
+  const h = Number(hp) || 0;
+  if (base <= 0) return 0;
+  return (h - base) / base;
+}
+
+export function dEhpFromDodge(dodge = 0) {
+  const d = Math.max(0, Math.min(0.95, Number(dodge) || 0));
+  return d / (1 - d);
+}
+
+export function dEhpFromRes(res = 0) {
+  const r = Math.max(0, Math.min(0.95, Number(res) || 0));
+  return r / (1 - r);
+}
+
+export const dEhpFromQiRegenPct = pct => Number(pct) || 0;
+export const dEhpFromMaxQiPct = pct => Number(pct) || 0;

--- a/src/lib/power/ehp.test.js
+++ b/src/lib/power/ehp.test.js
@@ -1,0 +1,9 @@
+import assert from 'assert';
+import { drFromArmor, dEhpFromHP, dEhpFromDodge, dEhpFromRes } from './ehp.js';
+
+assert.equal(drFromArmor(100), 0.5);
+assert.equal(dEhpFromHP(150), 0.5);
+assert.equal(Math.round(dEhpFromDodge(0.2) * 100) / 100, 0.25);
+assert.equal(dEhpFromRes(0.5), 1);
+
+console.log('ehp tests passed');

--- a/src/lib/power/index.js
+++ b/src/lib/power/index.js
@@ -1,1 +1,2 @@
 export * from './pp.js';
+export * from './ehp.js';


### PR DESCRIPTION
## Summary
- add effective HP helpers for armor, dodge, resists and Qi
- weight DPP by individual EHP contributions in `computePP`
- pass dodge and Qi stats to PP calculations across UI and mutators

## Testing
- `node src/lib/power/pp.test.js`
- `node src/lib/power/ehp.test.js`
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: requires project-structure.md updates)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a473fd6483269c13e42e02e4d4e4