### PR TITLE
feat: account for dodge and qi in power calc

### DIFF
--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -2,7 +2,7 @@ import { S, save } from '../../shared/state.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
-import { computePP, W_O, W_D } from '../../engine/pp.js';
+import { computePP, gatherDefense, W_O } from '../../engine/pp.js';
 import { devShowPP } from '../../config.js';
 export { usePill } from '../alchemy/mutators.js'; // deprecated shim
 
@@ -53,8 +53,8 @@ export function equipItem(item, slot = null, state = S) {
   const info = canEquip(item, slot, state);
   if (!info) return false;
   const slotKey = info.slot;
-  const prevPP = computePP(state);
-  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
+  const prevPP = computePP(state, gatherDefense(state));
+  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
   const existing = state.equipment[slotKey];
   const existingKey = typeof existing === 'string' ? existing : existing?.key;
   if (existingKey && existingKey !== 'fist') addToInventory(existing, state);
@@ -63,8 +63,8 @@ export function equipItem(item, slot = null, state = S) {
   removeFromInventory(id, state);
   console.log('[equip]', 'slot→', slotKey, 'item→', item.key);
   recomputePlayerTotals(state);
-  const nextPP = computePP(state);
-  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
+  const nextPP = computePP(state, gatherDefense(state));
+  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;
@@ -81,15 +81,15 @@ export function equipItem(item, slot = null, state = S) {
 export function unequip(slot, state = S) {
   const item = state.equipment[slot];
   if (!item) return;
-  const prevPP = computePP(state);
-  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
+  const prevPP = computePP(state, gatherDefense(state));
+  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
   const key = typeof item === 'string' ? item : item.key;
   if (key !== 'fist') addToInventory(item, state);
   state.equipment[slot] = null;
   console.log('[equip]', 'slot→', slot, 'item→', 'none');
   recomputePlayerTotals(state);
-  const nextPP = computePP(state);
-  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
+  const nextPP = computePP(state, gatherDefense(state));
+  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -8,7 +8,7 @@ import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
-import { computePP, getCurrentPP, W_O, W_D } from '../../../engine/pp.js';
+import { computePP, getCurrentPP, gatherDefense, W_O } from '../../../engine/pp.js';
 import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
 import { qiCostPerShield, QI_PER_SHIELD_BASE } from '../../combat/logic.js';
 import { getAgilityBonuses } from '../../agility/selectors.js';
@@ -236,13 +236,13 @@ function computeItemPPDelta(item, state = S) {
   if (!slot) return null;
   const temp = JSON.parse(JSON.stringify(state));
   recomputePlayerTotals(temp);
-  const prev = computePP(temp);
-  const prevTotal = W_O * prev.OPP + W_D * prev.DPP;
+  const prev = computePP(temp, gatherDefense(temp));
+  const prevTotal = W_O * prev.OPP + prev.DPP;
   temp.equipment = temp.equipment || {};
   temp.equipment[slot] = { ...item };
   recomputePlayerTotals(temp);
-  const next = computePP(temp);
-  const nextTotal = W_O * next.OPP + W_D * next.DPP;
+  const next = computePP(temp, gatherDefense(temp));
+  const nextTotal = W_O * next.OPP + next.DPP;
   return {
     opp: next.OPP - prev.OPP,
     dpp: next.DPP - prev.DPP,

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -12,7 +12,7 @@ import {
   updateActivitySelectors,
   renderActiveActivity,
 } from '../../activity/ui/activityUI.js';
-import { computePP, W_O, W_D } from '../../../engine/pp.js';
+import { computePP, gatherDefense, W_O } from '../../../engine/pp.js';
 import { configReport, featureFlags, devShowPP } from '../../../config.js';
 
 const STORAGE_KEY = 'astralTreeAllocated';
@@ -424,7 +424,7 @@ async function buildTree() {
     lines.push(`Cost: ${info.cost ?? '-'}`);
 
     if (devShowPP) {
-      const before = computePP(S);
+      const before = computePP(S, gatherDefense(S));
       const sim = { ...S, astralTreeBonuses: { ...(S.astralTreeBonuses || {}) } };
       if (info.bonus) {
         for (const [k, v] of Object.entries(info.bonus)) {
@@ -435,10 +435,10 @@ async function buildTree() {
           }
         }
       }
-      const after = computePP(sim);
+      const after = computePP(sim, gatherDefense(sim));
       const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-      const beforePP = W_O * before.OPP + W_D * before.DPP;
-      const afterPP = W_O * after.OPP + W_D * after.DPP;
+      const beforePP = W_O * before.OPP + before.DPP;
+      const afterPP = W_O * after.OPP + after.DPP;
       lines.push(
         `DEV:PP ${fmt(after.OPP - before.OPP)}/${fmt(after.DPP - before.DPP)}/${fmt(
           afterPP - beforePP
@@ -458,7 +458,7 @@ async function buildTree() {
         if ((S.astralPoints || 0) < (info2?.cost || 0)) return;
         const parentId = (adj[n.id] || []).find(id => allocated.has(id));
         let beforePP;
-        if (devShowPP) beforePP = computePP(S);
+        if (devShowPP) beforePP = computePP(S, gatherDefense(S));
         S.astralPoints -= info2.cost;
         allocated.add(n.id);
         applyEffects(n.id, manifest);
@@ -471,10 +471,10 @@ async function buildTree() {
           unlockStartingActivities(n.id);
         }
         if (devShowPP && beforePP) {
-          const afterPP = computePP(S);
+          const afterPP = computePP(S, gatherDefense(S));
           const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-          const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
-          const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
+          const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
+          const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
           console.log(
             `DEV:PP ${fmt(afterPP.OPP - beforePP.OPP)}/${fmt(afterPP.DPP - beforePP.DPP)}/${fmt(
               nextTotal - prevTotal

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -18,7 +18,7 @@ import { isProd, devShowPP } from '../../../config.js';
 import { mountAllFeatureUIs } from '../../index.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import { renderPillIcons } from '../../alchemy/ui/pillIcons.js';
-import { computePP, breakthroughPPSnapshot, W_O, W_D } from '../../../engine/pp.js';
+import { computePP, breakthroughPPSnapshot, gatherDefense, W_O } from '../../../engine/pp.js';
 
 let pendingAstralUnlock = false;
 
@@ -507,15 +507,15 @@ export function updateBreakthrough() {
       S.qi = 0;
       S.foundation = 0;
       let beforePP;
-      if (devShowPP) beforePP = computePP(S);
+      if (devShowPP) beforePP = computePP(S, gatherDefense(S));
       const info = advanceRealm(S);
       if (devShowPP && beforePP) {
-        const afterPP = computePP(S);
+        const afterPP = computePP(S, gatherDefense(S));
         const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
         const opp = afterPP.OPP - beforePP.OPP;
         const dpp = afterPP.DPP - beforePP.DPP;
-        const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
-        const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
+        const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
+        const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
         const pp = nextTotal - prevTotal;
         console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Breakthrough`);
       }

--- a/src/lib/power/ehp.js
+++ b/src/lib/power/ehp.js
@@ -1,0 +1,33 @@
+import { ACCURACY_BASE, DODGE_BASE, chanceToHit } from '../../features/combat/hit.js';
+
+export function drFromArmor(armor = 0) {
+  if (armor <= 0) return 0;
+  return armor / (armor + 100);
+}
+
+export function dEhpFromHP(hp = 0, dr = 0) {
+  if (hp <= 0) return 0;
+  const baseHp = 100;
+  const ehp = hp / (1 - dr);
+  return ehp / baseHp - 1;
+}
+
+export function dEhpFromDodge(dodge = DODGE_BASE, accuracy = ACCURACY_BASE) {
+  const baseHit = chanceToHit(accuracy, DODGE_BASE);
+  const newHit = chanceToHit(accuracy, dodge);
+  return baseHit / newHit - 1;
+}
+
+export function dEhpFromRes(res = 0) {
+  if (res <= 0) return 0;
+  if (res >= 1) return Infinity;
+  return 1 / (1 - res) - 1;
+}
+
+export function dEhpFromQiRegenPct(pct = 0) {
+  return pct / 100;
+}
+
+export function dEhpFromMaxQiPct(pct = 0) {
+  return pct / 100;
+}


### PR DESCRIPTION
## Summary
- add effective HP utility helpers for armor, dodge, resistances and qi effects
- rework power point calculations to include dodge, qi regen, and shield capacity
- forward defensive stats to PP computations across inventory and progression flows

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a63fc0988326bb71972c17e60b4e