### PR TITLE
Track rolling power point history and display averages

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
       <div class="title-wrap">
         <h1>Way of Ascension</h1>
         <div class="sub">Idle xianxia cultivation • autosaves</div>
+        <div id="ppAverages" class="sub"></div>
       </div>
     </div>
     </div>

--- a/src/engine/ppHistory.js
+++ b/src/engine/ppHistory.js
@@ -1,0 +1,45 @@
+import { getCurrentPP } from './pp.js';
+
+const SAMPLE_INTERVAL = 30; // seconds
+const MAX_SAMPLES = 360;
+
+export function initPPRolling(state) {
+  if (!state.ppHistory) {
+    state.ppHistory = { samples: [], startedAt: state.time || 0, lastAt: state.time || 0 };
+    return;
+  }
+  const ph = state.ppHistory;
+  if (!ph.samples) ph.samples = [];
+  if (!ph.startedAt) ph.startedAt = state.time || 0;
+  if (!ph.lastAt) ph.lastAt = state.time || 0;
+}
+
+export function tickPPSampler(state) {
+  initPPRolling(state);
+  const ph = state.ppHistory;
+  if (state.time - ph.lastAt < SAMPLE_INTERVAL) return;
+  ph.lastAt = state.time;
+  const { PP } = getCurrentPP(state);
+  ph.samples.push(PP);
+  if (ph.samples.length > MAX_SAMPLES) {
+    ph.samples.splice(0, ph.samples.length - MAX_SAMPLES);
+  }
+}
+
+export function avgPP(arr) {
+  if (!arr || arr.length === 0) return 0;
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
+}
+
+export function getAverages(state) {
+  const ph = state.ppHistory;
+  if (!ph || ph.samples.length === 0) {
+    return { lastHour: 0, sinceStart: 0 };
+  }
+  const samples = ph.samples;
+  const lastHourSamples = samples.slice(-120); // 3600 / 30 = 120
+  return {
+    lastHour: avgPP(lastHourSamples),
+    sinceStart: avgPP(samples),
+  };
+}

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -32,6 +32,7 @@ import { advanceCatching } from "./catching/logic.js";
 import { tickPhysiqueTraining } from "./physique/mutators.js";
 import { tickAgilityTraining } from "./agility/mutators.js";
 import { tickAlchemy } from "./alchemy/logic.js";
+import { tickPPSampler } from "../engine/ppHistory.js";
 import { isAutoMeditate, isAutoAdventure } from "./automation/selectors.js";
 import { startActivity } from "./activity/mutators.js";
 import { tickInsight } from "./progression/insight.js";
@@ -292,6 +293,7 @@ function autoConsumeFood(state) {
 
 export function runAllFeatureTicks(state, stepMs) {
   const stepSec = stepMs / 1000;
+  tickPPSampler(state);
   tickAbilityCooldowns(stepMs);
   mindOnTick(state, stepSec);
 

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -57,6 +57,7 @@ export const defaultState = () => {
   foundation: 0,
   astralPoints: 50,
   coin: 0,
+  ppHistory: { samples: [], startedAt: 0, lastAt: 0 },
   ...initHp(baseHP),
   shield: { current: 0, max: 0 },
   autoFillShieldFromQi: true,

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -18,6 +18,7 @@ import { ensureLaws } from '../features/progression/migrations.js';
 import { qs, setText, setFill, log } from '../shared/utils/dom.js';
 import { fmt } from '../shared/utils/number.js';
 import { emit } from '../shared/events.js';
+import { getAverages } from '../engine/ppHistory.js';
 import { setupAdventureTabs, updateAbilityBar } from '../features/adventure/logic.js';
 import { updateCookingSidebar } from '../features/cooking/ui/cookingDisplay.js';
 import {
@@ -187,6 +188,13 @@ function initUI(){
   updateAll();
 }
 
+function updatePPAverages() {
+  const el = qs('#ppAverages');
+  if (!el) return;
+  const { lastHour, sinceStart } = getAverages(S);
+  el.textContent = `PP avg (1h): ${fmt(lastHour)} | since start: ${fmt(sinceStart)}`;
+}
+
 function updateAll(){
   updateRealmUI();
   updateQiAndFoundation();
@@ -215,6 +223,8 @@ function updateAll(){
   updateResourceDisplay();
 
   updateCatchingUI(S);
+
+  updatePPAverages();
 
   // Disciples
 


### PR DESCRIPTION
## Summary
- extend default state with `ppHistory` tracking
- sample and average power points over time
- surface last-hour and since-start PP averages in the header

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`


------
https://chatgpt.com/codex/tasks/task_e_68c5b64166748326ae3d379252573979