### PR TITLE
Track and display PP averages

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,9 +63,10 @@
       <div class="title-wrap">
         <h1>Way of Ascension</h1>
         <div class="sub">Idle xianxia cultivation • autosaves</div>
+        <div class="sub" id="ppAvgDisplay">PP avg (1h): <span id="ppAvgHour">0</span> • Session: <span id="ppAvgAll">0</span></div>
       </div>
     </div>
-    </div>
+  </div>
   </div>
   </header>
 

--- a/src/engine/ppHistory.js
+++ b/src/engine/ppHistory.js
@@ -1,0 +1,46 @@
+import { getCurrentPP } from './pp.js';
+
+export function initPPRolling(state){
+  state.ppHistory = state.ppHistory || { samples: [], startedAt: 0, lastAt: 0 };
+  if(!state.ppHistory.startedAt){
+    const now = Date.now();
+    state.ppHistory.startedAt = now;
+    state.ppHistory.lastAt = now;
+    const { PP } = getCurrentPP(state);
+    state.ppHistory.samples = [{ at: now, pp: PP }];
+  }
+}
+
+export function tickPPSampler(state){
+  if(!state.ppHistory || !state.ppHistory.startedAt){
+    initPPRolling(state);
+  }
+  const now = Date.now();
+  if(now - state.ppHistory.lastAt < 30000){
+    return;
+  }
+  const { PP } = getCurrentPP(state);
+  state.ppHistory.samples.push({ at: now, pp: PP });
+  state.ppHistory.lastAt = now;
+  if(state.ppHistory.samples.length > 360){
+    state.ppHistory.samples.splice(0, state.ppHistory.samples.length - 360);
+  }
+}
+
+export function avgPP(samples){
+  if(!samples || samples.length === 0) return 0;
+  const total = samples.reduce((sum, s) => sum + (s.pp || 0), 0);
+  return total / samples.length;
+}
+
+export function getAverages(state){
+  if(!state.ppHistory) return { lastHour: 0, sinceStart: 0 };
+  const now = Date.now();
+  const oneHourAgo = now - 3600000;
+  const samples = state.ppHistory.samples || [];
+  const lastHourSamples = samples.filter(s => s.at >= oneHourAgo);
+  return {
+    lastHour: avgPP(lastHourSamples),
+    sinceStart: avgPP(samples),
+  };
+}

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -44,6 +44,7 @@ import { mountTutorialBox } from "../ui/tutorialBox.js";
 import { mountNotificationTray } from "../ui/notifications.js";
 import { mountAbilityTutorialPopup } from "../ui/tutorialPopups.js";
 import { renderEquipmentPanel } from "./inventory/ui/CharacterPanel.js";
+import { tickPPSampler } from "../engine/ppHistory.js";
 
 
 // Example placeholder for later:
@@ -353,5 +354,6 @@ export function runAllFeatureTicks(state, stepMs) {
   if (state.activities.adventure && state.adventure && state.adventure.inCombat) {
     updateAdventureCombat();
   }
+  tickPPSampler(state);
 }
 

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -57,6 +57,7 @@ export const defaultState = () => {
   foundation: 0,
   astralPoints: 50,
   coin: 0,
+  ppHistory: { samples: [], startedAt: 0, lastAt: 0 },
   ...initHp(baseHP),
   shield: { current: 0, max: 0 },
   autoFillShieldFromQi: true,

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -51,6 +51,7 @@ import { meditate } from '../features/progression/mutators.js';
 import { sellJunk } from '../features/inventory/mutators.js';
 import { usePill } from '../features/alchemy/mutators.js';
 import { initSideLocations } from '../features/sideLocations/logic.js';
+import { initPPRolling, getAverages } from '../engine/ppHistory.js';
 
 let controller;
 
@@ -190,6 +191,10 @@ function initUI(){
 function updateAll(){
   updateRealmUI();
   updateQiAndFoundation();
+
+  const avgs = getAverages(S);
+  setText('ppAvgHour', fmt(avgs.lastHour));
+  setText('ppAvgAll', fmt(avgs.sinceStart));
 
   // HP/Shield & combat stats are rendered by updateCombatStats()
   updateCombatStats();
@@ -403,6 +408,7 @@ function enableLayoutDebug() {
     updateAll();
     log('Welcome, cultivator.');
     // Own the loop via GameController (fixed 1000ms for now)
+    initPPRolling(S);
     controller = new GameController(S, 1000).setFrame(frame);
     controller.start();
     setInterval(() => {

--- a/style.css
+++ b/style.css
@@ -5344,3 +5344,7 @@ html.reduce-motion .log-sheet{transition:none;}
   font-size: 0.85rem;
   line-height: 1.4;
 }
+
+#ppAvgDisplay {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- extend game state with ppHistory tracking
- add ppHistory module with sampling and averaging utilities
- sample PP every 30s and surface averages in header
- ensure PP averages display on all screen sizes and record initial sample

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate` *(fails: UNDOCUMENTED FILE: src/engine/pp.js, src/engine/ppHistory.js, src/lib/index.js, src/lib/power/ehp.js, src/lib/power/index.js, src/lib/power/pp.js, src/lib/power/pp.test.js, app.js imports feature internals (mutators/logic/selectors). Only import registry, sidebar, debug, controller., UI write violation: src/features/activity/ui/activityUI.js mutates root.* (use mutators), UI state violation: src/features/adventure/ui/adventureDisplay.js imports S from shared/state.js, UI state violation: src/features/adventure/ui/mapUI.js imports S from shared/state.js, UI state violation: src/features/adventure/ui/progressBar.js imports S from shared/state.js, UI state violation: src/features/combat/ui/combatStats.js imports S from shared/state.js, UI state violation: src/features/cooking/ui/cookControls.js imports S from shared/state.js, UI state violation: src/features/cooking/ui/cookingDisplay.js imports S from shared/state.js, UI state violation: src/features/forging/ui/forgingDisplay.js imports S from shared/state.js, UI state violation: src/features/gathering/ui/gatheringDisplay.js imports S from shared/state.js, UI state violation: src/features/inventory/ui/resourceDisplay.js imports S from shared/state.js, UI state violation: src/features/karma/ui/karmaHUD.js imports S from shared/state.js, UI state violation: src/features/loot/ui/lootTab.js imports S from shared/state.js, UI state violation: src/features/mining/ui/miningDisplay.js imports S from shared/state.js, UI state violation: src/features/proficiency/ui/weaponProficiencyDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/lawDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiDisplay.js imports S from shared/state.js, UI state violation: src/features/progression/ui/qiOrb.js imports S from shared/state.js, UI state violation: src/features/progression/ui/realm.js imports S from shared/state.js, DOM in src/features/adventure/logic.js. Move DOM to features/<feature>/ui/*.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b64166748326ae3d379252573979