### PR TITLE
feat: add power point logging and download

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,6 +338,9 @@
               <h4>🌲 Astral Tree Effects</h4>
               <div id="astralTreeTotals"><div class="muted">No bonuses yet</div></div>
             </div>
+            <div class="card">
+              <button class="btn" id="downloadPPLogBtn">Download PP Log</button>
+            </div>
           </div>
         </div>
       </section>

--- a/src/engine/ppLog.js
+++ b/src/engine/ppLog.js
@@ -1,0 +1,43 @@
+import { getCurrentPP } from './pp.js';
+
+/**
+ * Record a Power Points snapshot for a given event.
+ * @param {object} state - game state
+ * @param {string} kind - event type
+ * @param {object} [meta={}] - additional metadata
+ */
+export function logPPEvent(state, kind, meta = {}) {
+  if (!state) return;
+  state.ppLog = state.ppLog || [];
+  const { OPP, DPP, PP } = getCurrentPP(state);
+  state.ppLog.push({
+    ts: Date.now(),
+    kind,
+    OPP,
+    DPP,
+    PP,
+    meta,
+  });
+}
+
+/**
+ * Download the Power Points log as a CSV file.
+ * @param {object} state - game state
+ */
+export function downloadPPLogCSV(state) {
+  const rows = state?.ppLog || [];
+  let csv = 'timestamp,kind,OPP,DPP,PP,meta\n';
+  csv += rows
+    .map(r => {
+      const meta = JSON.stringify(r.meta || {});
+      return `${new Date(r.ts).toISOString()},${r.kind},${r.OPP},${r.DPP},${r.PP},${meta}`;
+    })
+    .join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'pp-log.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/features/forging/logic.js
+++ b/src/features/forging/logic.js
@@ -2,6 +2,7 @@ import { S } from '../../shared/state.js';
 import { log } from '../../shared/utils/dom.js';
 import { getAgilityEffects } from '../agility/logic.js';
 import { getBuildingBonuses } from '../sect/selectors.js';
+import { logPPEvent } from '../../engine/ppLog.js';
 
 export function getForgingTime(tier, state = S) {
   const baseMinutes = tier === 0 ? 1 : Math.pow(3, tier + 1);
@@ -46,6 +47,7 @@ export function advanceForging(state = S) {
       item.element = job.element;
       item.tier = job.targetTier;
       log?.(`Finished forging ${item.name || item.id} to tier ${item.tier}`, 'good');
+      logPPEvent(state, 'forging_upgrade', { itemId: item.id || job.itemId, tier: item.tier });
     }
     state.forging.exp += 10;
     while (state.forging.exp >= state.forging.expMax) {

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -4,6 +4,7 @@ import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
 import { computePP, gatherDefense, W_O } from '../../engine/pp.js';
 import { devShowPP } from '../../config.js';
+import { logPPEvent } from '../../engine/ppLog.js';
 export { usePill } from '../alchemy/mutators.js'; // deprecated shim
 
 export function addToInventory(item, state = S) {
@@ -72,6 +73,7 @@ export function equipItem(item, slot = null, state = S) {
     const pp = nextTotal - prevTotal;
     console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Equip ${slotKey}`);
   }
+  logPPEvent(state, 'equip', { slot: slotKey, item: item.key });
   save?.();
   const payload = { key: item.key, name: WEAPONS[item.key]?.displayName || item.name || item.key, slot: slotKey };
   if (slotKey === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);
@@ -97,6 +99,7 @@ export function unequip(slot, state = S) {
     const pp = nextTotal - prevTotal;
     console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Unequip ${slot}`);
   }
+  logPPEvent(state, 'unequip', { slot });
   save?.();
   const payload = { key: 'fist', name: 'Fists', slot };
   if (slot === 'mainhand') emit('INVENTORY:MAINHAND_CHANGED', payload);

--- a/src/features/mind/mutators.js
+++ b/src/features/mind/mutators.js
@@ -13,6 +13,7 @@ import {
   applyManualEffects,
 } from './logic.js';
 import { on } from '../../shared/events.js';
+import { logPPEvent } from '../../engine/ppLog.js';
 
 export function awardFromProficiency(S, profXp) {
   const add = calcFromProficiency(profXp);
@@ -46,6 +47,7 @@ export function debugLevelManual(S) {
   rec.level += 1;
   rec.xp = 0;
   applyManualEffects(S, manual, rec.level);
+  logPPEvent(S, 'manual_level', { manualId: id, level: rec.level });
   if (rec.level >= manual.maxLevel) {
     stopReading(S);
   }
@@ -94,6 +96,7 @@ export function onTick(S, dt) {
     rec.xp -= needed;
     rec.level += 1;
     applyManualEffects(S, manual, rec.level);
+    logPPEvent(S, 'manual_level', { manualId: id, level: rec.level });
     if (rec.level >= manual.maxLevel) {
       stopReading(S);
     }

--- a/src/features/progression/mutators.js
+++ b/src/features/progression/mutators.js
@@ -6,6 +6,7 @@ import { log } from '../../shared/utils/dom.js';
 import { canLearnSkill } from './logic.js';
 import { clamp, fCap, foundationGainPerMeditate } from './selectors.js';
 import { unlockRecipe } from '../alchemy/mutators.js';
+import { logPPEvent } from '../../engine/ppLog.js';
 
 export function advanceRealm(state = progressionState) {
   const wasRealmAdvancement = state.realm.stage > REALMS[state.realm.tier].stages;
@@ -86,6 +87,7 @@ export function advanceRealm(state = progressionState) {
 
   checkLawUnlocks(state);
   awardLawPoints(state);
+  logPPEvent(state, 'realm_breakthrough', { type: result.type, realm: state.realm.tier, stage: state.realm.stage });
   return result;
 }
 

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -14,6 +14,7 @@ import {
 } from '../../activity/ui/activityUI.js';
 import { computePP, gatherDefense, W_O } from '../../../engine/pp.js';
 import { configReport, featureFlags, devShowPP } from '../../../config.js';
+import { logPPEvent } from '../../../engine/ppLog.js';
 
 const STORAGE_KEY = 'astralTreeAllocated';
 // Starting nodes must match the roots in the astral_tree.json dataset
@@ -462,6 +463,7 @@ async function buildTree() {
         S.astralPoints -= info2.cost;
         allocated.add(n.id);
         applyEffects(n.id, manifest);
+        logPPEvent(S, 'astral_node', { node: n.id });
         saveAllocations(allocated);
         updateInsight();
         refreshClasses();

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -19,6 +19,7 @@ import { mountAllFeatureUIs } from '../../index.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import { renderPillIcons } from '../../alchemy/ui/pillIcons.js';
 import { computePP, breakthroughPPSnapshot, gatherDefense, W_O } from '../../../engine/pp.js';
+import { downloadPPLogCSV } from '../../../engine/ppLog.js';
 
 let pendingAstralUnlock = false;
 
@@ -555,5 +556,8 @@ export function initRealmUI(){
   const astralBackdrop = astralOverlay?.querySelector('.modal-backdrop');
   if (closeAstralBtn) closeAstralBtn.addEventListener('click', hideAstralTreeUnlockOverlay);
   if (astralBackdrop) astralBackdrop.addEventListener('click', hideAstralTreeUnlockOverlay);
+
+  const ppLogBtn = qs('#downloadPPLogBtn');
+  if (ppLogBtn) ppLogBtn.addEventListener('click', () => downloadPPLogCSV(S));
 }
 

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -188,6 +188,7 @@ export const defaultState = () => {
   sideLocations: structuredClone(sideLocationState),
   tutorial: structuredClone(tutorialState),
   notifications: [],
+  ppLog: [],
   };
 };
 


### PR DESCRIPTION
## Summary
- track power point changes in `ppLog`
- log PP snapshots for equips, astral nodes, forging, breakthroughs, and manual levels
- allow downloading PP log CSV from stats page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b84b02588326a4aab081ccfbb78f