### PR TITLE
fix: ensure mind tab appears when unlocked

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -73,7 +73,9 @@ way-of-ascension/
 │   │   ├── combat/
 │   │   │   └── stun.js
 │   │   ├── enemyPP.js
-│   │   └── pp.js
+│   │   ├── pp.js
+│   │   ├── ppHistory.js
+│   │   └── ppLog.js
 │   ├── lib/
 │   │   ├── index.js
 │   │   └── power/
@@ -1049,6 +1051,8 @@ Paths added:
 - `src/engine/combat/stun.js` – Handles stun accumulation, decay, and status application.
 - `src/engine/pp.js` – Computes offensive, defensive, and total power points for the player.
 - `src/engine/enemyPP.js` – Enemy-focused power helpers mirroring player PP formulas.
+- `src/engine/ppHistory.js` – Maintains rolling PP samples for hourly and overall averages.
+- `src/engine/ppLog.js` – Logs PP events and supports downloading the log as CSV.
 
 ### Shared Library (`src/lib/`)
 - `src/lib/index.js` – Root exports for shared helper modules.

--- a/src/features/index.js
+++ b/src/features/index.js
@@ -188,6 +188,7 @@ export function mountAllFeatureUIs(state) {
     ensure('levelingActivities', 'agilitySelector', 'agility', 'Agility');
     ensure('levelingActivities', 'miningSelector', 'mining', 'Mining');
     ensure('levelingActivities', 'gatheringSelector', 'gathering', 'Gathering');
+    ensure('levelingActivities', 'mindSelector', 'mind', 'Mind');
     ensure('levelingActivities', 'forgingSelector', 'forging', 'Forging');
     ensure('levelingActivities', 'catchingSelector', 'catching', 'Catching');
     ensure('managementActivities', 'adventureSelector', 'adventure', 'Adventure');
@@ -217,7 +218,10 @@ export function mountAllFeatureUIs(state) {
   }
   if (flags.FEATURE_CATCHING?.parsedValue && vis.catching.visible) mountCatchingUI(state);
   if (flags.FEATURE_LAW?.parsedValue && vis.law.visible) mountLawDisplay(state);
-  if (flags.FEATURE_MIND?.parsedValue && vis.mind.visible) mountMindReadingUI(state);
+  if (flags.FEATURE_MIND?.parsedValue && vis.mind.visible) {
+    ensure('levelingActivities', 'mindSelector', 'mind', 'Mind');
+    mountMindReadingUI(state);
+  }
   if (vis.astralTree.visible) mountAstralTreeUI(state);
 
   // mountWeaponGenUI?.(state);

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -326,6 +326,7 @@ function unlockStartingActivities(id) {
   } else if (id === 4061) {
     enableFeatures(['gathering', 'mind']);
     ensureActivityTab('gathering', 'Gathering');
+    ensureActivityTab('mind', 'Mind');
     mountGatheringUI(S);
     mountMindReadingUI(S);
   } else if (id === 4062) {


### PR DESCRIPTION
## Summary
- add missing Mind activity tabs for dev builds and unlocks
- document ppHistory and ppLog in project structure

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint:balance`
- `npm run validate` (fails: UI state violations and DOM usage)

------
https://chatgpt.com/codex/tasks/task_e_68c5c393c5608326910e029fc51b6f2b