### PR TITLE
Align power point calculations to Forest Rabbit baseline

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -73,6 +73,7 @@ way-of-ascension/
 │   │   ├── combat/
 │   │   │   └── stun.js
 │   │   ├── enemyPP.js
+│   │   ├── powerConstants.js
 │   │   ├── pp.js
 │   │   ├── ppHistory.js
 │   │   └── ppLog.js
@@ -1050,6 +1051,7 @@ Paths added:
 ### Engine (`src/engine/`)
 - `src/engine/combat/stun.js` – Handles stun accumulation, decay, and status application.
 - `src/engine/pp.js` – Computes offensive, defensive, and total power points for the player.
+- `src/engine/powerConstants.js` – Defines PP weight constants and derives the shared Forest Rabbit baseline stats.
 - `src/engine/enemyPP.js` – Enemy-focused power helpers mirroring player PP formulas.
 - `src/engine/ppHistory.js` – Maintains rolling PP samples for hourly and overall averages.
 - `src/engine/ppLog.js` – Logs PP events and supports downloading the log as CSV.

--- a/src/engine/enemyPP.js
+++ b/src/engine/enemyPP.js
@@ -1,26 +1,18 @@
-import { drFromArmor, dEhpFromHP, dEhpFromRes, dEhpFromDodge } from '../lib/power/ehp.js';
-import { DODGE_BASE } from '../features/combat/hit.js';
-import { W_O, W_D } from './pp.js';
+import {
+  BASELINE_DPS,
+  BASELINE_EHP,
+  W_O,
+  W_D,
+  computeEnemyEHP,
+} from './powerConstants.js';
 
-export function enemyEHP(enemy = {}) {
-  const hp = enemy.hpMax ?? enemy.hp ?? 0;
-  const armor = enemy.armor ?? 0;
-  const dodge = (enemy.stats?.dodge ?? enemy.dodge ?? 0) + DODGE_BASE;
-  const resists = enemy.resists || {};
-  const dr = drFromArmor(armor);
-  let ehpPct = dEhpFromHP(hp, dr);
-  for (const val of Object.values(resists)) {
-    ehpPct += dEhpFromRes(val);
-  }
-  ehpPct += dEhpFromDodge(dodge);
-  return (1 + ehpPct) * 100;
-}
+export const enemyEHP = computeEnemyEHP;
 
 export function enemyPP(enemy = {}) {
   const dps = (enemy.attack || 0) * (enemy.attackRate || 1);
-  const E_OPP = dps;
-  const ehp = enemyEHP(enemy);
-  const E_DPP = ((ehp / 100) - 1) * 100 * W_D;
-  const EPP = W_O * E_OPP + E_DPP;
-  return { EPP, E_OPP, E_DPP, EHP: ehp };
+  const ehp = computeEnemyEHP(enemy);
+  const E_OPP = BASELINE_DPS > 0 ? 100 * (dps / BASELINE_DPS - 1) : 0;
+  const E_DPP = BASELINE_EHP > 0 ? 100 * (ehp / BASELINE_EHP - 1) : 0;
+  const EPP = W_O * E_OPP + W_D * E_DPP;
+  return { EPP, E_OPP, E_DPP, EHP: ehp, DPS: dps };
 }

--- a/src/engine/powerConstants.js
+++ b/src/engine/powerConstants.js
@@ -1,0 +1,29 @@
+import { ENEMY_DATA } from '../features/adventure/data/enemies.js';
+import { drFromArmor, dEhpFromHP, dEhpFromRes, dEhpFromDodge } from '../lib/power/ehp.js';
+import { DODGE_BASE } from '../features/combat/hit.js';
+
+export const W_O = 0.6;
+export const W_D = 0.4;
+
+export const BASELINE_ENEMY_KEY = 'Forest Rabbit';
+
+export function computeEnemyEHP(enemy = {}) {
+  const hp = enemy.hpMax ?? enemy.hp ?? 0;
+  const armor = enemy.armor ?? 0;
+  const dodge = (enemy.stats?.dodge ?? enemy.dodge ?? 0) + DODGE_BASE;
+  const resists = enemy.resists || {};
+  const dr = drFromArmor(armor);
+  let ehpPct = dEhpFromHP(hp, dr);
+  for (const val of Object.values(resists)) {
+    ehpPct += dEhpFromRes(val);
+  }
+  ehpPct += dEhpFromDodge(dodge);
+  return (1 + ehpPct) * 100;
+}
+
+const BASELINE_ENEMY = ENEMY_DATA[BASELINE_ENEMY_KEY] || {};
+const baselineEhp = computeEnemyEHP(BASELINE_ENEMY);
+const baselineDps = (BASELINE_ENEMY.attack || 0) * (BASELINE_ENEMY.attackRate || 0);
+
+export const BASELINE_EHP = baselineEhp > 0 ? baselineEhp : 1;
+export const BASELINE_DPS = baselineDps > 0 ? baselineDps : 1;

--- a/src/engine/pp.js
+++ b/src/engine/pp.js
@@ -1,4 +1,8 @@
-import { calcArmor, calculatePlayerAttackSnapshot } from '../features/progression/logic.js';
+import {
+  calcArmor,
+  calculatePlayerAttackRate,
+  calculatePlayerAttackSnapshot,
+} from '../features/progression/logic.js';
 import { REALMS } from '../features/progression/data/realms.js';
 import {
   drFromArmor,
@@ -8,9 +12,9 @@ import {
   dEhpFromQiRegenPct,
   dEhpFromMaxQiPct,
 } from '../lib/power/ehp.js';
+import { BASELINE_DPS, BASELINE_EHP, W_D, W_O } from './powerConstants.js';
 
-export const W_O = 0.6;
-export const W_D = 0.4;
+export { W_O, W_D } from './powerConstants.js';
 
 /**
  * Basic player power calculations. OPP (Offensive Power Points) and DPP
@@ -34,19 +38,20 @@ export function gatherDefense(state) {
 
 export function computePP(state, overrides = {}) {
   const snap = calculatePlayerAttackSnapshot(state);
+  const attackRate = calculatePlayerAttackRate(state);
   const combinePct = elem =>
     (snap.gearPct?.all || 0) +
     (snap.gearPct?.[elem] || 0) +
     (snap.astralPct?.[elem] || 0) +
     (snap.globalPct || 0);
 
-  let OPP = snap.profile.phys * (1 + combinePct('physical'));
+  let perHit = snap.profile.phys * (1 + combinePct('physical'));
   for (const [elem, dmg] of Object.entries(snap.profile.elems || {})) {
-    OPP += dmg * (1 + combinePct(elem));
+    perHit += dmg * (1 + combinePct(elem));
   }
-  OPP *= 1 + (snap.critChance || 0) * ((snap.critMult || 1) - 1);
-
-  OPP *= 1 + (snap.power?.opFromCult || 0);
+  perHit *= 1 + (snap.critChance || 0) * ((snap.critMult || 1) - 1);
+  perHit *= 1 + (snap.power?.opFromCult || 0);
+  const playerDps = perHit * attackRate;
 
   const dp = { ...gatherDefense(state), ...overrides };
   const dr = drFromArmor(dp.armor);
@@ -57,9 +62,12 @@ export function computePP(state, overrides = {}) {
   ehpPct += dEhpFromDodge(dp.dodge);
   ehpPct += dEhpFromQiRegenPct(dp.qiRegenPct);
   ehpPct += dEhpFromMaxQiPct(dp.maxQiPct);
-  let DPP = ehpPct * 100 * W_D;
-  DPP *= 1 + (snap.power?.dpFromCult || 0);
-  return { OPP, DPP };
+  let playerEhp = 100 * (1 + ehpPct);
+  playerEhp *= 1 + (snap.power?.dpFromCult || 0);
+
+  const OPP = BASELINE_DPS > 0 ? 100 * (playerDps / BASELINE_DPS - 1) : 0;
+  const DPP = BASELINE_EHP > 0 ? 100 * (playerEhp / BASELINE_EHP - 1) : 0;
+  return { OPP, DPP, dps: playerDps, ehp: playerEhp };
 }
 
 /**
@@ -69,11 +77,10 @@ export function computePP(state, overrides = {}) {
  * @returns {{ PP:number, OPP:number, DPP:number }}
  */
 export function getCurrentPP(state) {
-  const { OPP, DPP } = computePP(state);
+  const result = computePP(state);
   return {
-    OPP,
-    DPP,
-    PP: W_O * OPP + DPP,
+    ...result,
+    PP: W_O * result.OPP + W_D * result.DPP,
   };
 }
 
@@ -87,7 +94,7 @@ export function getCurrentPP(state) {
  */
 export function breakthroughPPSnapshot(state) {
   const before = computePP(state);
-  const beforePP = W_O * before.OPP + before.DPP;
+  const beforePP = W_O * before.OPP + W_D * before.DPP;
 
   // Deep clone relevant pieces to simulate the breakthrough
   const sim = JSON.parse(JSON.stringify(state));
@@ -104,7 +111,7 @@ export function breakthroughPPSnapshot(state) {
   }
 
   const after = computePP(sim);
-  const afterPP = W_O * after.OPP + after.DPP;
+  const afterPP = W_O * after.OPP + W_D * after.DPP;
   const diff = {
     OPP: after.OPP - before.OPP,
     DPP: after.DPP - before.DPP,

--- a/src/engine/ppLog.js
+++ b/src/engine/ppLog.js
@@ -1,4 +1,4 @@
-import { computePP, gatherDefense, W_O } from './pp.js';
+import { computePP, gatherDefense, W_D, W_O } from './pp.js';
 
 /**
  * Log a Power Points event. `meta.before` can include a pre-change
@@ -12,10 +12,10 @@ export function logPPEvent(state, kind, meta = {}) {
   if (!state) return;
   const before = meta.before;
   const after = computePP(state, gatherDefense(state));
-  const afterTotal = W_O * after.OPP + after.DPP;
+  const afterTotal = W_O * after.OPP + W_D * after.DPP;
   let diff;
   if (before) {
-    const beforeTotal = W_O * before.OPP + before.DPP;
+    const beforeTotal = W_O * before.OPP + W_D * before.DPP;
     diff = {
       OPP: after.OPP - before.OPP,
       DPP: after.DPP - before.DPP,

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -92,7 +92,9 @@ function tuneEnemyStats(enemy, playerDps, playerEhp) {
 }
 
 function powerColor(epp, playerPP) {
-  const ratio = epp / (playerPP || 1);
+  const enemyMetric = (epp ?? 0) + 100;
+  const playerMetric = Math.max((playerPP ?? 0) + 100, 1);
+  const ratio = enemyMetric / playerMetric;
   if (ratio > 1.1) return '#f87171';
   if (ratio < 0.9) return '#4ade80';
   return '#fbbf24';
@@ -1262,9 +1264,18 @@ export function startBossCombat() {
     resists: bossData.resists || {},
   };
   const playerPower = getCurrentPP(S);
-  const dp = gatherDefense(S);
-  const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const playerDps =
+    playerPower?.dps ?? (playerPower?.OPP || 0) * calculatePlayerAttackRate(S);
+  let playerEhp = playerPower?.ehp;
+  if (playerEhp === undefined) {
+    const dp = gatherDefense(S);
+    playerEhp = enemyEHP({
+      hpMax: dp.hp,
+      armor: dp.armor,
+      dodge: dp.dodge - DODGE_BASE,
+      resists: dp.resists,
+    });
+  }
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;
@@ -1327,9 +1338,18 @@ export function startAdventureCombat() {
     resists: enemyData.resists || {},
   };
   const playerPower = getCurrentPP(S);
-  const dp = gatherDefense(S);
-  const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const playerDps =
+    playerPower?.dps ?? (playerPower?.OPP || 0) * calculatePlayerAttackRate(S);
+  let playerEhp = playerPower?.ehp;
+  if (playerEhp === undefined) {
+    const dp = gatherDefense(S);
+    playerEhp = enemyEHP({
+      hpMax: dp.hp,
+      armor: dp.armor,
+      dodge: dp.dodge - DODGE_BASE,
+      resists: dp.resists,
+    });
+  }
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;
@@ -1406,9 +1426,18 @@ function startDungeonEncounter() {
     resists: enemyData.resists || {},
   };
   const playerPower = getCurrentPP(S);
-  const dp = gatherDefense(S);
-  const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const playerDps =
+    playerPower?.dps ?? (playerPower?.OPP || 0) * calculatePlayerAttackRate(S);
+  let playerEhp = playerPower?.ehp;
+  if (playerEhp === undefined) {
+    const dp = gatherDefense(S);
+    playerEhp = enemyEHP({
+      hpMax: dp.hp,
+      armor: dp.armor,
+      dodge: dp.dodge - DODGE_BASE,
+      resists: dp.resists,
+    });
+  }
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -2,7 +2,7 @@ import { S, save } from '../../shared/state.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
-import { computePP, gatherDefense, W_O } from '../../engine/pp.js';
+import { computePP, gatherDefense, W_D, W_O } from '../../engine/pp.js';
 import { logPPEvent } from '../../engine/ppLog.js';
 import { devShowPP } from '../../config.js';
 export { usePill } from '../alchemy/mutators.js'; // deprecated shim
@@ -55,7 +55,7 @@ export function equipItem(item, slot = null, state = S) {
   if (!info) return false;
   const slotKey = info.slot;
   const prevPP = computePP(state, gatherDefense(state));
-  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
+  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
   const existing = state.equipment[slotKey];
   const existingKey = typeof existing === 'string' ? existing : existing?.key;
   if (existingKey && existingKey !== 'fist') addToInventory(existing, state);
@@ -65,7 +65,7 @@ export function equipItem(item, slot = null, state = S) {
   console.log('[equip]', 'slot→', slotKey, 'item→', item.key);
   recomputePlayerTotals(state);
   const nextPP = computePP(state, gatherDefense(state));
-  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
+  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;
@@ -84,14 +84,14 @@ export function unequip(slot, state = S) {
   const item = state.equipment[slot];
   if (!item) return;
   const prevPP = computePP(state, gatherDefense(state));
-  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
+  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
   const key = typeof item === 'string' ? item : item.key;
   if (key !== 'fist') addToInventory(item, state);
   state.equipment[slot] = null;
   console.log('[equip]', 'slot→', slot, 'item→', 'none');
   recomputePlayerTotals(state);
   const nextPP = computePP(state, gatherDefense(state));
-  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
+  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -8,7 +8,7 @@ import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
-import { computePP, getCurrentPP, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, getCurrentPP, gatherDefense, W_D, W_O } from '../../../engine/pp.js';
 import { downloadPPLogCSV } from '../../../engine/ppLog.js';
 import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
 import { qiCostPerShield, QI_PER_SHIELD_BASE } from '../../combat/logic.js';
@@ -244,12 +244,12 @@ function computeItemPPDelta(item, state = S) {
   const temp = JSON.parse(JSON.stringify(state));
   recomputePlayerTotals(temp);
   const prev = computePP(temp, gatherDefense(temp));
-  const prevTotal = W_O * prev.OPP + prev.DPP;
+  const prevTotal = W_O * prev.OPP + W_D * prev.DPP;
   temp.equipment = temp.equipment || {};
   temp.equipment[slot] = { ...item };
   recomputePlayerTotals(temp);
   const next = computePP(temp, gatherDefense(temp));
-  const nextTotal = W_O * next.OPP + next.DPP;
+  const nextTotal = W_O * next.OPP + W_D * next.DPP;
   return {
     opp: next.OPP - prev.OPP,
     dpp: next.DPP - prev.DPP,

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -12,7 +12,7 @@ import {
   updateActivitySelectors,
   renderActiveActivity,
 } from '../../activity/ui/activityUI.js';
-import { computePP, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, gatherDefense, W_D, W_O } from '../../../engine/pp.js';
 import { logPPEvent } from '../../../engine/ppLog.js';
 import { configReport, featureFlags, devShowPP } from '../../../config.js';
 
@@ -439,8 +439,8 @@ async function buildTree() {
       }
       const after = computePP(sim, gatherDefense(sim));
       const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-      const beforePP = W_O * before.OPP + before.DPP;
-      const afterPP = W_O * after.OPP + after.DPP;
+      const beforePP = W_O * before.OPP + W_D * before.DPP;
+      const afterPP = W_O * after.OPP + W_D * after.DPP;
       lines.push(
         `DEV:PP ${fmt(after.OPP - before.OPP)}/${fmt(after.DPP - before.DPP)}/${fmt(
           afterPP - beforePP
@@ -475,8 +475,8 @@ async function buildTree() {
         if (devShowPP && beforePP) {
           const afterPP = computePP(S, gatherDefense(S));
           const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-          const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
-          const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
+          const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+          const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
           console.log(
             `DEV:PP ${fmt(afterPP.OPP - beforePP.OPP)}/${fmt(afterPP.DPP - beforePP.DPP)}/${fmt(
               nextTotal - prevTotal

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -18,7 +18,7 @@ import { isProd, devShowPP } from '../../../config.js';
 import { mountAllFeatureUIs } from '../../index.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import { renderPillIcons } from '../../alchemy/ui/pillIcons.js';
-import { computePP, breakthroughPPSnapshot, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, breakthroughPPSnapshot, gatherDefense, W_D, W_O } from '../../../engine/pp.js';
 import { logPPEvent } from '../../../engine/ppLog.js';
 
 let pendingAstralUnlock = false;
@@ -515,8 +515,8 @@ export function updateBreakthrough() {
         const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
         const opp = afterPP.OPP - beforePP.OPP;
         const dpp = afterPP.DPP - beforePP.DPP;
-        const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
-        const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
+        const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+        const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
         const pp = nextTotal - prevTotal;
         console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Breakthrough`);
       }


### PR DESCRIPTION
## Summary
- centralize the Forest Rabbit baseline constants for shared PP math
- scale player and enemy PP against the baseline so weighted totals share the same ruler
- adjust downstream UI/logic consumers and document the new engine helper

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_68c85bd840888326867009e580d30034