### PR TITLE
Align PP calculations to Forest Rabbit baseline

### DIFF
--- a/src/engine/baseline.js
+++ b/src/engine/baseline.js
@@ -1,0 +1,33 @@
+import { ENEMY_DATA } from '../features/adventure/data/enemies.js';
+import { DODGE_BASE } from '../features/combat/hit.js';
+import { effectiveHP } from '../lib/power/ehp.js';
+
+export const BASELINE_ENEMY_KEY = 'Forest Rabbit';
+
+const BASELINE_DATA = ENEMY_DATA[BASELINE_ENEMY_KEY] || {};
+
+const baselineHp = BASELINE_DATA.hpMax ?? BASELINE_DATA.hp ?? 1;
+const baselineAttack = BASELINE_DATA.attack ?? 0;
+const baselineRate = BASELINE_DATA.attackRate ?? 1;
+const computedDps = baselineAttack * baselineRate;
+
+export const BASELINE_HP = baselineHp || 1;
+export const BASELINE_DPS = computedDps > 0 ? computedDps : 1;
+
+const baselineEhp = effectiveHP({
+  hp: baselineHp,
+  armor: BASELINE_DATA.armor ?? 0,
+  dodge: (BASELINE_DATA.stats?.dodge ?? BASELINE_DATA.dodge ?? 0) + DODGE_BASE,
+  resists: BASELINE_DATA.resists || {},
+  qiRegenPct: BASELINE_DATA.qiRegenPct || 0,
+  maxQiPct: BASELINE_DATA.maxQiPct || 0,
+});
+
+export const BASELINE_EHP = Number.isFinite(baselineEhp) && baselineEhp > 0 ? baselineEhp : BASELINE_HP;
+
+export const BASELINE_ENEMY = {
+  ...BASELINE_DATA,
+  hp: baselineHp,
+  attack: baselineAttack,
+  attackRate: baselineRate,
+};

--- a/src/engine/enemyPP.js
+++ b/src/engine/enemyPP.js
@@ -1,26 +1,31 @@
-import { drFromArmor, dEhpFromHP, dEhpFromRes, dEhpFromDodge } from '../lib/power/ehp.js';
+import { effectiveHP } from '../lib/power/ehp.js';
 import { DODGE_BASE } from '../features/combat/hit.js';
 import { W_O, W_D } from './pp.js';
+import { BASELINE_DPS, BASELINE_EHP } from './baseline.js';
 
 export function enemyEHP(enemy = {}) {
   const hp = enemy.hpMax ?? enemy.hp ?? 0;
   const armor = enemy.armor ?? 0;
   const dodge = (enemy.stats?.dodge ?? enemy.dodge ?? 0) + DODGE_BASE;
   const resists = enemy.resists || {};
-  const dr = drFromArmor(armor);
-  let ehpPct = dEhpFromHP(hp, dr);
-  for (const val of Object.values(resists)) {
-    ehpPct += dEhpFromRes(val);
-  }
-  ehpPct += dEhpFromDodge(dodge);
-  return (1 + ehpPct) * 100;
+  const qiRegenPct = enemy.qiRegenPct || 0;
+  const maxQiPct = enemy.maxQiPct || 0;
+  return effectiveHP({ hp, armor, dodge, resists, qiRegenPct, maxQiPct });
 }
 
 export function enemyPP(enemy = {}) {
   const dps = (enemy.attack || 0) * (enemy.attackRate || 1);
-  const E_OPP = dps;
   const ehp = enemyEHP(enemy);
-  const E_DPP = ((ehp / 100) - 1) * 100 * W_D;
-  const EPP = W_O * E_OPP + E_DPP;
-  return { EPP, E_OPP, E_DPP, EHP: ehp };
+  const E_OPP = BASELINE_DPS > 0 ? 100 * (dps / BASELINE_DPS - 1) : 0;
+  const E_DPP = BASELINE_EHP > 0 ? 100 * (ehp / BASELINE_EHP - 1) : 0;
+  const safeEOPP = Number.isFinite(E_OPP) ? E_OPP : 0;
+  const safeEDPP = Number.isFinite(E_DPP) ? E_DPP : 0;
+  const EPP = W_O * safeEOPP + W_D * safeEDPP;
+  return {
+    EPP,
+    E_OPP: safeEOPP,
+    E_DPP: safeEDPP,
+    EHP: ehp,
+    raw: { dps, ehp },
+  };
 }

--- a/src/engine/ppLog.js
+++ b/src/engine/ppLog.js
@@ -1,4 +1,4 @@
-import { computePP, gatherDefense, W_O } from './pp.js';
+import { computePP, gatherDefense, W_O, W_D } from './pp.js';
 
 /**
  * Log a Power Points event. `meta.before` can include a pre-change
@@ -12,10 +12,10 @@ export function logPPEvent(state, kind, meta = {}) {
   if (!state) return;
   const before = meta.before;
   const after = computePP(state, gatherDefense(state));
-  const afterTotal = W_O * after.OPP + after.DPP;
+  const afterTotal = W_O * after.OPP + W_D * after.DPP;
   let diff;
   if (before) {
-    const beforeTotal = W_O * before.OPP + before.DPP;
+    const beforeTotal = W_O * before.OPP + W_D * before.DPP;
     diff = {
       OPP: after.OPP - before.OPP,
       DPP: after.DPP - before.DPP,

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -77,6 +77,27 @@ function rarityFromAffixCount(count) {
 
 const TARGET_TTK = 11; // seconds to kill enemy
 const TARGET_TTF = 50; // seconds for enemy to defeat player
+const POWER_COLOR_THRESHOLD = 40;
+
+function getPlayerCombatPower(state = S) {
+  const playerPower = getCurrentPP(state);
+  const defense = gatherDefense(state);
+  const fallbackEhp = enemyEHP({
+    hpMax: defense.hp,
+    armor: defense.armor,
+    dodge: Math.max(0, (defense.dodge || 0) - DODGE_BASE),
+    resists: defense.resists,
+    qiRegenPct: defense.qiRegenPct,
+    maxQiPct: defense.maxQiPct,
+  });
+  const rawStats = playerPower.raw || {};
+  const rawDps = rawStats.dps ?? (rawStats.damagePerHit ?? 0) * (rawStats.attackRate ?? 0);
+  const playerDps = Number.isFinite(rawDps) ? rawDps : 0;
+  const playerEhp = Number.isFinite(rawStats.ehp)
+    ? rawStats.ehp
+    : (Number.isFinite(fallbackEhp) ? fallbackEhp : 0);
+  return { playerPower, playerDps, playerEhp };
+}
 
 function tuneEnemyStats(enemy, playerDps, playerEhp) {
   if (playerDps > 0) {
@@ -91,10 +112,13 @@ function tuneEnemyStats(enemy, playerDps, playerEhp) {
   return enemy;
 }
 
-function powerColor(epp, playerPP) {
-  const ratio = epp / (playerPP || 1);
-  if (ratio > 1.1) return '#f87171';
-  if (ratio < 0.9) return '#4ade80';
+function powerColor(enemyPP, playerPP) {
+  if (!Number.isFinite(enemyPP) || !Number.isFinite(playerPP)) {
+    return '#fbbf24';
+  }
+  const diff = enemyPP - playerPP;
+  if (diff > POWER_COLOR_THRESHOLD) return '#f87171';
+  if (diff < -POWER_COLOR_THRESHOLD) return '#4ade80';
   return '#fbbf24';
 }
 
@@ -1261,10 +1285,7 @@ export function startBossCombat() {
     attackRate: bossData.attackRate,
     resists: bossData.resists || {},
   };
-  const playerPower = getCurrentPP(S);
-  const dp = gatherDefense(S);
-  const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const { playerDps, playerEhp } = getPlayerCombatPower(S);
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;
@@ -1326,10 +1347,7 @@ export function startAdventureCombat() {
     attackRate: enemyData.attackRate,
     resists: enemyData.resists || {},
   };
-  const playerPower = getCurrentPP(S);
-  const dp = gatherDefense(S);
-  const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const { playerDps, playerEhp } = getPlayerCombatPower(S);
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;
@@ -1405,10 +1423,7 @@ function startDungeonEncounter() {
     attackRate: enemyData.attackRate,
     resists: enemyData.resists || {},
   };
-  const playerPower = getCurrentPP(S);
-  const dp = gatherDefense(S);
-  const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const { playerDps, playerEhp } = getPlayerCombatPower(S);
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -2,7 +2,7 @@ import { S, save } from '../../shared/state.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
-import { computePP, gatherDefense, W_O } from '../../engine/pp.js';
+import { computePP, gatherDefense, W_O, W_D } from '../../engine/pp.js';
 import { logPPEvent } from '../../engine/ppLog.js';
 import { devShowPP } from '../../config.js';
 export { usePill } from '../alchemy/mutators.js'; // deprecated shim
@@ -55,7 +55,7 @@ export function equipItem(item, slot = null, state = S) {
   if (!info) return false;
   const slotKey = info.slot;
   const prevPP = computePP(state, gatherDefense(state));
-  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
+  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
   const existing = state.equipment[slotKey];
   const existingKey = typeof existing === 'string' ? existing : existing?.key;
   if (existingKey && existingKey !== 'fist') addToInventory(existing, state);
@@ -65,7 +65,7 @@ export function equipItem(item, slot = null, state = S) {
   console.log('[equip]', 'slot→', slotKey, 'item→', item.key);
   recomputePlayerTotals(state);
   const nextPP = computePP(state, gatherDefense(state));
-  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
+  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;
@@ -84,14 +84,14 @@ export function unequip(slot, state = S) {
   const item = state.equipment[slot];
   if (!item) return;
   const prevPP = computePP(state, gatherDefense(state));
-  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
+  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
   const key = typeof item === 'string' ? item : item.key;
   if (key !== 'fist') addToInventory(item, state);
   state.equipment[slot] = null;
   console.log('[equip]', 'slot→', slot, 'item→', 'none');
   recomputePlayerTotals(state);
   const nextPP = computePP(state, gatherDefense(state));
-  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
+  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -8,7 +8,7 @@ import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
-import { computePP, getCurrentPP, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, getCurrentPP, gatherDefense, W_O, W_D } from '../../../engine/pp.js';
 import { downloadPPLogCSV } from '../../../engine/ppLog.js';
 import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
 import { qiCostPerShield, QI_PER_SHIELD_BASE } from '../../combat/logic.js';
@@ -244,12 +244,12 @@ function computeItemPPDelta(item, state = S) {
   const temp = JSON.parse(JSON.stringify(state));
   recomputePlayerTotals(temp);
   const prev = computePP(temp, gatherDefense(temp));
-  const prevTotal = W_O * prev.OPP + prev.DPP;
+  const prevTotal = W_O * prev.OPP + W_D * prev.DPP;
   temp.equipment = temp.equipment || {};
   temp.equipment[slot] = { ...item };
   recomputePlayerTotals(temp);
   const next = computePP(temp, gatherDefense(temp));
-  const nextTotal = W_O * next.OPP + next.DPP;
+  const nextTotal = W_O * next.OPP + W_D * next.DPP;
   return {
     opp: next.OPP - prev.OPP,
     dpp: next.DPP - prev.DPP,

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -12,7 +12,7 @@ import {
   updateActivitySelectors,
   renderActiveActivity,
 } from '../../activity/ui/activityUI.js';
-import { computePP, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, gatherDefense, W_O, W_D } from '../../../engine/pp.js';
 import { logPPEvent } from '../../../engine/ppLog.js';
 import { configReport, featureFlags, devShowPP } from '../../../config.js';
 
@@ -439,8 +439,8 @@ async function buildTree() {
       }
       const after = computePP(sim, gatherDefense(sim));
       const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-      const beforePP = W_O * before.OPP + before.DPP;
-      const afterPP = W_O * after.OPP + after.DPP;
+      const beforePP = W_O * before.OPP + W_D * before.DPP;
+      const afterPP = W_O * after.OPP + W_D * after.DPP;
       lines.push(
         `DEV:PP ${fmt(after.OPP - before.OPP)}/${fmt(after.DPP - before.DPP)}/${fmt(
           afterPP - beforePP
@@ -475,8 +475,8 @@ async function buildTree() {
         if (devShowPP && beforePP) {
           const afterPP = computePP(S, gatherDefense(S));
           const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-          const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
-          const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
+          const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+          const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
           console.log(
             `DEV:PP ${fmt(afterPP.OPP - beforePP.OPP)}/${fmt(afterPP.DPP - beforePP.DPP)}/${fmt(
               nextTotal - prevTotal

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -18,7 +18,7 @@ import { isProd, devShowPP } from '../../../config.js';
 import { mountAllFeatureUIs } from '../../index.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import { renderPillIcons } from '../../alchemy/ui/pillIcons.js';
-import { computePP, breakthroughPPSnapshot, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, breakthroughPPSnapshot, gatherDefense, W_O, W_D } from '../../../engine/pp.js';
 import { logPPEvent } from '../../../engine/ppLog.js';
 
 let pendingAstralUnlock = false;
@@ -515,8 +515,8 @@ export function updateBreakthrough() {
         const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
         const opp = afterPP.OPP - beforePP.OPP;
         const dpp = afterPP.DPP - beforePP.DPP;
-        const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
-        const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
+        const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+        const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
         const pp = nextTotal - prevTotal;
         console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Breakthrough`);
       }

--- a/src/lib/power/ehp.js
+++ b/src/lib/power/ehp.js
@@ -31,3 +31,27 @@ export function dEhpFromQiRegenPct(pct = 0) {
 export function dEhpFromMaxQiPct(pct = 0) {
   return pct / 100;
 }
+
+export function effectiveHP({
+  hp = 0,
+  armor = 0,
+  dodge = DODGE_BASE,
+  resists = {},
+  qiRegenPct = 0,
+  maxQiPct = 0,
+  accuracy = ACCURACY_BASE,
+} = {}) {
+  if (hp <= 0) return 0;
+  const dr = drFromArmor(armor);
+  const denom = 1 - dr;
+  if (denom <= 0) return Infinity;
+  const baseEhp = hp / denom;
+  let bonusPct = 0;
+  for (const val of Object.values(resists || {})) {
+    bonusPct += dEhpFromRes(val);
+  }
+  bonusPct += dEhpFromDodge(dodge, accuracy);
+  bonusPct += dEhpFromQiRegenPct(qiRegenPct);
+  bonusPct += dEhpFromMaxQiPct(maxQiPct);
+  return baseEhp * (1 + bonusPct);
+}


### PR DESCRIPTION
## Summary
- add a shared Forest Rabbit baseline definition and reuse it when computing power comparisons
- convert player and enemy PP calculations to percent differences against the baseline while preserving raw DPS/EHP data
- update all weighted PP consumers, combat tuning, and UI colors to use the new shared scale

## Testing
- npm run lint:balance

------
https://chatgpt.com/codex/tasks/task_e_68c85bd840888326867009e580d30034