### PR TITLE
Implement combat Qi regen and ability cost reductions

### DIFF
--- a/index.html
+++ b/index.html
@@ -903,6 +903,7 @@
                 <div class="stat"><span>Cooldown Reduction</span><span id="stat-cooldownReduction">0%</span></div>
                 <div class="stat"><span>Adventure Speed</span><span id="stat-adventureSpeed">1.00</span></div>
                 <div class="stat"><span>Qi Shield Efficiency</span><span id="stat-qiShieldEfficiency">100%</span></div>
+                <div class="stat"><span>Qi Regeneration</span><span id="stat-qiRegenPerSec">0.0/s</span></div>
                 <div class="stat"><span>Qi Cost Reduction</span><span id="stat-qiCostReduction">0%</span></div>
                 <div class="stat"><span>Forge Speed</span><span id="stat-forgeSpeed">0%</span></div>
                 <div class="stat"><span>Spell Damage</span><span id="stat-spellDamage">0%</span></div>

--- a/src/features/ability/mutators.js
+++ b/src/features/ability/mutators.js
@@ -9,6 +9,7 @@ import { performAttack } from '../combat/attack.js';
 import { mergeStats } from '../../shared/utils/stats.js';
 import { chanceToHit, DODGE_BASE } from '../combat/hit.js';
 import { getStatEffects, calculatePlayerAttackSnapshot, qCap } from '../progression/selectors.js';
+import { getAbilityQiCost } from './selectors.js';
 import { emit } from '../../shared/events.js';
 
 export function tryCastAbility(abilityKey, state = S) {
@@ -23,7 +24,8 @@ export function tryCastAbility(abilityKey, state = S) {
   const mods = state.abilityMods?.[abilityKey] || {};
   const cd = state.abilityCooldowns?.[abilityKey] || 0;
   if (cd > 0) return false;
-  if (state.qi < ability.costQi) return false;
+  const qiCost = getAbilityQiCost(abilityKey, state);
+  if (state.qi < qiCost) return false;
   if (!state.abilityCooldowns) state.abilityCooldowns = {};
   const isSpell = ability.tags?.includes('spell');
   const speedMult =
@@ -58,6 +60,7 @@ export function tryCastAbility(abilityKey, state = S) {
     enqueue();
     processAbilityQueue(state);
   }
+  state.qi = Math.max(0, state.qi - qiCost);
   return true;
 }
 

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -1,9 +1,9 @@
 import { S, save } from '../../shared/state.js';
-import { calculatePlayerAttackSnapshot, calculatePlayerAttackRate, qCap } from '../progression/selectors.js';
+import { calculatePlayerAttackSnapshot, calculatePlayerAttackRate, qCap, getLawBonuses } from '../progression/selectors.js';
 import { initializeFight, processAttack } from '../combat/mutators.js';
 import { refillShieldFromQi, ARMOR_K, ARMOR_CAP } from '../combat/logic.js';
 import { getEquippedWeapon } from '../inventory/selectors.js';
-import { getAbilitySlots, getAbilityDamage } from '../ability/selectors.js';
+import { getAbilitySlots, getAbilityDamage, getAbilityQiCost } from '../ability/selectors.js';
 import { getWeaponProficiencyBonuses } from '../proficiency/selectors.js';
 import { rollLoot, toLootTableKey } from '../loot/logic.js'; // WEAPONS-INTEGRATION
 import { WEAPONS } from '../weaponGeneration/data/weapons.js'; // WEAPONS-INTEGRATION
@@ -14,6 +14,7 @@ import { performAttack } from '../combat/attack.js'; // STATUS-REFORM
 import { tickStunDecay, initStun, STUN_THRESHOLD, DECAY_PER_SECOND } from '../../engine/combat/stun.js';
 import { chanceToHit, DODGE_BASE } from '../combat/hit.js';
 import { tryCastAbility, processAbilityQueue } from '../ability/mutators.js';
+import { updateQiDerivedStats } from '../inventory/logic.js';
 import { ENEMY_DATA } from './data/enemies.js';
 import { setText, setFill, log } from '../../shared/utils/dom.js';
 import { on, emit } from '../../shared/events.js';
@@ -547,6 +548,15 @@ function hideAbilityTooltip() {
   tooltipFromTouch = false;
 }
 
+function formatQiCost(cost) {
+  if (!Number.isFinite(cost)) return '0';
+  const rounded = Math.round(cost * 10) / 10;
+  if (Math.abs(rounded - Math.round(rounded)) < 0.05) {
+    return Math.round(rounded).toString();
+  }
+  return rounded.toFixed(1);
+}
+
 function showAbilityTooltip(anchor, abilityKey, fromTouch = false) {
   hideAbilityTooltip();
   const tooltip = document.createElement('div');
@@ -603,7 +613,12 @@ function abilityDetailsHTML(key) {
   );
   const dmg = getAbilityDamage(key, S);
   const rows = [];
-  rows.push(`<div class="stat-row"><span class="label">Qi Cost</span><span class="value">${def.costQi}</span></div>`);
+  const qiCost = getAbilityQiCost(key, S);
+  const formattedCost = formatQiCost(qiCost);
+  const costLabel = Math.abs(qiCost - def.costQi) > 0.05
+    ? `${formattedCost} (base ${def.costQi})`
+    : formattedCost;
+  rows.push(`<div class="stat-row"><span class="label">Qi Cost</span><span class="value">${costLabel}</span></div>`);
   if (castTimeMs > 0)
     rows.push(`<div class="stat-row"><span class="label">Cast</span><span class="value">${(castTimeMs / 1000).toFixed(2)}s</span></div>`);
   rows.push(`<div class="stat-row"><span class="label">Cooldown</span><span class="value">${(cooldownMs / 1000).toFixed(2)}s</span></div>`);
@@ -654,6 +669,7 @@ export function updateAbilityBar() {
           (1 + (S.astralTreeBonuses?.cooldownPct || 0) / 100) /
           speedMult
       );
+      const qiCost = getAbilityQiCost(slot.abilityKey, S);
       let content = `
         <div class="ability-title">
           <div class="ability-name">${def.displayName}</div>
@@ -661,7 +677,7 @@ export function updateAbilityBar() {
           ${castLine}
         </div>
         <div class="ability-icon">${renderAbilityIcon(def.icon)}</div>
-        <div class="qi-badge">${def.costQi} Qi</div>
+        <div class="qi-badge">${formatQiCost(qiCost)} Qi</div>
         <div class="keybind">[${i + 1}]</div>
       `;
       if (slot.cooldownRemainingMs > 0) {
@@ -741,7 +757,6 @@ export function updateAbilityBar() {
           }
           hideAbilityTooltip();
           if (tryCastAbility(data.abilityKey)) {
-            S.qi -= ABILITIES[data.abilityKey].costQi;
             flashAbilityCard(i + 1);
             updateAbilityBar();
           } else {
@@ -758,7 +773,6 @@ export function updateAbilityBar() {
         }
         hideAbilityTooltip();
         if (tryCastAbility(data.abilityKey)) {
-          S.qi -= ABILITIES[data.abilityKey].costQi;
           flashAbilityCard(i + 1);
           updateAbilityBar();
         } else {
@@ -810,6 +824,19 @@ export function updateAdventureCombat() {
     }
     const deltaTime = (now - (S.adventure.lastCombatTick || now)) / 1000; // STATUS-REFORM
     S.adventure.lastCombatTick = now; // STATUS-REFORM
+    updateQiDerivedStats(S);
+    const lawRegenMult = getLawBonuses(S).qiRegen || 1;
+    const regenRate = (S.derivedStats?.qiRegenPerSec || 0) * lawRegenMult;
+    const combatPaused =
+      S.adventure?.combatPaused === true ||
+      (S.adventure?.combatPausedUntil || 0) > now;
+    if (!combatPaused && regenRate > 0 && deltaTime > 0) {
+      const gained = regenRate * deltaTime;
+      if (gained > 0) {
+        const cap = qCap(S);
+        S.qi = Math.min(cap, (S.qi || 0) + gained);
+      }
+    }
     tickStunDecay(S, deltaTime, now); // STATUS-REFORM
     S.adventure.playerStunBar = S.stun?.value || 0; // STATUS-REFORM
     if (S.adventure.currentEnemy) {
@@ -1844,7 +1871,6 @@ document.addEventListener('keydown', e => {
     const slot = slots[num - 1];
     if (slot?.abilityKey) {
       if (tryCastAbility(slot.abilityKey)) {
-        S.qi -= ABILITIES[slot.abilityKey].costQi;
         flashAbilityCard(num);
         updateAbilityBar();
       } else {

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -175,10 +175,15 @@ const STAT_INFO = {
     desc: 'Shield gained per point of Qi when refilling.',
     calc: 'Base 100% +1% per Mind level',
   },
+  qiRegenPerSec: {
+    name: 'Qi Regeneration',
+    desc: 'Qi recovered per second during combat.',
+    calc: 'Base scales with Mind plus bonuses from manuals, gear, and laws',
+  },
   qiCostReduction: {
     name: 'Qi Cost Reduction',
     desc: 'Reduces Qi cost of abilities.',
-    calc: 'Bonuses from gear, manuals and laws',
+    calc: 'Bonuses from Mind, gear, manuals and laws',
   },
   forgeSpeed: {
     name: 'Forge Speed',
@@ -336,11 +341,17 @@ function renderStats() {
       const cost = qiCostPerShield(mind);
       return QI_PER_SHIELD_BASE / cost;
     }, format: v => `${(v * 100).toFixed(0)}%` },
+    { id: 'qiRegenPerSec', value: () => {
+      const base = S.derivedStats?.qiRegenPerSec || 0;
+      const lawMult = getLawBonuses(S).qiRegen || 1;
+      return base * lawMult;
+    }, format: v => `${v.toFixed(1)}/s` },
     { id: 'qiCostReduction', value: () => {
-      const pct = S.derivedStats?.qiCost || 0;
+      const derived = S.derivedStats?.qiCostReductionPct || 0;
       const lawMult = getLawBonuses(S).qiCost || 1;
-      const total = (1 + pct / 100) * lawMult;
-      return 1 - total;
+      const derivedMult = Math.max(0, 1 - derived / 100);
+      const totalMult = Math.max(0, derivedMult * lawMult);
+      return 1 - totalMult;
     }, format: v => `${(v * 100).toFixed(1)}%` },
     { id: 'forgeSpeed', value: () => getAgilityBonuses(S).forgeSpeed - 1, format: v => `${(v * 100).toFixed(0)}%` },
     { id: 'spellDamage', value: () => S.derivedStats?.spellDamage || 0, format: v => `${v.toFixed(1)}%` },

--- a/src/features/mind/logic.js
+++ b/src/features/mind/logic.js
@@ -5,6 +5,7 @@
 
 import { unlockRecipe } from '../alchemy/mutators.js';
 import { isAttributeStat } from '../../shared/utils/stats.js';
+import { updateQiDerivedStats } from '../inventory/logic.js';
 
 export function calcFromProficiency(profXp) {
   return Math.max(0, profXp) * 0.25;
@@ -143,5 +144,7 @@ export function applyManualEffects(player, manual, level) {
       player[key] = (player[key] || 0) + val;
     }
   }
+
+  updateQiDerivedStats(player);
 }
 

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -41,6 +41,8 @@ export const defaultState = () => {
     armor: 0,           // Total armor from gear and bonuses
     accuracy: ACCURACY_BASE,        // Chance to hit with attacks
     dodge: DODGE_BASE,          // Chance to avoid attacks
+    qiRegenPerSec: 0,          // Combat Qi regeneration from stats
+    qiCostReductionPct: 0,     // Percentage reduction to ability Qi costs
     stunBuildMult: 0,           // Bonus stun build applied by attacker
     stunDurationMult: 0,        // Bonus stun duration applied by attacker
     stunResist: 0,              // Resistance to stun effects


### PR DESCRIPTION
## Summary
- derive combat Qi regeneration and ability cost reduction stats from Mind, manuals, and equipment for consistent reuse
- factor the new cost reduction into ability casting and UI, including tooltips and cost badges
- regenerate Qi periodically during combat and surface the current regen and cost bonuses in the character panel

## Testing
- npm run validate *(fails: pre-existing AI enforcement violations reported by the validator)*

------
https://chatgpt.com/codex/tasks/task_e_68c861ef53c083269a796a8e73f487a5