### PR TITLE
Align PP calculations to Forest Rabbit baseline

### DIFF
--- a/src/engine/enemyPP.js
+++ b/src/engine/enemyPP.js
@@ -1,5 +1,6 @@
 import { drFromArmor, dEhpFromHP, dEhpFromRes, dEhpFromDodge } from '../lib/power/ehp.js';
 import { DODGE_BASE } from '../features/combat/hit.js';
+import { BASELINE_HP, BASELINE_DPS } from '../lib/power/baseline.js';
 import { W_O, W_D } from './pp.js';
 
 export function enemyEHP(enemy = {}) {
@@ -13,14 +14,17 @@ export function enemyEHP(enemy = {}) {
     ehpPct += dEhpFromRes(val);
   }
   ehpPct += dEhpFromDodge(dodge);
-  return (1 + ehpPct) * 100;
+  const baseHp = BASELINE_HP || 1;
+  return (1 + ehpPct) * baseHp;
 }
 
 export function enemyPP(enemy = {}) {
   const dps = (enemy.attack || 0) * (enemy.attackRate || 1);
-  const E_OPP = dps;
+  const baseDps = BASELINE_DPS || 1;
+  const E_OPP = baseDps > 0 ? ((dps / baseDps) - 1) * 100 : 0;
   const ehp = enemyEHP(enemy);
-  const E_DPP = ((ehp / 100) - 1) * 100 * W_D;
-  const EPP = W_O * E_OPP + E_DPP;
-  return { EPP, E_OPP, E_DPP, EHP: ehp };
+  const baseHp = BASELINE_HP || 1;
+  const E_DPP = baseHp > 0 ? ((ehp / baseHp) - 1) * 100 : 0;
+  const EPP = W_O * E_OPP + W_D * E_DPP;
+  return { EPP, E_OPP, E_DPP, EHP: ehp, DPS: dps };
 }

--- a/src/engine/ppLog.js
+++ b/src/engine/ppLog.js
@@ -1,4 +1,4 @@
-import { computePP, gatherDefense, W_O } from './pp.js';
+import { computePP, gatherDefense, W_O, W_D } from './pp.js';
 
 /**
  * Log a Power Points event. `meta.before` can include a pre-change
@@ -12,10 +12,10 @@ export function logPPEvent(state, kind, meta = {}) {
   if (!state) return;
   const before = meta.before;
   const after = computePP(state, gatherDefense(state));
-  const afterTotal = W_O * after.OPP + after.DPP;
+  const afterTotal = W_O * after.OPP + W_D * after.DPP;
   let diff;
   if (before) {
-    const beforeTotal = W_O * before.OPP + before.DPP;
+    const beforeTotal = W_O * before.OPP + W_D * before.DPP;
     diff = {
       OPP: after.OPP - before.OPP,
       DPP: after.DPP - before.DPP,

--- a/src/features/adventure/logic.js
+++ b/src/features/adventure/logic.js
@@ -26,7 +26,7 @@ import { ZONES as ZONE_IDS } from './data/zoneIds.js';
 import { addSessionLoot, claimSessionLoot, forfeitSessionLoot } from '../loot/mutators.js'; // EQUIP-CHAR-UI
 import { updateLootTab } from '../loot/ui/lootTab.js';
 import { renderPillIcons } from '../alchemy/ui/pillIcons.js';
-import { getCurrentPP, gatherDefense } from '../../engine/pp.js';
+import { computePP, getCurrentPP, gatherDefense } from '../../engine/pp.js';
 import { enemyPP, enemyEHP } from '../../engine/enemyPP.js';
 import {
   playSlashArc,
@@ -1319,7 +1319,9 @@ export function startBossCombat() {
   const playerPower = getCurrentPP(S);
   const dp = gatherDefense(S);
   const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const playerDps = Number.isFinite(playerPower?.dps)
+    ? playerPower.dps
+    : computePP(S, dp).dps || 0;
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;
@@ -1387,7 +1389,9 @@ export function startAdventureCombat() {
   const playerPower = getCurrentPP(S);
   const dp = gatherDefense(S);
   const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const playerDps = Number.isFinite(playerPower?.dps)
+    ? playerPower.dps
+    : computePP(S, dp).dps || 0;
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;
@@ -1469,7 +1473,9 @@ function startDungeonEncounter() {
   const playerPower = getCurrentPP(S);
   const dp = gatherDefense(S);
   const playerEhp = enemyEHP({ hpMax: dp.hp, armor: dp.armor, dodge: dp.dodge - DODGE_BASE, resists: dp.resists });
-  const playerDps = playerPower.OPP * calculatePlayerAttackRate(S);
+  const playerDps = Number.isFinite(playerPower?.dps)
+    ? playerPower.dps
+    : computePP(S, dp).dps || 0;
   enemyObj = tuneEnemyStats(enemyObj, playerDps, playerEhp);
   const pow = enemyPP(enemyObj);
   S.adventure.inCombat = true;

--- a/src/features/inventory/mutators.js
+++ b/src/features/inventory/mutators.js
@@ -2,7 +2,7 @@ import { S, save } from '../../shared/state.js';
 import { WEAPONS } from '../weaponGeneration/data/weapons.js';
 import { emit } from '../../shared/events.js';
 import { recomputePlayerTotals, canEquip } from './logic.js';
-import { computePP, gatherDefense, W_O } from '../../engine/pp.js';
+import { computePP, gatherDefense, W_O, W_D } from '../../engine/pp.js';
 import { logPPEvent } from '../../engine/ppLog.js';
 import { devShowPP } from '../../config.js';
 export { usePill } from '../alchemy/mutators.js'; // deprecated shim
@@ -55,7 +55,7 @@ export function equipItem(item, slot = null, state = S) {
   if (!info) return false;
   const slotKey = info.slot;
   const prevPP = computePP(state, gatherDefense(state));
-  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
+  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
   const existing = state.equipment[slotKey];
   const existingKey = typeof existing === 'string' ? existing : existing?.key;
   if (existingKey && existingKey !== 'fist') addToInventory(existing, state);
@@ -65,7 +65,7 @@ export function equipItem(item, slot = null, state = S) {
   console.log('[equip]', 'slot→', slotKey, 'item→', item.key);
   recomputePlayerTotals(state);
   const nextPP = computePP(state, gatherDefense(state));
-  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
+  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;
@@ -84,14 +84,14 @@ export function unequip(slot, state = S) {
   const item = state.equipment[slot];
   if (!item) return;
   const prevPP = computePP(state, gatherDefense(state));
-  const prevTotal = W_O * prevPP.OPP + prevPP.DPP;
+  const prevTotal = W_O * prevPP.OPP + W_D * prevPP.DPP;
   const key = typeof item === 'string' ? item : item.key;
   if (key !== 'fist') addToInventory(item, state);
   state.equipment[slot] = null;
   console.log('[equip]', 'slot→', slot, 'item→', 'none');
   recomputePlayerTotals(state);
   const nextPP = computePP(state, gatherDefense(state));
-  const nextTotal = W_O * nextPP.OPP + nextPP.DPP;
+  const nextTotal = W_O * nextPP.OPP + W_D * nextPP.DPP;
   if (devShowPP) {
     const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
     const opp = nextPP.OPP - prevPP.OPP;

--- a/src/features/inventory/ui/CharacterPanel.js
+++ b/src/features/inventory/ui/CharacterPanel.js
@@ -8,7 +8,7 @@ import { GEAR_ICONS } from '../../gearGeneration/data/gearIcons.js';
 import { usePill } from '../../alchemy/mutators.js';
 import { ALCHEMY_RECIPES } from '../../alchemy/data/recipes.js';
 import { PILL_LINES } from '../../alchemy/data/pills.js';
-import { computePP, getCurrentPP, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, getCurrentPP, gatherDefense, W_O, W_D } from '../../../engine/pp.js';
 import { downloadPPLogCSV } from '../../../engine/ppLog.js';
 import { calculatePlayerAttackSnapshot } from '../../progression/selectors.js';
 import { qiCostPerShield, QI_PER_SHIELD_BASE } from '../../combat/logic.js';
@@ -249,12 +249,12 @@ function computeItemPPDelta(item, state = S) {
   const temp = JSON.parse(JSON.stringify(state));
   recomputePlayerTotals(temp);
   const prev = computePP(temp, gatherDefense(temp));
-  const prevTotal = W_O * prev.OPP + prev.DPP;
+  const prevTotal = W_O * prev.OPP + W_D * prev.DPP;
   temp.equipment = temp.equipment || {};
   temp.equipment[slot] = { ...item };
   recomputePlayerTotals(temp);
   const next = computePP(temp, gatherDefense(temp));
-  const nextTotal = W_O * next.OPP + next.DPP;
+  const nextTotal = W_O * next.OPP + W_D * next.DPP;
   return {
     opp: next.OPP - prev.OPP,
     dpp: next.DPP - prev.DPP,

--- a/src/features/progression/ui/astralTree.js
+++ b/src/features/progression/ui/astralTree.js
@@ -12,7 +12,7 @@ import {
   updateActivitySelectors,
   renderActiveActivity,
 } from '../../activity/ui/activityUI.js';
-import { computePP, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, gatherDefense, W_O, W_D } from '../../../engine/pp.js';
 import { logPPEvent } from '../../../engine/ppLog.js';
 import { configReport, featureFlags, devShowPP } from '../../../config.js';
 
@@ -439,8 +439,8 @@ async function buildTree() {
       }
       const after = computePP(sim, gatherDefense(sim));
       const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-      const beforePP = W_O * before.OPP + before.DPP;
-      const afterPP = W_O * after.OPP + after.DPP;
+      const beforePP = W_O * before.OPP + W_D * before.DPP;
+      const afterPP = W_O * after.OPP + W_D * after.DPP;
       lines.push(
         `DEV:PP ${fmt(after.OPP - before.OPP)}/${fmt(after.DPP - before.DPP)}/${fmt(
           afterPP - beforePP
@@ -475,8 +475,8 @@ async function buildTree() {
         if (devShowPP && beforePP) {
           const afterPP = computePP(S, gatherDefense(S));
           const fmt = v => (v >= 0 ? '+' : '') + Math.round(v);
-          const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
-          const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
+          const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+          const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
           console.log(
             `DEV:PP ${fmt(afterPP.OPP - beforePP.OPP)}/${fmt(afterPP.DPP - beforePP.DPP)}/${fmt(
               nextTotal - prevTotal

--- a/src/features/progression/ui/realm.js
+++ b/src/features/progression/ui/realm.js
@@ -18,7 +18,7 @@ import { isProd, devShowPP } from '../../../config.js';
 import { mountAllFeatureUIs } from '../../index.js';
 import { startActivity as startActivityMut, stopActivity as stopActivityMut } from '../../activity/mutators.js';
 import { renderPillIcons } from '../../alchemy/ui/pillIcons.js';
-import { computePP, breakthroughPPSnapshot, gatherDefense, W_O } from '../../../engine/pp.js';
+import { computePP, breakthroughPPSnapshot, gatherDefense, W_O, W_D } from '../../../engine/pp.js';
 import { logPPEvent } from '../../../engine/ppLog.js';
 
 let pendingAstralUnlock = false;
@@ -515,8 +515,8 @@ export function updateBreakthrough() {
         const fmt = n => (n >= 0 ? '+' : '') + n.toFixed(2);
         const opp = afterPP.OPP - beforePP.OPP;
         const dpp = afterPP.DPP - beforePP.DPP;
-        const prevTotal = W_O * beforePP.OPP + beforePP.DPP;
-        const nextTotal = W_O * afterPP.OPP + afterPP.DPP;
+        const prevTotal = W_O * beforePP.OPP + W_D * beforePP.DPP;
+        const nextTotal = W_O * afterPP.OPP + W_D * afterPP.DPP;
         const pp = nextTotal - prevTotal;
         console.log(`PP Δ: ${fmt(pp)} (O${fmt(opp)} / D${fmt(dpp)}) — source: Breakthrough`);
       }

--- a/src/lib/power/baseline.js
+++ b/src/lib/power/baseline.js
@@ -1,0 +1,26 @@
+import { ENEMY_DATA } from '../../features/adventure/data/enemies.js';
+
+export const BASELINE_ENEMY_KEY = 'Forest Rabbit';
+
+function toNumber(value, fallback = 0) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+const baselineEnemy = ENEMY_DATA?.[BASELINE_ENEMY_KEY] ?? {};
+
+const rawHp = toNumber(baselineEnemy.hpMax ?? baselineEnemy.hp, 0);
+export const BASELINE_HP = rawHp > 0 ? rawHp : 1;
+
+const rawAttack = toNumber(baselineEnemy.attack, 0);
+const rawRate = toNumber(baselineEnemy.attackRate, 1) || 1;
+const rawDps = rawAttack * rawRate;
+export const BASELINE_DPS = rawDps > 0 ? rawDps : 1;
+
+export function getBaselineEnemy() {
+  return baselineEnemy;
+}
+

--- a/src/lib/power/ehp.js
+++ b/src/lib/power/ehp.js
@@ -1,4 +1,5 @@
 import { ACCURACY_BASE, DODGE_BASE, chanceToHit } from '../../features/combat/hit.js';
+import { BASELINE_HP } from './baseline.js';
 
 export function drFromArmor(armor = 0) {
   if (armor <= 0) return 0;
@@ -7,7 +8,8 @@ export function drFromArmor(armor = 0) {
 
 export function dEhpFromHP(hp = 0, dr = 0) {
   if (hp <= 0) return 0;
-  const baseHp = 100;
+  const baseHp = BASELINE_HP || 1;
+  if (baseHp <= 0) return 0;
   const ehp = hp / (1 - dr);
   return ehp / baseHp - 1;
 }


### PR DESCRIPTION
## Summary
- introduce a shared Forest Rabbit baseline so player and enemy PP math compares damage and durability to the same reference.
- recalculate player/enemy offensive and defensive PP as percentage deltas from the baseline, exposing raw DPS/EHP where needed and updating consumers to weight totals with both PP coefficients.
- adjust adventure enemy tuning and PP logs/UI to consume the new DPS value and weighted totals.

## Testing
- npm run lint:balance

------
https://chatgpt.com/codex/tasks/task_e_68c9a7958f9083268ad32bfb087ba01b