### PR TITLE
Add stage enemy power reference column to PP log export

### DIFF
--- a/src/engine/ppLog.js
+++ b/src/engine/ppLog.js
@@ -1,4 +1,81 @@
 import { computePP, gatherDefense, W_O } from './pp.js';
+import { enemyPP } from './enemyPP.js';
+import { ENEMY_DATA } from '../features/adventure/data/enemies.js';
+import { ZONES } from '../features/adventure/data/zones.js';
+
+const STAGE_REFERENCE_LIMIT = 5;
+
+function csvEscape(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (!/[",\n]/.test(str)) return str;
+  return '"' + str.replace(/"/g, '""') + '"';
+}
+
+function stageEnemyPowerReferences(limit = STAGE_REFERENCE_LIMIT) {
+  const stages = [];
+  for (let stage = 1; stage <= limit; stage++) {
+    const zone = ZONES[stage - 1];
+    const entry = { stage };
+    if (!zone) {
+      stages.push(entry);
+      continue;
+    }
+    const firstEnemyArea = zone.areas?.find(area => !area.isBoss);
+    const bossArea = zone.areas?.find(area => area.isBoss);
+    const readEnemyPower = enemyKey => {
+      if (!enemyKey) return null;
+      const data = ENEMY_DATA[enemyKey];
+      if (!data) return null;
+      const power = enemyPP(data);
+      return {
+        name: data.name || enemyKey,
+        OPP: power.E_OPP,
+        DPP: power.E_DPP,
+      };
+    };
+    if (stage > 1) {
+      entry.enemy = readEnemyPower(firstEnemyArea?.enemy);
+    }
+    entry.boss = readEnemyPower(bossArea?.enemy);
+    stages.push(entry);
+  }
+  return stages;
+}
+
+function formatStageEnemySummary(stages) {
+  const fmt = value => (typeof value === 'number' ? value.toFixed(2) : '--');
+  return stages
+    .map(entry => {
+      const parts = [];
+      if (entry.stage === 1) {
+        if (entry.boss) {
+          parts.push(
+            `Stage 1 Boss (${entry.boss.name}): OPP ${fmt(entry.boss.OPP)} / DPP ${fmt(entry.boss.DPP)}`
+          );
+        } else {
+          parts.push('Stage 1 Boss: n/a');
+        }
+      } else {
+        if (entry.enemy) {
+          parts.push(
+            `Stage ${entry.stage} Enemy (${entry.enemy.name}): OPP ${fmt(entry.enemy.OPP)} / DPP ${fmt(entry.enemy.DPP)}`
+          );
+        } else {
+          parts.push(`Stage ${entry.stage} Enemy: n/a`);
+        }
+        if (entry.boss) {
+          parts.push(
+            `Stage ${entry.stage} Boss (${entry.boss.name}): OPP ${fmt(entry.boss.OPP)} / DPP ${fmt(entry.boss.DPP)}`
+          );
+        } else {
+          parts.push(`Stage ${entry.stage} Boss: n/a`);
+        }
+      }
+      return parts.join(' | ');
+    })
+    .join(' || ');
+}
 
 /**
  * Log a Power Points event. `meta.before` can include a pre-change
@@ -40,9 +117,20 @@ export function logPPEvent(state, kind, meta = {}) {
  */
 export function downloadPPLogCSV(state) {
   const log = state.ppLog || [];
-  const rows = [
-    'time,kind,PP,OPP,DPP,deltaPP,deltaOPP,deltaDPP,meta'
+  const stageSummary = formatStageEnemySummary(stageEnemyPowerReferences());
+  const header = [
+    'time',
+    'kind',
+    'PP',
+    'OPP',
+    'DPP',
+    'deltaPP',
+    'deltaOPP',
+    'deltaDPP',
+    'meta',
+    'stageEnemyPower',
   ];
+  const rows = [header.join(',')];
   for (const e of log) {
     const { time, kind, after, diff, meta } = e;
     rows.push([
@@ -54,8 +142,9 @@ export function downloadPPLogCSV(state) {
       diff?.PP ?? '',
       diff?.OPP ?? '',
       diff?.DPP ?? '',
-      JSON.stringify(meta || {})
-    ].join(','));
+      JSON.stringify(meta || {}),
+      stageSummary,
+    ].map(csvEscape).join(','));
   }
   const blob = new Blob([rows.join('\n')], { type: 'text/csv' });
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- add an adventure stage enemy power reference column to the PP log CSV export, covering stage 1 boss and stages 2–5 enemy/boss pairs
- escape CSV fields when writing log rows so the new summary and existing meta data import cleanly in spreadsheets

## Testing
- npm run lint:balance

------
https://chatgpt.com/codex/tasks/task_e_68c9a7f523c08326a4444f85da6d80be