### PR TITLE
Add enemy ability system and integrate into adventure combat

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -132,9 +132,9 @@ way-of-ascension/
 │   │   │   ├── data/
 │   │   │   │   ├── _balance.contract.js
 │   │   │   │   ├── ailments.js
+│   │   │   │   ├── enemyAbilities.js
 │   │   │   │   ├── status.js
-│   │   │   │   ├── statusesByElement.js
-│   │   │   │   └── ailments.js
+│   │   │   │   └── statusesByElement.js
 │   │   │   ├── hit.js
 │   │   │   ├── logic.js
 │   │   │   ├── migrations.js
@@ -1130,11 +1130,16 @@ Paths added:
 - `src/features/combat/data/status.js` – Definitions for all status effects.
 - `src/features/combat/data/statusesByElement.js` – Maps elements to their default status applications.
 - `src/features/combat/data/ailments.js` – Ailment definitions and their effects.
+- `src/features/combat/data/enemyAbilities.js` – Catalog of enemy ability templates with cooldowns, triggers, and effect metadata.
 - `src/features/combat/ui/combatStats.js` – Displays player and enemy combat statistics.
 
 #### `src/features/combat/data/ailments.js` - Ailment Definitions
 **Purpose**: Enumerates poison, burn, chill and other ailments with durations, stack limits and effect callbacks.
 **When to modify**: Add new ailments or adjust existing damage-over-time and debuff behaviour.
+
+#### `src/features/combat/data/enemyAbilities.js` - Enemy Ability Templates
+**Purpose**: Defines reusable enemy ability configurations (damage scaling, status application, cooldowns, health gates) referenced by adventure combat logic.
+**When to modify**: Introduce new enemy specials or tweak existing ability behaviour such as cooldowns, damage ratios, or status payloads.
 
 ### Karma Feature (`src/features/karma/`)
 - `src/features/karma/state.js` – Stores karma points and purchased bonuses.

--- a/src/features/adventure/data/enemies.js
+++ b/src/features/adventure/data/enemies.js
@@ -17,6 +17,7 @@ export const ENEMY_DATA = {
     attack: 4.48,
     accuracy: 50,
     attackRate: 0.9,
+    abilities: ['heavyStrike'],
     resists: { fire: 0, water: 0, wood: 0, earth: 0, metal: 0 },
     loot: { stones: 4, ore: 1 }
   },
@@ -103,12 +104,13 @@ export const ENEMY_DATA = {
 
   // === DARK FOREST ===
   // Corrupted creatures infused with shadow essence
-  'Shadow Wolf': { 
+  'Shadow Wolf': {
     name: 'Shadow Wolf',
     hp: 450,
     attack: 25,
     accuracy: 65,
     attackRate: 1.2,
+    abilities: ['shadowEnrage'],
     resists: { fire: 0, water: 0, wood: 0, earth: 0, metal: 0 },
     loot: { shadowEssence: 1, pelt: 2 },
     drops: { meat: 0.8 }
@@ -122,14 +124,15 @@ export const ENEMY_DATA = {
     resists: { fire: 0, water: 0, wood: 0, earth: 0, metal: 0 },
     loot: { corruptedWood: 2, shadowEssence: 2 } 
   },
-  'Cursed Toad': { 
+  'Cursed Toad': {
     name: 'Cursed Toad',
     hp: 540,
     attack: 40,
     accuracy: 65,
     attackRate: 1.1,
+    abilities: ['venomSpit'],
     resists: { fire: 0, water: 0, wood: 0, earth: 0, metal: 0 },
-    loot: { venom: 3, shadowEssence: 1 } 
+    loot: { venom: 3, shadowEssence: 1 }
   },
   'Thorn Beast': {
     name: 'Thorn Beast',
@@ -182,8 +185,9 @@ export const ENEMY_DATA = {
     attack: 80,
     accuracy: 65,
     attackRate: 1.1,
+    abilities: ['shadowBolt'],
     resists: { fire: 0, water: 0, wood: 0, earth: 0, metal: 0 },
-    loot: { shadowEssence: 5, arcaneTome: 1 } 
+    loot: { shadowEssence: 5, arcaneTome: 1 }
   },
 
   // === SHADOW REALM ===
@@ -194,6 +198,7 @@ export const ENEMY_DATA = {
     attack: 100,
     accuracy: 70,
     attackRate: 1.5,
+    abilities: ['shadowBolt', 'shadowEnrage', 'darkRecovery'],
     resists: { fire: 0, water: 0, wood: 0, earth: 0, metal: 0 },
     loot: { shadowEssence: 10, darkCrystal: 1, ancientRelic: 5 }
   },

--- a/src/features/combat/data/enemyAbilities.js
+++ b/src/features/combat/data/enemyAbilities.js
@@ -1,0 +1,77 @@
+export const ENEMY_ABILITIES = {
+  heavyStrike: {
+    key: 'heavyStrike',
+    name: 'Heavy Strike',
+    description: 'Delivers a crushing blow for greatly increased physical damage.',
+    actionType: 'attack',
+    cooldownMs: 9000,
+    initialDelayMs: 2000,
+    priority: 1,
+    attack: {
+      physPct: 1.6,
+      critChanceBonus: 0.1,
+    },
+    log: 'The enemy winds up for a heavy strike!',
+  },
+  venomSpit: {
+    key: 'venomSpit',
+    name: 'Venom Spit',
+    description: 'Spits venom that damages and attempts to poison the player.',
+    actionType: 'attack',
+    cooldownMs: 12000,
+    priority: 1,
+    attack: {
+      physPct: 0.6,
+    },
+    status: { key: 'poison', power: 0.7 },
+    log: 'The enemy spits a glob of venom!',
+  },
+  shadowEnrage: {
+    key: 'shadowEnrage',
+    name: 'Shadow Enrage',
+    description: 'When wounded, the enemy becomes enraged, increasing attack and speed.',
+    actionType: 'buff',
+    cooldownMs: 0,
+    healthBelowPct: 0.5,
+    once: true,
+    priority: 10,
+    buff: {
+      attackMult: 1.25,
+      attackRateMult: 1.15,
+    },
+    log: 'Shadows coil around the enemy as it becomes enraged!',
+  },
+  shadowBolt: {
+    key: 'shadowBolt',
+    name: 'Shadow Bolt',
+    description: 'Unleashes crackling metal-aspected energy that inflicts elemental damage and weakens armor.',
+    actionType: 'attack',
+    cooldownMs: 10000,
+    priority: 2,
+    attack: {
+      physPct: 0.4,
+      elemPct: { metal: 0.85 },
+      critChanceBonus: 0.05,
+    },
+    status: { key: 'ionize', power: 0.6 },
+    log: 'The enemy channels a bolt of shadowed lightning!',
+  },
+  darkRecovery: {
+    key: 'darkRecovery',
+    name: 'Dark Recovery',
+    description: 'Draws on dark energy to recover health and purge lingering ailments.',
+    actionType: 'heal',
+    cooldownMs: 20000,
+    healthBelowPct: 0.3,
+    priority: 8,
+    heal: {
+      hpPct: 0.15,
+      clearAilments: ['poison', 'burn'],
+    },
+    log: 'The enemy siphons shadows to mend its wounds!',
+  },
+};
+
+export function getEnemyAbility(key) {
+  return ENEMY_ABILITIES[key];
+}


### PR DESCRIPTION
## Summary
- add a reusable enemy ability catalog describing cooldowns, triggers, and effects
- wire adventure enemy records to ability keys and reset cooldown state when fights start/end
- update adventure combat loop to pick abilities, resolve damage/status effects, and log outcomes while documenting the new module

## Testing
- npm run validate *(fails: repository has existing AI enforcement violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a389ffc08326ae6302bf9cd9f09e