### PR TITLE
Refine sect upgrade cards layout and states

### DIFF
--- a/src/features/sect/ui/sectScreen.js
+++ b/src/features/sect/ui/sectScreen.js
@@ -2,58 +2,198 @@ import { SECT_BUILDINGS } from '../data/buildings.js';
 import { getBuildingLevel } from '../selectors.js';
 import { getBuildingCost, canUpgrade } from '../logic.js';
 import { upgradeBuilding } from '../mutators.js';
+import { REALMS } from '../../progression/data/realms.js';
 import { on } from '../../../shared/events.js';
+import { log } from '../../../shared/utils/dom.js';
 import { updateActivitySelectors } from '../../activity/ui/activityUI.js';
+
+function meetsRequirement(realm, req) {
+  if (!req) return true;
+  if (!realm) return false;
+  if (realm.tier > req.realm) return true;
+  if (realm.tier < req.realm) return false;
+  return (realm.stage || 1) >= req.stage;
+}
+
+function formatRequirement(req) {
+  if (!req) return '';
+  const realmName = REALMS[req.realm]?.name || `Realm ${req.realm}`;
+  return `${realmName} ${req.stage}`;
+}
+
+function createCostItems(cost, state) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'building-cost-items';
+  Object.entries(cost).forEach(([res, amt]) => {
+    const item = document.createElement('span');
+    const current = Number(state[res] || 0);
+    const enough = current >= amt;
+    item.className = `building-cost-item ${enough ? 'enough' : 'missing'}`;
+    item.textContent = `${amt} ${res}`;
+    wrapper.appendChild(item);
+  });
+  return wrapper;
+}
+
+function createTooltip({ card, desc, currentEffect, nextEffect, requirementText, locked, maxed }) {
+  const tooltip = document.createElement('div');
+  tooltip.className = 'building-tooltip';
+
+  const tooltipDesc = document.createElement('div');
+  tooltipDesc.className = 'building-tooltip-desc';
+  tooltipDesc.textContent = desc;
+  tooltip.appendChild(tooltipDesc);
+
+  if (currentEffect) {
+    const line = document.createElement('div');
+    line.className = 'building-tooltip-line';
+    const label = document.createElement('span');
+    label.className = 'building-tooltip-label';
+    label.textContent = 'Current';
+    line.append(label, document.createTextNode(currentEffect));
+    tooltip.appendChild(line);
+  }
+
+  if (nextEffect) {
+    const line = document.createElement('div');
+    line.className = 'building-tooltip-line';
+    const label = document.createElement('span');
+    label.className = 'building-tooltip-label';
+    label.textContent = 'Next';
+    line.append(label, document.createTextNode(nextEffect));
+    tooltip.appendChild(line);
+  } else if (maxed) {
+    const line = document.createElement('div');
+    line.className = 'building-tooltip-line';
+    const label = document.createElement('span');
+    label.className = 'building-tooltip-label';
+    label.textContent = 'Max';
+    line.append(label, document.createTextNode('Level cap reached')); 
+    tooltip.appendChild(line);
+  }
+
+  if (locked && requirementText) {
+    const line = document.createElement('div');
+    line.className = 'building-tooltip-line';
+    const label = document.createElement('span');
+    label.className = 'building-tooltip-label';
+    label.textContent = 'Requires';
+    line.append(label, document.createTextNode(requirementText));
+    tooltip.appendChild(line);
+  }
+
+  card.appendChild(tooltip);
+}
 
 function renderBuildings(state){
   const container = document.getElementById('buildingsContainer');
   if(!container) return;
   container.innerHTML = '';
+  container.classList.add('building-grid');
+  const realm = state.realm || { tier: 0, stage: 1 };
   for(const [key, b] of Object.entries(SECT_BUILDINGS)){
     const level = getBuildingLevel(key, state);
     const next = level + 1;
+    const maxed = level >= b.maxLevel;
+    const requirementText = formatRequirement(b.unlockReq);
+    const unlocked = level > 0 || meetsRequirement(realm, b.unlockReq);
+    const locked = !unlocked;
 
     const card = document.createElement('div');
     card.className = 'building-card';
+    card.tabIndex = 0;
+    card.classList.add(locked ? 'locked' : 'unlocked');
+    if (maxed) card.classList.add('maxed');
 
-    const title = document.createElement('h5');
-    title.textContent = `${b.icon} ${b.name} (Lv ${level}/${b.maxLevel})`;
-    card.appendChild(title);
-
-    const effect = document.createElement('div');
-    effect.className = 'effect';
-    if(next > b.maxLevel){
-      effect.textContent = b.effects[level]?.desc || '';
-    } else {
-      effect.textContent = b.effects[next]?.desc || '';
+    let cost = null;
+    if (!maxed) {
+      cost = getBuildingCost(key, next);
     }
-    card.appendChild(effect);
+
+    const affordable = Boolean(!locked && !maxed && cost && Object.entries(cost).every(([res, amt]) => (state[res] || 0) >= amt));
+    if (!locked && !maxed) {
+      card.classList.add(affordable ? 'affordable' : 'unaffordable');
+    }
+
+    const header = document.createElement('div');
+    header.className = 'building-header';
+
+    const icon = document.createElement('div');
+    icon.className = 'building-icon';
+    icon.textContent = b.icon;
+    header.appendChild(icon);
+
+    const info = document.createElement('div');
+    info.className = 'building-info';
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'building-name';
+    nameEl.textContent = b.name;
+    info.appendChild(nameEl);
+
+    const levelEl = document.createElement('div');
+    levelEl.className = 'building-level';
+    levelEl.textContent = `Lv ${Math.min(level, b.maxLevel)}/${b.maxLevel}`;
+    info.appendChild(levelEl);
+
+    header.appendChild(info);
+    card.appendChild(header);
+
+    const footer = document.createElement('div');
+    footer.className = 'building-footer';
 
     const costDiv = document.createElement('div');
-    costDiv.className = 'materials';
-    if(next > b.maxLevel){
+    costDiv.className = 'building-cost';
+    if (locked && level === 0) {
+      costDiv.textContent = requirementText ? `Requires ${requirementText}` : 'Locked';
+    } else if (maxed) {
       costDiv.textContent = 'Max level';
-    } else {
-      const cost = getBuildingCost(key, next);
-      costDiv.innerHTML = Object.entries(cost).map(([res, amt]) => {
-        const current = state[res] || 0;
-        const color = current >= amt ? 'var(--foundation-primary)' : '#a52a2a';
-        return `<span style="color:${color}">${current}/${amt} ${res}</span>`;
-      }).join(', ');
+    } else if (cost) {
+      const label = document.createElement('span');
+      label.className = 'building-cost-label';
+      label.textContent = 'Cost';
+      costDiv.appendChild(label);
+      costDiv.appendChild(createCostItems(cost, state));
     }
-    card.appendChild(costDiv);
+    footer.appendChild(costDiv);
 
     const btn = document.createElement('button');
     btn.className = 'btn small';
-    btn.textContent = next > b.maxLevel ? 'Max' : 'Upgrade';
-    btn.disabled = next > b.maxLevel || !canUpgrade(state.sect.buildings, state, state, key);
+    btn.textContent = maxed ? 'Max' : (locked && level === 0 ? 'Locked' : 'Upgrade');
+
+    const actionable = !locked && !maxed;
+    if (!actionable) {
+      btn.disabled = true;
+      btn.classList.add('disabled');
+    }
+
     btn.addEventListener('click', () => {
+      if (!actionable) return;
+      if (!canUpgrade(state.sect.buildings, state, state, key)) {
+        log('Not enough materials for that upgrade.', 'bad');
+        return;
+      }
       if(upgradeBuilding(state, key)){
         render(state);
         updateActivitySelectors(state);
       }
     });
-    card.appendChild(btn);
+
+    footer.appendChild(btn);
+    card.appendChild(footer);
+
+    const currentEffect = level > 0 ? b.effects[level]?.desc : null;
+    const nextEffect = !maxed ? (b.effects[next]?.desc || null) : null;
+
+    createTooltip({
+      card,
+      desc: b.desc,
+      currentEffect,
+      nextEffect,
+      requirementText,
+      locked,
+      maxed,
+    });
 
     container.appendChild(card);
   }

--- a/style.css
+++ b/style.css
@@ -3771,134 +3771,222 @@ html.reduce-motion .shield-shimmer{animation:none;}
   margin-bottom: 10px;
 }
 
-.buildings-grid {
+.building-grid,
+#buildingsContainer {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 15px;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+  align-items: stretch;
+}
+
+@media (min-width: 768px) {
+  .building-grid,
+  #buildingsContainer {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .building-grid,
+  #buildingsContainer {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 }
 
 .building-card {
-  background: linear-gradient(135deg, rgba(15, 23, 42, 0.8), rgba(30, 41, 59, 0.6));
-  border: 2px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(135deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.75));
+  border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 12px;
-  padding: 16px;
-  transition: all 0.3s ease;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 160px;
   position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+  color: var(--ink);
 }
 
 .building-card.unlocked {
-  border-color: rgba(59, 130, 246, 0.3);
+  cursor: pointer;
 }
 
 .building-card.affordable {
-  border-color: #22c55e;
-  box-shadow: 0 0 15px rgba(34, 197, 94, 0.2);
+  border-color: rgba(74, 222, 128, 0.9);
+  box-shadow: 0 0 0 2px rgba(74, 222, 128, 0.35);
+}
+
+.building-card.affordable:hover,
+.building-card.affordable:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(74, 222, 128, 0.22);
+}
+
+.building-card.unaffordable {
+  opacity: 0.65;
 }
 
 .building-card.locked {
-  opacity: 0.6;
-  border-color: rgba(239, 68, 68, 0.3);
+  background: linear-gradient(135deg, rgba(75, 85, 99, 0.55), rgba(55, 65, 81, 0.5));
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--muted);
+  cursor: not-allowed;
 }
 
-.building-card:hover.unlocked {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(59, 130, 246, 0.15);
+.building-card.locked::after {
+  content: '🔒';
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-size: 1.2rem;
+  opacity: 0.85;
 }
 
 .building-header {
   display: flex;
-  align-items: center;
-  margin-bottom: 12px;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .building-icon {
-  font-size: 24px;
-  margin-right: 12px;
-  width: 32px;
-  text-align: center;
+  font-size: 1.5rem;
+  line-height: 1;
 }
 
 .building-info {
-  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .building-name {
   font-weight: 600;
-  color: #fff;
-  font-size: 16px;
-  margin-bottom: 4px;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
 }
 
 .building-level {
-  font-size: 12px;
-  color: #a1a1aa;
-  font-weight: 500;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
 }
 
-.building-desc {
-  color: #d1d5db;
-  font-size: 13px;
-  line-height: 1.4;
-  margin-bottom: 12px;
-}
-
-.unlock-req {
-  color: #ef4444;
-  font-size: 12px;
-  font-weight: 500;
-  padding: 6px 10px;
-  background: rgba(239, 68, 68, 0.1);
-  border-radius: 6px;
-  text-align: center;
-}
-
-.current-effect {
-  color: #22c55e;
-  font-size: 13px;
-  font-weight: 500;
-  margin-bottom: 8px;
-  padding: 6px 10px;
-  background: rgba(34, 197, 94, 0.1);
-  border-radius: 6px;
-}
-
-.next-effect {
-  color: #3b82f6;
-  font-size: 13px;
-  font-weight: 500;
-  margin-bottom: 8px;
-  padding: 6px 10px;
-  background: rgba(59, 130, 246, 0.1);
-  border-radius: 6px;
+.building-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .building-cost {
-  color: #fbbf24;
-  font-size: 12px;
-  margin-bottom: 10px;
-  text-align: center;
-  font-weight: 500;
+  font-size: 0.75rem;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
-.max-level {
-  background: linear-gradient(90deg, #8b5cf6, #3b82f6);
-  color: white;
-  text-align: center;
-  padding: 8px;
-  border-radius: 6px;
+.building-cost-label {
   font-weight: 600;
-  font-size: 12px;
-  letter-spacing: 0.5px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.building-cost-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+}
+
+.building-cost-item {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(148, 163, 184, 0.15);
+  color: #e2e8f0;
+  font-size: 0.7rem;
+}
+
+.building-cost-item.enough {
+  background: rgba(74, 222, 128, 0.18);
+  color: #bbf7d0;
+}
+
+.building-cost-item.missing {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fecaca;
 }
 
 .building-card .btn {
   width: 100%;
-  margin-top: 8px;
 }
 
 .building-card .btn.disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.building-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  transform: translateX(-50%);
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 220px;
+  max-width: 260px;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.45);
+  pointer-events: none;
+  z-index: 20;
+}
+
+.building-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: rgba(15, 23, 42, 0.95);
+  border-left: 1px solid rgba(148, 163, 184, 0.3);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.building-card:hover .building-tooltip,
+.building-card:focus .building-tooltip,
+.building-card:focus-within .building-tooltip {
+  display: flex;
+}
+
+.building-tooltip-desc {
+  font-size: 0.8rem;
+  color: #f8fafc;
+  line-height: 1.4;
+}
+
+.building-tooltip-line {
+  font-size: 0.75rem;
+  color: #cbd5f5;
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.building-tooltip-label {
+  font-weight: 600;
+  color: #facc15;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  margin-top: 1px;
 }
 
 .pill{display:inline-flex; align-items:center; gap:6px; padding:6px 9px; border-radius:999px; font-size:12px; border:1px solid #23304c; background:#0b1222}
@@ -5203,10 +5291,36 @@ html.reduce-motion .log-sheet{transition:none;}
 .creature-header{display:flex;align-items:center;gap:4px}
 .creature-actions{margin-top:4px;display:flex;gap:4px}
 .creature-list .bar{height:6px;margin:4px 0}
-#buildingsContainer{display:flex;flex-wrap:wrap;gap:1rem}
-.building-card{border:1px solid #374151;background:var(--secondary-bg);padding:12px;border-radius:6px;width:100%;box-sizing:border-box}
-@media(min-width:768px){.building-card{width:40%}}
-.building-card .materials{margin:8px 0;color:#6b7280;font-size:.9rem}
+#buildingsContainer{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:12px;align-items:stretch}
+@media(min-width:768px){#buildingsContainer{grid-template-columns:repeat(3,minmax(0,1fr))}}
+@media(min-width:1280px){#buildingsContainer{grid-template-columns:repeat(4,minmax(0,1fr))}}
+.building-card{border:1px solid rgba(148,163,184,.2);background:linear-gradient(135deg,rgba(30,41,59,.85),rgba(15,23,42,.75));padding:12px;border-radius:12px;display:flex;flex-direction:column;gap:8px;min-height:160px;position:relative;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease;color:var(--ink);cursor:pointer}
+.building-card.unlocked{cursor:pointer}
+.building-card.affordable{border-color:rgba(74,222,128,.9);box-shadow:0 0 0 2px rgba(74,222,128,.35)}
+.building-card.affordable:hover,.building-card.affordable:focus-within{transform:translateY(-2px);box-shadow:0 12px 20px rgba(74,222,128,.22)}
+.building-card.unaffordable{opacity:.65}
+.building-card.locked{background:linear-gradient(135deg,rgba(75,85,99,.55),rgba(55,65,81,.5));border-color:rgba(148,163,184,.35);color:var(--muted);cursor:not-allowed}
+.building-card.locked::after{content:"🔒";position:absolute;top:8px;right:10px;font-size:1.2rem;opacity:.85}
+.building-header{display:flex;align-items:flex-start;gap:8px}
+.building-icon{font-size:1.5rem;line-height:1}
+.building-info{display:flex;flex-direction:column;gap:2px}
+.building-name{font-weight:600;font-size:.95rem;letter-spacing:.02em}
+.building-level{font-size:.7rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
+.building-footer{margin-top:auto;display:flex;flex-direction:column;gap:8px}
+.building-cost{font-size:.75rem;color:var(--muted);display:flex;flex-direction:column;gap:4px}
+.building-cost-label{font-weight:600;font-size:.7rem;text-transform:uppercase;letter-spacing:.08em}
+.building-cost-items{display:flex;flex-wrap:wrap;gap:4px 6px}
+.building-cost-item{padding:2px 6px;border-radius:4px;background:rgba(148,163,184,.15);color:#e2e8f0;font-size:.7rem}
+.building-cost-item.enough{background:rgba(74,222,128,.18);color:#bbf7d0}
+.building-cost-item.missing{background:rgba(239,68,68,.18);color:#fecaca}
+.building-card .btn{width:100%}
+.building-card .btn.disabled{opacity:.5;cursor:not-allowed}
+.building-tooltip{position:absolute;left:50%;bottom:calc(100% + 10px);transform:translateX(-50%);display:none;flex-direction:column;gap:6px;min-width:220px;max-width:260px;padding:12px;border-radius:10px;background:rgba(15,23,42,.95);border:1px solid rgba(148,163,184,.3);box-shadow:0 12px 20px rgba(15,23,42,.45);pointer-events:none;z-index:20}
+.building-tooltip::after{content:"";position:absolute;top:100%;left:50%;transform:translateX(-50%) rotate(45deg);width:12px;height:12px;background:rgba(15,23,42,.95);border-left:1px solid rgba(148,163,184,.3);border-bottom:1px solid rgba(148,163,184,.3)}
+.building-card:hover .building-tooltip,.building-card:focus .building-tooltip,.building-card:focus-within .building-tooltip{display:flex}
+.building-tooltip-desc{font-size:.8rem;color:#f8fafc;line-height:1.4}
+.building-tooltip-line{font-size:.75rem;color:#cbd5f5;display:flex;gap:6px;align-items:flex-start}
+.building-tooltip-label{font-weight:600;color:#facc15;text-transform:uppercase;font-size:.65rem;letter-spacing:.08em;margin-top:1px}
 
 .tutorial-highlight {
   animation: tutorialPulse 1s infinite alternate;


### PR DESCRIPTION
## Summary
- refactor the sect upgrade renderer to build compact cards with icons, costs, state-aware styling, and hover tooltips for details
- add affordability feedback, lock handling, and requirement formatting so cards highlight status while keeping buttons aligned
- restyle the buildings container into a responsive grid with consistent card sizing and hover treatments

## Testing
- npm run validate *(fails: existing AI verification violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc1f680f4832686d90f16d92b6170