### PR TITLE
Hide developer UI controls in production

### DIFF
--- a/index.html
+++ b/index.html
@@ -1313,11 +1313,25 @@
 
   <script type="module" src="src/ui/app.js"></script>
   <script type="module">
-    import { mountDevQuickMenu } from "./src/ui/dev/devQuickMenu.js";
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", () => mountDevQuickMenu());
+    import { isProd } from "./src/config.js";
+
+    const onReady = (cb) => {
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", cb, { once: true });
+      } else {
+        cb();
+      }
+    };
+
+    if (isProd) {
+      onReady(() => {
+        const debugConsole = document.getElementById("debugConsole");
+        if (debugConsole) debugConsole.remove();
+      });
     } else {
-      mountDevQuickMenu();
+      import("./src/ui/dev/devQuickMenu.js").then(({ mountDevQuickMenu }) => {
+        onReady(mountDevQuickMenu);
+      });
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- guard the dev quick menu so it only loads outside production
- remove the debug console overlay when running in production

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3f1fafec483269b1c727c9eb8466b