### PR TITLE
Prevent silhouette flicker when opening sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -620,11 +620,13 @@ html.reduce-motion .rune-ring .orbit {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate3d(-50%, -50%, 0);
   width: 200px;
   height: 200px;
   z-index: 5;
   animation: breathingAura 6s ease-in-out infinite;
+  will-change: transform, opacity;
+  backface-visibility: hidden;
 }
 
 .lotus-silhouette::before {
@@ -745,7 +747,10 @@ html.reduce-motion .rune-ring .orbit {
   position: absolute;
   inset: 0;
   z-index: 1;
-  background: 
+  transform: translateZ(0);
+  will-change: transform, opacity;
+  backface-visibility: hidden;
+  background:
     /* Aurora borealis base layers */
     radial-gradient(ellipse 300px 200px at 30% 50%, rgba(74, 222, 128, 0.4) 0%, transparent 70%),
     radial-gradient(ellipse 250px 150px at 70% 30%, rgba(34, 197, 94, 0.3) 0%, transparent 60%),


### PR DESCRIPTION
## Summary
- keep the cultivation silhouette on its own compositor layer by switching to `translate3d` and enabling backface hiding
- pin the foundation fill to a GPU layer so it no longer flashes when the sidebar animates in

## Testing
- npm run validate *(fails: pre-existing AI verification enforcement errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fd5cc1a483268c027ca4f7ae796f