### PR TITLE
Stabilize cultivation tab layering during sidebar animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -364,6 +364,9 @@ h1, .ability-name {
   flex-direction: row;
   gap: 20px;
   align-items: flex-start; /* Align items to the top */
+  isolation: isolate;
+  transform: translateZ(0);
+  will-change: transform;
 }
 
 /* Cultivation Visualization */
@@ -620,11 +623,13 @@ html.reduce-motion .rune-ring .orbit {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate3d(-50%, -50%, 0);
   width: 200px;
   height: 200px;
   z-index: 5;
   animation: breathingAura 6s ease-in-out infinite;
+  will-change: transform, opacity;
+  backface-visibility: hidden;
 }
 
 .lotus-silhouette::before {
@@ -745,7 +750,10 @@ html.reduce-motion .rune-ring .orbit {
   position: absolute;
   inset: 0;
   z-index: 1;
-  background: 
+  transform: translateZ(0);
+  will-change: transform, opacity;
+  backface-visibility: hidden;
+  background:
     /* Aurora borealis base layers */
     radial-gradient(ellipse 300px 200px at 30% 50%, rgba(74, 222, 128, 0.4) 0%, transparent 70%),
     radial-gradient(ellipse 250px 150px at 70% 30%, rgba(34, 197, 94, 0.3) 0%, transparent 60%),
@@ -2159,6 +2167,10 @@ html.reduce-motion .shield-shimmer{animation:none;}
 
 .cultivation-tab-content {
   display: none;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  will-change: opacity, transform;
+  contain: paint;
 }
 
 .cultivation-tab-content.active {


### PR DESCRIPTION
## Summary
- isolate the cultivation layout container on its own layer so it doesn't repaint above the sidebar
- hint the cultivation tab content for GPU compositing to keep the whole tab from flashing during sidebar motion

## Testing
- npm run validate *(fails: pre-existing UI state validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fd5cc1a483268c027ca4f7ae796f